### PR TITLE
Correction/chapter palettes

### DIFF
--- a/docs/palettes/creating-palettes.md
+++ b/docs/palettes/creating-palettes.md
@@ -104,8 +104,8 @@ a palette number and press \[Store\]
     Beams includes IGBES. If you use the \<Record\> button then you need
     to set the mask manually.
 
--   Press the **Attribute Options** button to toggle each mask group between
-    Include and Exclude.
+-   Press the \<Attribute Options\> (or \<Options\> on newer consoles)
+    button to toggle each mask group between Include and Exclude.
 
 ![Setting a mask for recording a palette](/docs/images/Setting-a-mask-for-recording-a-palette.png)
 

--- a/docs/palettes/editing-palettes.md
+++ b/docs/palettes/editing-palettes.md
@@ -24,12 +24,10 @@ To edit an attribute value, touch/click on it in the window. The
 softkeys will give you a list of available settings for this attribute
 or you can type in a numerical value.
 
-You cannot **Delete** a value from a palette. However, you can disable it
-so that it has no effect as like as it were deleted, with the benefit that you 
-can enable it again. To disable a value, select it and select \[Off\] from
-the softkeys, or press the \<Off\> key. If you select a value which shows
-'[Off]', the softkey will show \[On\], and would re-enable the value. The 
-\<Off\> key toggles between '[Off]' and the value.
+You cannot **Delete** a value from a palette, but you can disable it by selecting the value and
+pressing the \[Off\] softkey or \<Off\> button. If you select a value which shows
+'[Off]', the softkey will show \[On\], and would re-enable the previous value, or the 
+\<Off\> button will toggle between **Off** and the previous value.
 
 -   When the palette contains other palettes, the context menu option
     \[View/Hide Nested Palettes\] sets whether or not the view shows the

--- a/docs/palettes/editing-palettes.md
+++ b/docs/palettes/editing-palettes.md
@@ -24,9 +24,12 @@ To edit an attribute value, touch/click on it in the window. The
 softkeys will give you a list of available settings for this attribute
 or you can type in a numerical value.
 
-There is also a \[Delete\] button which allows you to remove the value
-from the attribute. This is the same as using the
-[\<Off\> function](../cues/editing-cues.md#removing-attributes-from-cues-using-off).
+You cannot **Delete** a value from a palette. However, you can disable it
+so that it has no effect as like as it were deleted, with the benefit that you 
+can enable it again. Do disable a value select it and select \[Off\] from
+the softbuttons, or press the \<Off\> key. If you select a value which shows
+'[Off]', the softkey will show \[On\], and would re-enable the value. The 
+\<Off\> key toggles between '[Off]' and the value.
 
 -   When the palette contains other palettes, the context menu option
     \[View/Hide Nested Palettes\] sets whether or not the view shows the
@@ -82,7 +85,7 @@ When double clicking a palette button to update, the default option is
     previously recorded values in the palette.*
 
 -   You can remove attributes from palettes using the
-    [\<Off\> function](../cues/editing-cues.md#removing-attributes-from-cues-using-off)
+    [\<Off\> function](../cues/editing-cues.md#removing-attributes-from-cues-using-off).
 
 -   When editing a palette the state of the programmer will be
     preserved; when the modified palette is saved, your original

--- a/docs/palettes/editing-palettes.md
+++ b/docs/palettes/editing-palettes.md
@@ -26,7 +26,7 @@ or you can type in a numerical value.
 
 You cannot **Delete** a value from a palette. However, you can disable it
 so that it has no effect as like as it were deleted, with the benefit that you 
-can enable it again. Do disable a value select it and select \[Off\] from
+can enable it again. To disable a value, select it and select \[Off\] from
 the softkeys, or press the \<Off\> key. If you select a value which shows
 '[Off]', the softkey will show \[On\], and would re-enable the value. The 
 \<Off\> key toggles between '[Off]' and the value.

--- a/docs/palettes/editing-palettes.md
+++ b/docs/palettes/editing-palettes.md
@@ -27,7 +27,7 @@ or you can type in a numerical value.
 You cannot **Delete** a value from a palette. However, you can disable it
 so that it has no effect as like as it were deleted, with the benefit that you 
 can enable it again. Do disable a value select it and select \[Off\] from
-the softbuttons, or press the \<Off\> key. If you select a value which shows
+the softkeys, or press the \<Off\> key. If you select a value which shows
 '[Off]', the softkey will show \[On\], and would re-enable the value. The 
 \<Off\> key toggles between '[Off]' and the value.
 

--- a/docs/palettes/timing-with-palettes.md
+++ b/docs/palettes/timing-with-palettes.md
@@ -99,4 +99,4 @@ fade button, and so on.\
 A number of macros for various fade times (\[Palette Fade x s\]) and overlaps
 (\[Palette Overlap y%\]) are available in the macro library. To open this press \<Macro\>, 
 then the softkey \[View All\]. Macros from the library can be copied onto buttons
-using \<Copy\> as usual
+using \<Copy\> as usual.

--- a/docs/palettes/timing-with-palettes.md
+++ b/docs/palettes/timing-with-palettes.md
@@ -96,7 +96,7 @@ palette recall.
 Repeat these steps to create a Palette Snap button (0 sec), or a 1 sec
 fade button, and so on.\
 \
-A number of macros for various fade times (\[Palette Fade xs\]) and overlaps
+A number of macros for various fade times (\[Palette Fade x s\]) and overlaps
 (\[Palette Overlap y%\]) are available in the macro library. To open this press \<Macro\>, 
-then the softbutton \[View All\]. Macros from the library can be copied onto buttons
+then the softkey \[View All\]. Macros from the library can be copied onto buttons
 using \<Copy\> as usual

--- a/docs/palettes/timing-with-palettes.md
+++ b/docs/palettes/timing-with-palettes.md
@@ -12,10 +12,13 @@ Palettes with Saved Times
 
 If you have
 [saved time information in a palette](creating-palettes.md#creating-a-time-palette),
-it will normally recall with this timing information. So if you
-programmed a 2 second fade, the palette will recall with a 2 second fade.
+the times will be used in any playback which is recorded using this palette. 
+So if you programmed a 2 second fade into this palette, every playback with this 
+palette will have a 2 second fade.
 
-You can turn this off (which can be useful during programming) using the
+By default these times are **not** used when the palette is called directly, to allow 
+for a fluent programming. You may however turn this on (which further enhances [busking 
+with palettes](../running-the-show/playback-controls#busking-with-palettes)) using the
 [key profile setting](../system-settings/key-profiles.md) for palette keys.
 You can set \[Palette Is Fired With Its Times\] or \[Palette Is Fired
 Ignoring Its Times\].
@@ -70,6 +73,12 @@ next will start its fade.
     use the same overlap every time, set a Master Overlap: Press
     \<Palette\>, \[Master Overlap\]. To disable \[Master Overlap\] set to 100%.
 
+-   Fixture Overlap always requires a fade time in order to have a visible effect.
+
+>   When using Fixture Overlap with global palettes without fixtures selected (Quick Palette)
+    bear in mind that Fixture Overlap may be performed on a large number of fixtures which
+    may lead to unwanted results.
+
 Master Time for Palettes
 ------------------------
 
@@ -85,4 +94,9 @@ palette recall.
 \<Macro\>, \[Record\], press a button to store your macro on. Then press
 \<Palette\>, \[Master Time\], \<3\> (for 3 sec), \<Exit\>, \<Macro\>.
 Repeat these steps to create a Palette Snap button (0 sec), or a 1 sec
-fade button, and so on.
+fade button, and so on.\
+\
+A number of macros for various fade times (\[Palette Fade xs\]) and overlaps
+(\[Palette Overlap y%\]) are available in the macro library. To open this press \<Macro\>, 
+then the softbutton \[View All\]. Macros from the library can be copied onto buttons
+using \<Copy\> as usual


### PR DESCRIPTION
some corrections in the chapter palettes, see commit annotations (e.g. there is no Delete for palette values, default setting is to be called **ignoring times**, mentioned library macros, etc.)