### PR TITLE
rsync whole build for versions page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,7 +168,7 @@ jobs:
         env:
           DEPLOY_KEY: ${{secrets.DEPLOY_KEY}}
         with:
-          flags: '-avzr --delete --include="versions.html" --include="versions/index.html" --exclude="*"'
+          flags: '-avzr --delete'
           options: ''
           ssh_options: ''
           src: 'website/build/AvoDocs/'
@@ -179,7 +179,7 @@ jobs:
         env:
           DEPLOY_KEY: ${{secrets.AVO_DEPLOY_KEY}}
         with:
-          flags: '-avzr --delete --include="versions.html" --include="versions/index.html" --exclude="*"'
+          flags: '-avzr --delete'
           options: ''
           ssh_options: ''
           src: 'website/build/AvoDocs/'


### PR DESCRIPTION
As almost all of the new deploy method works, this should fix the last bit: making https://manual.avolites.com/versions/ match https://manual.avolites.com/versions.html