### PR TITLE
Correct repo URL

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -143,7 +143,7 @@ const siteConfig = {
 
   // You may provide arbitrary config keys to be used as needed by your
   // template. For example, if you need your repo's URL...
-  repoUrl: 'https://github.com/Farrser/AvoDocs',
+  repoUrl: 'https://github.com/AvolitesLtd/TitanManual',
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
This commit corrects the github repository URL, which previously was
referencing the old development repository. It now references the correct
repository within the Avolites organisation.