### PR TITLE
U/simone/updated licensing for prism v1.3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: PDF Docker Build
         run: |
-          docker-compose run pdf
+          docker compose run pdf
           mkdir downloads
           mv parse/output/*.pdf downloads
 
@@ -99,7 +99,7 @@ jobs:
 
       - name: Prism PDF Docker Build
         run: |
-          docker-compose run prismpdf
+          docker compose run prismpdf
           mkdir downloads
           mv parse/output/*.pdf downloads
       - name: Upload artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.os}}
           path: website/download
@@ -82,7 +82,7 @@ jobs:
           mv parse/output/*.pdf downloads
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: 'PDF'
           path: downloads
@@ -103,7 +103,7 @@ jobs:
           mkdir downloads
           mv parse/output/*.pdf downloads
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: 'Prism PDF'
           path: downloads

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.os}}
           path: website/download
@@ -91,7 +91,7 @@ jobs:
           mv parse/output/*.pdf website/download
 
       - name: Upload artifacts to GitHub
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: 'PDF'
           path: website/download
@@ -121,7 +121,7 @@ jobs:
           mv parse/output/*.pdf website/download
 
       - name: Upload artifacts to GitHub
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: 'Prism PDF'
           path: website/download

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: PDF Docker Build
         run: |
-          docker-compose run pdf
+          docker compose run pdf
           mkdir website/download
           mv parse/output/*.pdf website/download
 
@@ -116,7 +116,7 @@ jobs:
 
       - name: Prism PDF Docker Build
         run: |
-          docker-compose run prismpdf
+          docker compose run prismpdf
           mkdir website/download
           mv parse/output/*.pdf website/download
 

--- a/.github/workflows/v2-test.yml
+++ b/.github/workflows/v2-test.yml
@@ -60,7 +60,7 @@ jobs:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.os}}
           path: website/downloads
@@ -80,7 +80,7 @@ jobs:
           mv parse/output/*.pdf downloads
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: 'PDF'
           path: downloads

--- a/.github/workflows/v2-test.yml
+++ b/.github/workflows/v2-test.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: PDF Docker Build
         run: |
-          docker-compose run pdf
+          docker compose run pdf
           mkdir downloads
           mv parse/output/*.pdf downloads
 


### PR DESCRIPTION
changed version of `actions/upload-asset` to use `v4` - github has now deprecated `v1` & `v2`

updated `docker-compose` to use `docker compose`