### PR TITLE
Fix Pandoc version in DockerFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pandoc/latex as builder
+FROM pandoc/latex:2.9.1.1 as builder
 
 ENTRYPOINT ["/bin/sh", "-c"]
 


### PR DESCRIPTION
Newer versions of pandoc seemed to create issues with tables being generated with links or images inside. Fixed to a specific version that we know works