### PR TITLE
Update using-the-select-buttons-and-wheels.md

### DIFF
--- a/website/versioned_docs/version-14.0/controlling-fixtures/using-the-select-buttons-and-wheels.md
+++ b/website/versioned_docs/version-14.0/controlling-fixtures/using-the-select-buttons-and-wheels.md
@@ -216,45 +216,29 @@ To go back to normal, press \<Unfold\> then \[Exit Unfold\].
 You can also use the numeric keypad to quickly select cells. The syntax
 is as follows: (\<THRO\> is called Through on some consoles)
 
-  .            all sub-fixtures of selection                    
 
-  n\.            all sub-fixtures of fixture n
-
-  . \<THRO\> .j    sub-fixtures 1j of all selected fixtures         
-
-  n\. \<THRO\>       all sub-fixtures of fixture nlast consecutive of type
-
-  n \<THRO\> .j      shorthand for above                              
-
-  n\. \<THRO\> i     sub-fixtures 1i of fixture n
-
-  .m           sub-fixture m of all selected fixtures           
-
-  n\. \<THRO\> i.j   sub-fixtures 1j of fixtures ni
-
-  .m \<THRO\>      sub-fixtures mlast of all selected fixtures      
-
-  n.m            sub-fixture m of fixture n
-
-  .m \<THRO\> .j   sub-fixtures mj of all selected fixtures         
-
-  n.m \<THRO\>       sub-fixtures mlast of fixture n
-
-  .m \<THRO\> j    shorthand for above                              
-
-  n.m \<THRO\> i     sub-fixtures mi of fixture n
-
-  n \<THRO\> i.    all sub-fixtures of fixtures ni                  
-
-  n.m \<THRO\> i.    sub-fixture mlast of fixtures ni
-
-  n \<THRO\> i.j   sub-fixture j of fixtures ni                     
-
-  n.m \<THRO\> i.j   sub-fixtures mj of fixtures ni
-
-  n \<THRO\> .j    sub-fixture 1j of fixture n                      
-
-  n.m \<THRO\> .j    sub-fixtures mj of fixture n
+|button presses         |selection                      |
+|-----------------------|-------------------------------|
+|\<.\>                   |all sub fixtures of selection  |                    
+|n \<.\>                |all sub fixtures of fixture n  |
+|\<.\> \<THRO\> \<.\> j |sub fixtures 1 - j of all selected fixtures  |       
+|n \<.\> \<THRO\>       |all sub fixtures of fixture n through last consecutive of that type |
+|n \<THRO\> \<.\> j     |shorthand for above            |                            
+|n \<.\> \<THRO\> i     |sub fixtures 1 - i of fixture n |
+|\<.\> m                |sub fixture m of all selected fixtures  |
+|n\<.\> \<THRO\> i \<.\> j   |sub fixtures 1 - j of fixtures n - i |
+|\<.\> m \<THRO\>       |sub fixtures mlast of all selected fixtures   |   
+|n \<.\> m              |sub fixture m of fixture n  |
+|\<.\> m \<THRO\> \<.\> j   |sub fixtures m - j of all selected fixtures      |   
+|n \<.\> m \<THRO\>     |sub fixtures mlast of fixture n  |
+|\<.\> m \<THRO\> j     |shorthand for above              |
+|n \<.\> m \<THRO\> i   |sub fixtures m - i of fixture n  |
+|n \<THRO\> i \<.\>     |all sub fixtures of fixtures n - i |
+|n \<.\> m \<THRO\> i \<.\>  |sub fixture m - last of fixtures n - i |
+|n \<THRO\> i \<.\> j   |sub fixture j of fixtures n - i  |
+|n \<.\> m \<THRO\> i \<.\> j  | sub fixtures m - j of fixtures n - i |
+|n \<THRO\> \<.\> j     |sub fixture 1 - j of fixture n  |
+|n \<.\> m \<THRO\> \<.\> j  |sub fixtures m - j of fixture n  |
 
 -   Fixture cell selection can be saved as a group, this provides a
     quick way to select cells / sub-fixtures without having to use the


### PR DESCRIPTION
- added symbols which were stripped when converting from docx (the dash in i - j)
- to my mind writing the . as \<.\> emphasizes that it really is a button to be pressed as many users don't understand this
- formatting this as table improves readability