### PR TITLE
Remove old deployment server.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,16 +156,6 @@ jobs:
         yarn run download
         yarn run build
         yarn run test
-    - name: Deploy
-      uses: Pendect/action-rsyncer@v2.0.0
-      env:
-        DEPLOY_KEY: ${{secrets.DEPLOY_KEY}}
-      with:
-        flags: '-avzr --delete'
-        options: ''
-        ssh_options: ''
-        src: 'website/build/'
-        dest: 'root@176.58.122.97:/var/www/sites/avodocs/'
     - name: AvoDeploy
       uses: Pendect/action-rsyncer@v2.0.0
       env:
@@ -210,17 +200,6 @@ jobs:
           yarn install --frozen-lockfile
           yarn run download
           yarn run build
-
-      - name: Deploy
-        uses: Pendect/action-rsyncer@v2.0.0
-        env:
-          DEPLOY_KEY: ${{secrets.DEPLOY_KEY}}
-        with:
-          flags: '-avzr --delete'
-          options: ''
-          ssh_options: ''
-          src: 'website/build/'
-          dest: 'root@176.58.122.97:/var/www/sites/avodocs/'
 
       - name: AvoDeploy
         uses: Pendect/action-rsyncer@v2.0.0


### PR DESCRIPTION
Remove steps to deploy to 176.58.122.97 which appears to be an old server used to develop and test the manual.