### PR TITLE
correction/personalities

### DIFF
--- a/docs/fixture-personalities.md
+++ b/docs/fixture-personalities.md
@@ -69,10 +69,9 @@ library, the actual personality library is identical in each version.
 This will list all installers - software and personalities - found in the root of 
 the stick (provided you haven't changed their name).
 
-3. Click the **TitanFixtureLibrary.exe**, and follow the instructions.
-
-  > If for whatever reason Titan doesn't show the file in the *Titan Installers* submenu
-    you can find and double-click it through Tools -> Folders.
+3. Click the **TitanFixtureLibrary.exe**, and follow the instructions.\
+   If for whatever reason Titan doesn't show the file in the *Titan Installers* submenu
+   you can find and double-click it through Tools -> Folders.
 
 4. Shut down and then restart the console *(using the Restart Software
 button on the screen Tools menu is OK)*.

--- a/docs/fixture-personalities.md
+++ b/docs/fixture-personalities.md
@@ -49,27 +49,30 @@ Updating the Personality Library on the Console
 -----------------------------------------------
 
 Download the current Titan personality library by clicking on **Titan
-Fixture Library** at the [personality website](https://personalities.avolites.com) home screen, or the disk
-icon in the Cache column for any fixture. Alternatively you can get this
-file by clicking on the **Download** link at the top of the screen, then
-clicking on **Titan Fixture Library**.
+Fixture Library** at the [personality website](https://personalities.avolites.com) 
+home screen. Alternatively you can get this file by clicking on the **Download** 
+link at the top of the screen, then clicking on **Titan Fixture Library**.
 
 There are different library installers depending on the **version of Titan 
 you are running**. This is to ensure you get the right version of the Capture
 library, the actual personality library is identical in each version.
 
 > Updating will overwrite any custom personalities you have stored in the library. To avoid this, store your custom personalities in the user personalities folder (see next section for details).
-  ---------------------------------------------------------------------------------------------------- --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+------
 
 ### Console Update Procedure
 
 1. Copy the downloaded file **TitanFixtureLibrary.exe** onto a USB stick and plug in to the console.
 
-2. Click the **Tools** menu on the toolbar, then the **folder** icon on the
-menu.
+2. Click the **Tools** menu on the toolbar, then **Control Panel**, then **Titan Installers**.
+This will list all installers - software and personalities - found in the root of 
+the stick (provided you haven't changed their name).
 
-3. Locate the downloaded file on the USB drive and double click on it
-to run it. Click **Ok** on the warning box.
+3. Click the **TitanFixtureLibrary.exe**, and follow the instructions.
+
+  > If for whatever reason Titan doesn't show the file in the *Titan Installers* submenu
+    you can find and double-click it through Tools -> Folders.
 
 4. Shut down and then restart the console *(using the Restart Software
 button on the screen Tools menu is OK)*.


### PR DESCRIPTION
Any reference to the Disk or Cache columns is really wrong as these refer to older personalities (Classic, Diamond 4), and every now and then a user tries this and fails.

The update procedure should mention the 'Titan Installers' thing for consoles (works only if the personality installer's file name hasn't been changed). The Tools/Folders procedure is more a fallback if the 'Titan Installers' thing doesn't work.