### PR TITLE
Correction/#95 copy move buttons

### DIFF
--- a/docs/chases/copying-moving-linking-and-deleting.md
+++ b/docs/chases/copying-moving-linking-and-deleting.md
@@ -7,7 +7,7 @@ sidebar_label: Copying, Moving, Linking and Deleting
 Copying or moving a chase
 -------------------------
 
-Chases can be copied or moved to a new playback, or you can create a
+Using the \<Copy\> and \<Move\> buttons, chases can be copied or moved to a new playback, or you can create a
 linked copy of a playback. Move is useful for tidying up the console.
 Linked chases are handy if you want a chase to appear on more than one
 page for ease of operation; the linked chase can have different timings
@@ -20,7 +20,7 @@ Deleting a chase
 ----------------
 
 You can delete an entire chase by pressing \<Delete\> followed by the
-**Swop** button of the chase to delete. Press once more to confirm.
+**Select** button of the chase to delete. Press once more to confirm.
 
 Deleting a step from a chase
 ----------------------------
@@ -29,7 +29,7 @@ To delete a single step from a chase:
 
 1. Press \<Delete\> button.
 
-2. Press the **Swop** button of the chase.
+2. Press the **Select** button of the chase.
 
 3. The steps in the chase are listed on the screen. Use **Wheel A** to select the step you
 want to delete, or type in the number of the step to be deleted.

--- a/docs/chases/copying-moving-linking-and-deleting.md
+++ b/docs/chases/copying-moving-linking-and-deleting.md
@@ -10,7 +10,7 @@ Copying or moving a chase
 Using the \<Copy\> and \<Move\> buttons, chases can be copied or moved to a new playback, or you can create a
 linked copy of a playback. Move is useful for tidying up the console.
 Linked chases are handy if you want a chase to appear on more than one
-page for ease of operation; the linked chase can have different timings
+page for ease of operation; also a linked chase can have different timings
 and playback options.
 
 This operation is exactly the same as for Cues and is described in

--- a/docs/cue-lists/copying-moving-linking-and-deleting.md
+++ b/docs/cue-lists/copying-moving-linking-and-deleting.md
@@ -5,8 +5,8 @@ sidebar_label: Copying, Moving, Linking and Deleting Cue Lists
 ---
 
 This section describes how to copy, move and delete entire cue lists. 
-The [previous section](editing-cue-lists.md) describes how you [copy, move and delete
-individual cues within a cue list](editing-cue-lists.md#moving-and-copying-cues).
+The [Editing Cue Lists](editing-cue-lists.md) section describes how you [copy, move and delete
+individual cues within a cue list](editing-cue-lists.md#moving-copying-and-deleting-individual-cues).
 
 Copying or Moving a Cue List
 ----------------------------
@@ -24,4 +24,3 @@ Deleting a Cue List
 You can delete a whole cue list by pressing \<Delete\> then the **Select**
 button of the playback to be deleted. Confirm the deletion by pressing
 the select button again, or the \[Confirm\] softkey, or \<Enter\>.
-

--- a/docs/cue-lists/copying-moving-linking-and-deleting.md
+++ b/docs/cue-lists/copying-moving-linking-and-deleting.md
@@ -1,17 +1,19 @@
 ---
 id: copying-moving-linking-and-deleting
-title: Copying, Moving, Linking and Deleting
-sidebar_label: Copying, Moving, Linking and Deleting
+title: Copying, Moving, Linking and Deleting Cue Lists
+sidebar_label: Copying, Moving, Linking and Deleting Cue Lists
 ---
 
-The [previous section](editing-cue-lists.md) also has other methods of [copying and moving
+This section describes how to copy, move and delete entire cue lists. 
+The [previous section](editing-cue-lists.md) describes how you [copy, move and delete
 individual cues within a cue list](editing-cue-lists.md#moving-and-copying-cues).
 
 Copying or Moving a Cue List
 ----------------------------
 
-Cue lists can be copied or moved to a new playback, or you can create a
-linked copy of a playback. Move is useful for tidying up the console.
+Using the \<Copy\> and \<Move\> buttons, cue lists can be copied or moved to a new playback, or you can create a
+linked copy of a playback. Move is useful for tidying up the console. Linked copies are
+useful if you want the same cue list to appear on different playback pages.
 
 This operation is exactly the same as for Cues and is described in
 [Copying, Moving, Linking and Deleting](../cues/copying-moving-linking-and-deleting.md).
@@ -23,34 +25,3 @@ You can delete a whole cue list by pressing \<Delete\> then the **Select**
 button of the playback to be deleted. Confirm the deletion by pressing
 the select button again, or the \[Confirm\] softkey, or \<Enter\>.
 
-Moving a Cue in a Cue List
---------------------------
-
-You can move an individual cue in a cue list by selecting it in the
-[playback view window](editing-cue-lists.md#playback-view-window) and changing the number using the \[Change to\]
-softkey. It will then move to the right place in the list, for example
-to go between cues 14 and 15 set the number to 14.5.
-
-See section [Moving and Copying Cues](editing-cue-lists.md#moving-and-copying-cues) for more ways to move and copy cues,
-including ways to copy cues between different cue lists.
-
-Deleting a Cue from a Cue List
-------------------------------
-
-To delete a single cue from a cue list:
-
-1. Press the \<Delete\> button
-
-2. Press the **Swop** button of the cue list
-
-3. The cues in the cue list are listed on the screen. Use **Wheel A** to
-select the cue you want to delete, or type in the number of the cue to be
-deleted.
-
-4. Press \[Delete Cue x\] to delete the cue
-
-5. Press \[Confirm\] to confirm the delete
-
-> Alternatively you can use the 
-[\<Unfold\> function](editing-cue-lists.md#editing-a-cue-list-using-unfold)
-to delete a cue from a cue list.

--- a/docs/cue-lists/editing-cue-lists.md
+++ b/docs/cue-lists/editing-cue-lists.md
@@ -4,6 +4,10 @@ title: Editing Cue Lists
 sidebar_label: Editing Cue Lists
 ---
 
+This section describes how to edit cues within a cue list. 
+To copy, move or delete an entire cue list see the section 
+[Copying, Moving, Linking and Deleting](../cue-lists/copying-moving-linking-and-deleting.md).
+
 Playback View Window
 --------------------
 
@@ -11,7 +15,9 @@ The easiest way to edit a cue list is using the Playback View window
 (press \<View/Open\> then the **select** button for the cue list to open
 it). This shows a grid with each cue and allows you to change most
 features of the cue. Select the item you want to change in the grid,
-and the softkeys will offer you the different options.
+and the softkeys will offer you options for what you can change.
+
+![Playback view](/docs/images/Cue-List-Window-with-Autoload-playback.png)
 
 To change multiple cues at once, draw a box across the items you want to
 change.
@@ -41,14 +47,19 @@ the softkeys.
     (values which have tracked through from another cue rather than
     being stored directly in this cue) are shown in light grey.
 
-Moving and Copying Cues
+Moving, Copying and Deleting individual Cues
 -----------------------
 
-You can copy or move cues within a cue list or to other cue lists.
-Either click and drag the cue in the [Playback
-View window](#playback-view-window) (press
-Open/View then the **select** button for the cue list), or use **Unfold** ([next
-section](#editing-a-cue-list-using-unfold)), or you can use a `command-line` style series of keypresses.
+There are several ways to copy or move cues within a cue list. You can also move cues to other cue lists.\
+You can use **Unfold** ([as described in the next
+section](#editing-a-cue-list-using-unfold)).\
+To move a cue you can either click and drag the cue in the [Playback
+View window](#playback-view-window), or click on the cue number and use the \[Change To\] softkey
+to enter the new cue number - once you have changed the number the cue will move to
+its correct position in the list.\
+To delete a cue, select the cue in the window and press \<Delete\>, followed by \<Delete\> again or \<Enter\> to confirm.
+
+You can also use a `command-line` style series of keypresses.
 
 **Copy/Move within the same playback:**
 
@@ -62,6 +73,10 @@ section](#editing-a-cue-list-using-unfold)), or you can use a `command-line` sty
 
 `COPY/MOVE <playback> <cue> [THRO <cue>] [NOT <cue>] [AND <cue>] ENTER ENTER`
 
+**Delete cue(s)**
+
+`DELETE <playback> <cue> [THRO <cue>] [NOT <cue>] [AND <cue>] ENTER ENTER`
+
 **Copy/Move to a different playback:**
 
 `COPY/MOVE <playback> <cue> [THRO <cue>] [NOT <cue>] [AND <cue>] [@] [ENTER] <playback> <cue> ENTER`
@@ -72,7 +87,7 @@ section](#editing-a-cue-list-using-unfold)), or you can use a `command-line` sty
 
 `COPY/MOVE <playback> <cue> [THRO <cue>] [NOT <cue>] [AND <cue>] [@] [ENTER] <playback> <playback>`
 
-> **\<playback\>** is a playback swop key, **\<cue\>** is the cue number and
+> **<playback\>** is a playback select key, **<cue\>** is the cue number and
 sections in square brackets are optional)
 
 Editing a Cue List using Unfold

--- a/docs/cue-lists/editing-cue-lists.md
+++ b/docs/cue-lists/editing-cue-lists.md
@@ -47,7 +47,7 @@ the softkeys.
     (values which have tracked through from another cue rather than
     being stored directly in this cue) are shown in light grey.
 
-Moving, Copying and Deleting individual Cues
+Moving, Copying and Deleting Individual Cues
 -----------------------
 
 There are several ways to copy or move cues within a cue list. You can also move cues to other cue lists.\

--- a/docs/cues/copying-moving-linking-and-deleting.md
+++ b/docs/cues/copying-moving-linking-and-deleting.md
@@ -4,37 +4,36 @@ title: Copying, Moving, Linking and Deleting a Cue
 sidebar_label: Copying, Moving, Linking and Deleting
 ---
 
-Copying or Moving a Cue
+Copying a Cue
 -----------------------
 
-Using the \<Copy\> button you can make a **copy** of an existing cue, **move**
-it to a new playback, or create a new playback which is **linked** to the
-existing playback. You can **copy**, **move** or **link** multiple playbacks (which
+Using the \<Copy\> button you can make a **copy** of an existing cue, or create a 
+new playback which is **linked** to the
+existing playback. You can **copy** multiple playbacks (which
 may be cues, [chases](../chases.md) or [cue lists](../cue-lists.md)) in one operation.
 
-Move is useful for tidying up the console. Linked cues are handy if you
+Linked cues are handy if you
 want a cue to appear on more than one page for ease of operation; also
 the linked cue can have different [timings](cue-timing.md) and 
 playback [Options](playback-options.md) from the cue it's linked to.
 
 1. Press \<Copy\>
 
-2. Select \[Copy\], \[Move\] or \[Link\]. Pressing \<Copy\> again will
-also toggle these options. Some consoles have a \<Move\> button to get
-straight into Move mode.
+2. If you want to make a linked copy, press \<Copy\> again or press the \[Link\] softkey. 
 
-3. Press the **select** button of the cue you want to **copy**/**move**/**link**. You
+3. Press the **select** button of the cue you want to **copy**. You
 can select a range of playbacks by holding the first button while
 pressing the last in the range, or use the \<Thro\> and \<And\> buttons
 to add more playbacks to the selection - hold down \<And\> to keep
 adding them.
 
-4. Press the empty select button where you want it to go.
+4. Press an empty select button where you want it to go, or if you are copying multiple
+playbacks, where you want them to start.
 
 ---
 
--   The \<Menu Latch\> button latches the **Copy/Move/Link menu**, so you
-    can keep copying, moving or linking things without having to keep
+-   The \<Menu Latch\> button latches the **Copy** menu, so you
+    can keep copying things without having to keep
     pressing the button. The latched menu will stay active until you
     press \<Menu Latch\> to unlatch it.
 
@@ -42,13 +41,27 @@ adding them.
     cues with empty playbacks in the group - you can either keep the
     empty playbacks, or bunch up the used playbacks together.
 
--   When in **Copy** mode, the option \[Copy Legends\] can be changed to \[Don't
+-   The option \[Copy Legends\] can be changed to \[Don't
     copy legends\] so that the copied cues are given default legends.
 
--   When in Move mode, \[Swap Items if Required\] will attempt to
-    reposition any existing playbacks which are in the way of the move.
+Moving a Cue
+-----------------------
+
+The \<Move\> button allows you to move one or more cues to a different playback handle. **Move** is useful for tidying 
+up the console after programming to put similar cues together or move them onto different pages. 
+
+Again you can move multiple cues by holding down the first playback button while pressing
+the last in the range or using the \<Thro\> and \<And\> buttons as described above and latch
+the **Move** function using the \<Menu Latch\> button. 
+
+-   On older consoles which do not have a hardware button for Move, hold \<Avo\> while pressing \<Copy\>
+	to obtain the **Move** function (as printed on the console panel).
+
+-   When moving a block of cues, \[Swap Items if Required\] will attempt to
+    reposition any existing playbacks which are in the way of the moved block.
     This is useful when rearranging playbacks on a page which is nearly
     full.
+
 
 Deleting a Cue
 --------------

--- a/docs/palettes/copying-moving-and-deleting-palettes.md
+++ b/docs/palettes/copying-moving-and-deleting-palettes.md
@@ -7,22 +7,20 @@ sidebar_label: Copying, Moving and Deleting Palettes
 Copying or Moving a Palette
 ---------------------------
 
-Using the \<Copy\> button you can make a copy of an existing palette or
+Using the \<Copy\> and \<Move\> buttons you can make a copy of an existing palette or
 move it to a new button. You can copy or move multiple palettes in one
-operation. You cannot link palette buttons.
+operation. You cannot link palette buttons like you can with cues.
 
 Move is useful for tidying up the console.
 
-1. Press \<Copy\>
+1. Press \<Copy\> or \<Move\> (if the console does not have a **Move** button,
+	you can get this function by holding \<Avo\> and pressing \<Copy\> ).
 
-2. Select \[Copy\] or \[Move\]. Pressing the \<Copy\> button again will
-also toggle these options. Some consoles have a \<Move\> button.
-
-3. Press the **Select** button of the palette you want to copy/move. You
+2. Press the **Select** button of the palette you want to copy/move. You
 can select multiple palettes - use the \<Thro\> and \<And\> buttons to
 add more to the selection - hold down \<And\> to keep adding them.
 
-4. Press the empty button where you want it to go
+3. Press the empty button where you want it to go
 
 ---
 

--- a/docs/patching/copying-moving-and-deleting-fixtures.md
+++ b/docs/patching/copying-moving-and-deleting-fixtures.md
@@ -7,8 +7,8 @@ sidebar_label: Copying, moving and deleting fixtures
 Copying or moving a patched fixture
 -----------------------------------
 
-Using the \<Copy\> button you can make a copy of an existing fixture or
-move it to a new button. You cannot link fixture buttons. You can copy
+Using the \<Copy\> or \<Move\> buttons you can make a copy of an existing fixture or
+move it to a new handle. You cannot link fixture handle like you can with cues. You can copy
 or move multiple fixtures in one operation.
 
 Fixture copying is very useful if you need an additional fixture of a
@@ -20,16 +20,14 @@ allocated) so you will need to set an address before you can use it (see
 
 Move is useful for tidying up the console.
 
-1. Press the \<Copy\> button.
+1. Press the \<Copy\> or \<Move\> button (on consoles which don't have
+	a **Move** button press \<Avo\> and \<Copy\>).
 
-2. Select \[Copy\] or \[Move\]. Pressing the \<Copy\> button again will
-also toggle through these options.
-
-3. Press the Select button of the fixture you want to copy/move. You
+2. Press the Select button of the fixture you want to copy/move. You
 can select multiple fixtures -- use the \<Thro\> and \<And\> buttons to
 add more fixtures to the selection.
 
-4. Press the empty Select button where you want it to go.
+3. Press the empty Select button where you want it to go.
 
 -   The \<Menu Latch\> button latches the Copy/Move/Link menu, so you
     can keep copying or moving things without having to keep pressing

--- a/docs/running-the-show/organising-the-console.md
+++ b/docs/running-the-show/organising-the-console.md
@@ -14,8 +14,8 @@ Using the Move function
 
 To move fixtures, palettes, groups and playbacks is very simple.
 
-1. Press \<Copy\> then \[Move\] to select Move mode (or just press
-\<Move\> if the console has a button for it).
+1. Press \<Move\> to select Move mode (hold \<Avo\> and press
+\<Move\> if the console does not have a **Move** button).
 
 2. Press or touch the select key(s) of the item(s) to move.
 

--- a/docs/running-the-show/organising-the-console.md
+++ b/docs/running-the-show/organising-the-console.md
@@ -14,8 +14,8 @@ Using the Move function
 
 To move fixtures, palettes, groups and playbacks is very simple.
 
-1. Press \<Move\> to select Move mode (hold \<Avo\> and press
-\<Move\> if the console does not have a **Move** button).
+1. Press \<Move\> to select Move mode (if the console does not have a **Move** button,
+	you can get this function by holding \<Avo\> and pressing \<Copy\> ).
 
 2. Press or touch the select key(s) of the item(s) to move.
 


### PR DESCRIPTION
Change copy/move descriptions to use individual buttons rather than old method of cycling through copy/move/link options.