### PR TITLE
Adding licensing notes on introductions

### DIFF
--- a/prismdocs/licensing/licensing.md
+++ b/prismdocs/licensing/licensing.md
@@ -6,14 +6,6 @@ sidebar_label: Prism Licensing
 
 # Prism Suite v1.3
 
-The below table shows which app can be use against Avolites current set of **Ai** / **Prism** Licenses.
-
-|             | Ai Demo  | Ai Anjuna | Ai Bondi | Ai Miami | Prism Player  | Prism Zero | Prism One | 
-|-----------------|:--------:|:---------:|:--------:|:--------:|:-------------:|:----------:|:---------:|
-| **Prism**       |          |     x     |    x     |    x     |               |            |    x      |
-| **Prism Zero**  |    x     |     x     |    x     |    x     |               |     x      |    x      |
-| **Prism Player**|    x     |     x     |    x     |    x     |       x       |     x      |    x      |
-
 ## Prism
 
 **Prism** runs with any valid **AvoKey** or **Editor Keys** with an **Ai** (_Anjuna_, _Bondi_, _Miami_) or **Prism One** license. Both keys can also be purchased from any of our distributors.
@@ -34,16 +26,27 @@ The below table shows which app can be use against Avolites current set of **Ai*
 
 ## Prism Player
 
-**Prism Player** runs with any valid **AvoKey** or **Editor Keys** with an **Ai** (_Demo_, _Anjuna_, _Bondi_, _Miami_) or **Prism** license.
+**Prism Player** runs with any valid **AvoKey** or **Editor Keys** with an **Ai** (_Demo_, _Anjuna_, _Bondi_, _Miami_) or **Prism** (_Player_, _Zero_, _One_) license.
 
 **Prism Player** can be installed without an **AvoKey** or **Editor Keys**, in this case an internet connection to download the free software license is required. The license is automatically installed as **Prism Player Component** or **3501 Avolites Prism Player**. The specific name of this license will appear in codemeter webadmin page, instructions are below.
 
 If you have no internet connection, and no **AvoKey** or **Editor Keys**, you will need to purchase an AvoKey requesting our free *Prism Player Component License*. If you require an AvoKey please speak to any of our distributors found [here](https://www.avolites.com/official-distributors).
 
-# CodeMeter
+## All Licenses
+
+The below table shows which app can be use against Avolites current set of **Ai** / **Prism** Licenses.
+
+|             | Ai Demo  | Ai Anjuna | Ai Bondi | Ai Miami | Prism Player  | Prism Zero | Prism One | 
+|-----------------|:--------:|:---------:|:--------:|:--------:|:-------------:|:----------:|:---------:|
+| **Prism**       |          |     x     |    x     |    x     |               |            |    x      |
+| **Prism Zero**  |    x     |     x     |    x     |    x     |               |     x      |    x      |
+| **Prism Player**|    x     |     x     |    x     |    x     |       x       |     x      |    x      |
+
+
+## CodeMeter
 
 - To Find out which license you already have installed, open **CodeMeter Control Center**.
-- Select your available licenses on codeMeter Control Center from the left side menu.
+- Select your available licenses on **CodeMeter Control Center** from the left side menu.
 - Then click on **WebAdmin** on the bottom righthand side. And find a list of licenses you have installed under **Avolites LTD**.
 
 For any further enquiry, please submit a support request to <a href="mailto:support@avolites.com?subject=Prism:">support@avolites.com</a>

--- a/prismdocs/player/introduction.md
+++ b/prismdocs/player/introduction.md
@@ -7,6 +7,8 @@ sidebar_label: Introduction
 
 It allows for easy previewing of media files as well as for preparing and converting them using the **AiM codec**, ready for use in **Ai**, [Prism](../prism/introduction) or [Prism Zero](../zero/introduction). Not only does **Prism Player** playback your favourite codecs such as *H264*, *HAP* and *Prores*, but it also supports playback of **NotchLC**.
 
+**Prism Player** requires a license to run. Please refer to the [licensing page](../licensing#prism-player) in this manual.
+
 ![Prism Player UI](/prismdocs/images/prism-player-ui.png)
 
 **Prism Player** is composed of two parts - the **Server** and the **UI**. The **Server** runs in the [system tray](./quick-start/system-tray) and the **UI** will run separately and show the interface. The components communicate using **port 9030**, no other application must use this port in order to work.

--- a/prismdocs/prism/introduction.md
+++ b/prismdocs/prism/introduction.md
@@ -13,6 +13,8 @@ The bank also allows for input sources to be added including, **NDI input**, **L
 
 **Prism** provides 1 physical output and 1 NDI output.
 
+**Prism** requires a license to run. Please refer to the [licensing page](../licensing#prism) in this manual.
+
 ![Prism UI](/prismdocs/images/prism-ui.png)
 
 **Prism** is composed of two parts - the **Server** and the **UI**. The **Server** runs in the [system tray](./quick-start/system-tray) and the **UI** will run separately and show the interface.  

--- a/prismdocs/zero/introduction.md
+++ b/prismdocs/zero/introduction.md
@@ -11,6 +11,8 @@ On top of providing conversion, previewing and playback of media, **Prism Zero**
 
 **Prism Zero** provides 1 physical output and 1 NDI output.
 
+**Prism Zero** requires a license to run. Please refer to the [licensing page](../licensing#prism-zero) in this manual.
+
 ![Prism Zero UI](/prismdocs/images/prism-zero-ui.png)
 
 **Prism Zero** is composed of two parts - the **Server** and the **UI**. The **Server** runs in the [system tray](./quick-start/system-tray) and the **UI** will run separately and show the interface.  


### PR DESCRIPTION
Adding notes on licensing on introduction pages.
Rearranged the licensing page to make it more clear.