### PR TITLE
fix link to go to run-on-startup playbacks

### DIFF
--- a/docs/titan-net.md
+++ b/docs/titan-net.md
@@ -7,7 +7,7 @@ sidebar_label: Titan Net Processor Operation
 A TNP (TitanNet Processor) unit can operate either as a slave unit,
 producing additional DMX lines for a console, or as a simple console for
 stand-alone operation. In console mode you can prepare a show on a full
-console, then load it into a TNP for operation, using [power-on playbacks](cues/cue-playback.md#programming-the-release-power-on-state), or you can connect an external
+console, then load it into a TNP for operation, using [power-on playbacks](cues/playback-options.md#run-on-startup), or you can connect an external
 touchscreen to the TNP and operate it using the Titan Go interface
 screen.
 


### PR DESCRIPTION
I feel this is where the link is supposed to point to