### PR TITLE
Remove (false) hint to requiring library updates

### DIFF
--- a/docs/effects/pixel-mapper.md
+++ b/docs/effects/pixel-mapper.md
@@ -229,6 +229,3 @@ To create a Mask Effect:
 
 - This function replaces the **Block Effect** function of previous versions. Shows containing Block Effect from previous versions
   will load and work as expected, but they will be renamed "Mask".
-
-- The personality library may need updating for this to work. 
-

--- a/docs/effects/shape-generator.md
+++ b/docs/effects/shape-generator.md
@@ -290,8 +290,6 @@ To create a mask:
 - This function replaces the **Block Shapes** function of previous versions. Shows containing Block Shapes from previous versions
   will load and work as expected, but the block shapes will be renamed "Mask".
 
-- The personality library may need updating for this to work. 
-
 ## Storing Shapes in Palettes
 
 You can create palettes containing shapes. This is really useful to


### PR DESCRIPTION
I believe the last line "The personality library may need updating for this to work." has nothing to do with Mask FX but is a leftover from the previous section 'Pixel Mapper Layer Masters'. Also, Layer Masters are now that old that I'd rather delete this line altogether.