### PR TITLE
german translation for v19

### DIFF
--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0.json
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0.json
@@ -1,0 +1,102 @@
+{
+  "version.label": {
+    "message": "19.0",
+    "description": "The label for version current"
+  },
+  "sidebar.docs.category.Introduction": {
+    "message": "Einführung",
+    "description": "The label for category Introduction in sidebar docs"
+  },
+  "sidebar.docs.category.Quick Start": {
+    "message": "Schnellstartanleitung",
+    "description": "The label for category Quick Start in sidebar docs"
+  },
+  "sidebar.docs.category.About The Consoles": {
+    "message": "Die Titan-Pulte",
+    "description": "The label for category About The Consoles in sidebar docs"
+  },
+  "sidebar.docs.category.Titan Basics": {
+    "message": "Titan-Grundlagen",
+    "description": "The label for category Titan Basics in sidebar docs"
+  },
+  "sidebar.docs.category.Patching": {
+    "message": "Patchen",
+    "description": "The label for category Patching in sidebar docs"
+  },
+  "sidebar.docs.category.Controlling Fixtures": {
+    "message": "Steuern von Dimmern und Geräten",
+    "description": "The label for category Controlling Fixtures in sidebar docs"
+  },
+  "sidebar.docs.category.Palettes": {
+    "message": "Paletten",
+    "description": "The label for category Palettes in sidebar docs"
+  },
+  "sidebar.docs.category.Shapes and Effects": {
+    "message": "Shapes und Effekte",
+    "description": "The label for category Shapes and Effects in sidebar docs"
+  },
+  "sidebar.docs.category.Cues": {
+    "message": "Cues",
+    "description": "The label for category Cues in sidebar docs"
+  },
+  "sidebar.docs.category.Chases": {
+    "message": "Chaser",
+    "description": "The label for category Chases in sidebar docs"
+  },
+  "sidebar.docs.category.Cue Lists": {
+    "message": "Cuelisten",
+    "description": "The label for category Cue Lists in sidebar docs"
+  },
+  "sidebar.docs.category.Timelines": {
+    "message": "Timelines",
+    "description": "The label for category Timelines in sidebar docs"
+  },
+  "sidebar.docs.category.Capture Visualiser": {
+    "message": "Der Capture Visualiser",
+    "description": "The label for category Capture Visualiser in sidebar docs"
+  },
+  "sidebar.docs.category.Synergy": {
+    "message": "Synergy",
+    "description": "The label for category Synergy in sidebar docs"
+  },
+  "sidebar.docs.category.Running The Show": {
+    "message": "Steuern der Show",
+    "description": "The label for category Running The Show in sidebar docs"
+  },
+  "sidebar.docs.category.Remote Control": {
+    "message": "Fernsteuerung",
+    "description": "The label for category Remote Control in sidebar docs"
+  },
+  "sidebar.docs.category.Titan Net": {
+    "message": "Titan Net",
+    "description": "The label for category Titan Net in sidebar docs"
+  },
+  "sidebar.docs.category.System Settings": {
+    "message": "System und Benutzereinstellungen",
+    "description": "The label for category System Settings in sidebar docs"
+  },
+  "sidebar.docs.category.Fixture Personalities": {
+    "message": "Personalities (Gerätedateien)",
+    "description": "The label for category Fixture Personalities in sidebar docs"
+  },
+  "sidebar.docs.category.Networking Consoles": {
+    "message": "Netzwerkeinstellungen",
+    "description": "The label for category Networking Consoles in sidebar docs"
+  },
+  "sidebar.docs.category.Titan Commands": {
+    "message": "Titan Befehlsreferenz",
+    "description": "The label for category Titan Reference in sidebar docs"
+  },
+  "sidebar.docs.category.Titan Reference": {
+    "message": "Titan Referenz",
+    "description": "The label for category Titan Reference in sidebar docs"
+  },
+  "sidebar.docs.category.Glossary": {
+    "message": "Glossar/ Stichwortverzeichnis",
+    "description": "The label for category Glossary in sidebar docs"
+  },
+  "sidebar.docs.category.Index": {
+    "message": "Index",
+    "description": "The label for category Index in sidebar docs"
+  }
+}

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles.md
@@ -1,0 +1,20 @@
+---
+id: about-the-consoles
+title: Die verschiedenen Pulte
+sidebar_label: Die verschiedenen Pulte
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Dieses Handbuch dient als Anleitung für alle aktuellen Avolites
+Titan-Pulte. Dabei sind die Funktionen bei allen Pulten weitgehend
+identisch, während sich das Layout und die Bedienelemente im Detail
+unterscheiden können.
+
+In diesem Abschnitt werden die wichtigsten Unterschiede und
+Ausstattungsmerkmale erläutert.
+
+Auch die per USB angeschlossenen Modelle [T1, T2](about-the-consoles/t1-and-t2.md), 
+das Titan Mobile, die [TNPs (Netzwerk-Prozessoren)](about-the-consoles/tnp.md) und die 
+[verschiedenen Wings](about-the-consoles/fader-wings.md) sind hier berücksichtigt.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles.md
@@ -15,6 +15,4 @@ unterscheiden können.
 In diesem Abschnitt werden die wichtigsten Unterschiede und
 Ausstattungsmerkmale erläutert.
 
-Auch die per USB angeschlossenen Modelle [T1, T2](about-the-consoles/t1-and-t2.md), 
-das Titan Mobile, die [TNPs (Netzwerk-Prozessoren)](about-the-consoles/tnp.md) und die 
-[verschiedenen Wings](about-the-consoles/fader-wings.md) sind hier berücksichtigt.
+Auch der [TNP (TitanNet-Prozessor)](about-the-consoles/tnp.md) ist hier berücksichtigt.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/arena.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/arena.md
@@ -1,0 +1,170 @@
+---
+id: arena
+title: Das Arena
+sidebar_label: Das Arena
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Das Arena hat fünf grundsätzliche Bedienungsbereiche:
+
+![Arena](/docs/images/Arena.png)
+
+&nbsp;<Keys.Annotation>A</Keys.Annotation> Der **Touchscreen** zeigt Schaltflächen zur 
+Auswahl von Geräten, Paletten und Gruppen. Ferner zeigt er Bezeichnungen der Playbacks, 
+sowie -- oben rechts -- die aktuelle Menüseite und die Bezeichnungen der variablen Tasten.
+
+
+
+&nbsp;<Keys.Annotation>B</Keys.Annotation> Die **Playbacks** dienen zur Auswahl und 
+Steuerung von Bildern und Abläufen: Cues, Cuelisten und Chaser. 
+
+
+
+&nbsp;<Keys.Annotation>C</Keys.Annotation>Auf der linken Seite gibt es dazu noch **weitere Playbacks**, 
+auf die ebenfalls Cues, Cuelisten, Chaser programmiert werden, aber auch Geräte gepatcht werden können.
+
+
+
+&nbsp;<Keys.Annotation>D</Keys.Annotation> Das **kleine Display** bietet ebenfalls Platz für 
+Arbeitsfenster. Auf den vier Encodern daneben können z.B. Master komfortabel programmiert werden. 
+
+
+
+&nbsp;<Keys.Annotation>E</Keys.Annotation> Auf den **Macrotasten** darunter können häufig benutzte 
+Tastenfolgen gespeichert werden.
+
+
+
+&nbsp;<Keys.Annotation>F</Keys.Annotation> Die **Programmiersektion** enthält alle Steuerelemente 
+zum Einrichten und Programmieren des Pultes.
+
+![Arena controls](/docs/images/Arena-controls.png)
+
+## Bedienoberfläche
+
+
+
+&nbsp;<Keys.Annotation>G</Keys.Annotation> Die **Arbeitsfenster** auf dem Touchscreen zeigen Tasten 
+für Geräte, Paletten, Gruppen, Speicherplätze, Makros und anderes. Ebenso lassen sich hier Attribute 
+einstellen und Informationsfenster einblenden.
+
+
+
+&nbsp;<Keys.Annotation>H</Keys.Annotation> Die **Systemanzeige** ist die Schaltzentrale des Pultes 
+und liefert Informationen über den jeweiligen Zustand. Hier werden diverse Hinweisfenster eingeblendet, 
+abhängig vom momentanen Arbeits- und Programmierablauf.
+
+
+
+&nbsp;<Keys.Annotation>I</Keys.Annotation> Die **Menütasten** (bezeichnet mit A -- G) dienen zur 
+Auswahl verschiedener Steuerungsoptionen. Im Display wird direkt neben jedem Taster die jeweilige 
+Funktion angezeigt, abhängig vom jeweiligen Status des Pultes. Befehle dieser Taster sind in diesem 
+Handbuch blau dargestellt,  z.B. <Keys.SoftKey>Edit Times</Keys.SoftKey>
+
+
+
+
+&nbsp;<Keys.Annotation>J</Keys.Annotation> Das **Mini-Display** kann weitere Arbeitsfenster anzeigen. 
+
+
+
+&nbsp;<Keys.Annotation>K</Keys.Annotation> Die vier **Encoder** daneben können wie normale Playbacks 
+programmiert werden und bieten sich insbesondere für Master an. Die Encoder sind gleichzeitig Drucktaster; 
+zum Auswählen beim Programmieren müssen sie gedrückt werden.
+
+
+
+&nbsp;<Keys.Annotation>L</Keys.Annotation> Auf den **Makro-Tastern** lassen sich sowohl Playbacks wie z.B. 
+ein Strobe-Cue als auch häufig benutzte Abläufe von Tastendrücken abspeichern, die dann mit einem einzigen 
+Tastendruck abgerufen werden können. 
+
+![Arena controls 2](/docs/images/Arena-controls-2.png)
+
+
+
+&nbsp;<Keys.Annotation>M</Keys.Annotation> Der **Master** (Hauptregler) steuert die Gesamthelligkeit aller 
+über das Pult abgerufenen Szenen und ist normalerweise deaktiviert. Der **DBO-Taster** dient zum 
+unmittelbaren Dunkelschalten.
+
+
+
+&nbsp;<Keys.Annotation>N</Keys.Annotation> Die **Playbacks** dienen zum Speichern und Abrufen von Cues 
+(Szenen) und Chasern/Cuelisten (Szenensequenzen). 
+
+
+
+&nbsp;<Keys.Annotation>O</Keys.Annotation>Mit den **Seitenwechseltasten** kann man zu verschiedenen Seiten 
+der Playbacks wechseln. Im Touchscreen werden oberhalb der Regler Informationen über jeden einzelnen Speicherplatz eingeblendet. 
+
+
+
+&nbsp;<Keys.Annotation>P</Keys.Annotation>Links gibt es **weitere 30 Playbacks**, organisiert in zwei 
+Bänken à 15 Playbacks, die jeweils gesonderte Seiten-Umschalttasten haben.
+
+
+
+&nbsp;<Keys.Annotation>Q</Keys.Annotation> Mit den **Drehreglern** (Encodern) werden sowohl Attribute der Geräte, 
+als auch Geschwindigkeit und Überblendung der Sequenzen eingestellt. Im Touchscreen oberhalb der Räder wird 
+angezeigt, welche Parameter momentan mit welchem Rad verknüpft sind. Das Betätigen des **Bildlaufschalters** 
+schaltet die Räder in den Bildlauf-Modus: damit lässt sich eine Auswahlbox über den Bildschirm bewegen.
+
+
+
+&nbsp;<Keys.Annotation>R</Keys.Annotation> Mit dem **Ziffern- und Tastenfeld** lassen sich Werte eingeben sowie 
+Einstellungen des Pultes ändern.
+
+
+
+&nbsp;<Keys.Annotation>S</Keys.Annotation> Mit den **Funktionstasten** sind verschiedene Funktionen verknüpft, 
+etwa Speichern, Kopieren, Speichern auf Disk. Diese Buttons haben LEDs zur Anzeige der gerade aktiven Funktion.
+
+&nbsp;<Keys.Annotation>K</Keys.Annotation> Mit den Tastern der **Attributauswahl** werden die Attribute der 
+Geräte angewählt (z.B. Farbe, Gobo, Bewegung, Fokus), welche dann durch die Drehregler gesteuert werden sollen. 
+Die jeweils aktiven Taster werden durch LEDs angezeigt. Der untere (rote) Taster erlaubt das '**Locaten**' von 
+Geräten, indem sie auf eine vordefinierte Startposition gesetzt werden.
+
+## Anschlussfeld auf der Rückseite
+
+
+![Arena Back Panel](/docs/images/Arena-Back-Panel.png)
+
+
+
+&nbsp;<Keys.Annotation>U</Keys.Annotation> USB-Anschlüsse, Reset-Taster, Unterbrecher für die USV
+
+
+
+&nbsp;<Keys.Annotation>V</Keys.Annotation> Monitor und Netzwerk, SMPTE und Audio
+
+
+
+&nbsp;<Keys.Annotation>W</Keys.Annotation> DMX und MIDI in/out.
+
+
+
+&nbsp;<Keys.Annotation>X</Keys.Annotation> Anschlüsse für Pultleuchten.
+
+Sämtliche für das Pult erforderlichen Anschlüsse befinden sich auf der Rückseite. Es gibt 8 
+DMX-Anschlüsse (XLR 5-pol), MIDI In/Out/Thru (5-pol DIN), zwei XLR-Buchsen für Pultleuchten, 
+vier Ethercon-Ethernet-Anschlüsse vom integrierten Switch, einen opticalCon Duo Glasfaseranschluss, 
+einen DVI-Anschluss für einen externen Bildschirm, drei USB-Anschlüsse, SMPTE Timecode-Eingang, 
+Audio-Eingang (6,3 mm Klinke) und einen Anschluss für einen Trigger-Schalter (ebenfalls 6,3 mm Klinke).
+
+Mit dem „Panel Reset"-Schalter werden die Panels zurückgesetzt, ohne die
+Software neu zu starten. Allerdings wird dabei auch das DMX-Panel
+resettet und daher das DMX-Signal unterbrochen.
+
+Sollte das Pult einmal auf gar kein Kommando reagieren und auch mit dem
+Hauptschalter nicht heruntergefahren werden können, so kann mit dem
+Schalter "Battery Disconnect" die USV unterbrochen werden.
+
+  >   Wird die USV zum Neustart des Pultes unterbrochen, so wird auch der integrierte Netzwerkswitch 
+  stromlos. Bitte berücksichtigen Sie dies beim Betrieb größerer Backup-Systeme.
+
+Die Füße des Arena sind verstellbar, so dass die Neigung des Pultes
+angepasst werden kann: heben Sie dazu das Pult hinten an und drücken Sie
+auf der linken und rechten Seite jeweils den Knopf "Leg Release".
+
+![Arena Leg](/docs/images/Arena-Leg.jpeg)

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/d3.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/d3.md
@@ -2,221 +2,236 @@
 id: d3
 title: D3
 sidebar_label: D3
-description: D3 range - design and features
+description: Die D3-Serie - design and features
 ---
 
 import Keys from '@site/src/components/key.ts';
 import Video from '@site/src/components/video.tsx';
 
-The D3 range includes two consoles, a standalone rack processing unit, a touch controller and 
-a matching fader wing.
+Die D3-Serie besteht aus zwei Pulten, einer eigenständigen Rackeinheit, einem Touch-Controller und einem passenden Faderwing.
 
 ## D3-110
 
 ![D3-110](/docs/images/D3-110-front.png)
 
-The D3-110 is a compact standalone console with a built in touchscreen and 10 playback faders.
+Das D3-110 ist ein kompaktes eigenständiges Pult mit Touchscreen und 10 Playbackfadern.
 
-&nbsp;<Keys.Annotation>A</Keys.Annotation> The **Playback faders** and buttons are the main place to store and play back cues or chases
-but can also be assigned a range of other functions.
-
-
-
-&nbsp;<Keys.Annotation>B</Keys.Annotation> The **Page Select buttons** let you change to a different page of
-playbacks. The bottom of the screen shows information about each
-playback.
+&nbsp;<Keys.Annotation>A</Keys.Annotation> Die **Playbackfader** dienen zum 
+Speichern und Abrufen von Cues (Szenen) und Chasern/Cuelisten (Szenensequenzen). 
 
 
 
-&nbsp;<Keys.Annotation>C</Keys.Annotation> The **Attribute Control wheels** are used to set control values
-(attributes) for the fixtures, and also to set other parameters. The
-bottom right corner of the screen shows information about the parameters and values the wheels are controlling.
+Mit den &nbsp;<Keys.Annotation>B</Keys.Annotation> **Seitenwechseltasten** kann
+man zu verschiedenen Seiten der Playbacks wechseln. Im Touchscreen
+werden Informationen zur Belegung jedes Playbacks eingeblendet.
 
 
 
-&nbsp;<Keys.Annotation>D</Keys.Annotation> The **Attribute select buttons** are used to select which attributes of
-a fixture (e.g. colour, gobo, position) are going to be controlled using
-the Control wheels. The buttons light up to show you which
-attributes are active. 
+&nbsp;<Keys.Annotation>C</Keys.Annotation> Mit den **Encodern** werden 
+sowohl Attribute der Geräte, als auch Geschwindigkeit und Überblendung 
+von Chasern eingestellt. Im Touchscreen unten rechts wird angezeigt, 
+welche Parameter momentan mit welchem Rad verknüpft sind.
 
 
 
-&nbsp;<Keys.Annotation>E</Keys.Annotation> The **Playback control buttons** allow you to control cue lists and chases, and move about in the list.
+&nbsp;<Keys.Annotation>D</Keys.Annotation> Mit den Tastern der 
+**Attributauswahl** werden die Attribute der Geräte
+angewählt (z.B. Farbe, Gobo, Bewegung, Fokus), welche dann durch die
+Drehregler gesteuert werden sollen. Die jeweils aktiven Taster werden
+durch LEDs angezeigt.
 
 
 
-&nbsp;<Keys.Annotation>F</Keys.Annotation> The **Numeric keypad** and other control buttons are used to enter
-values and change controls on the system.
+&nbsp;<Keys.Annotation>E</Keys.Annotation> Sequenzen, also Chaser und 
+Cuelisten, lassen sich mit den Tasten der &nbsp;**Ablaufsteuerung** genauer 
+steuern.
 
 
 
-&nbsp;<Keys.Annotation>G</Keys.Annotation> The **Function buttons** are used to carry out functions such as recording
-cues, copying, saving to disk, etc.
+&nbsp;<Keys.Annotation>F</Keys.Annotation> Mit dem **Ziffern- und Tastenfeld** 
+lassen sich Werte eingeben sowie Einstellungen des Pultes ändern.
 
 
 
-&nbsp;<Keys.Annotation>H</Keys.Annotation> The **Workspace, Macros and Executer** buttons are programmable
-buttons which can be used to store cues such as strobe cues, workspaces 
-(screen layouts), or button macros.
+&nbsp;<Keys.Annotation>G</Keys.Annotation> Mit den **Funktionstasten** sind 
+verschiedene Funktionen verknüpft, etwa Speichern, Kopieren, Speichern auf Disk.
 
 
 
-&nbsp;<Keys.Annotation>I</Keys.Annotation> The **Workspace Window buttons**, along with the <Keys.HardKey>View</Keys.HardKey> button at the top right of the numeric keypad, are used to set which windows are shown on the screen. The <Keys.HardKey>Latch</Keys.HardKey> button bottom right keeps the current menu active.
+&nbsp;<Keys.Annotation>H</Keys.Annotation> Mit den **Macro- und Executor-Tasten** 
+lassen sich Macros, Cues sowie Workspaces (Arbeitsumgebungen) aufrufen.
 
 
 
-&nbsp;<Keys.Annotation>J</Keys.Annotation> The **Menu Softkeys** (labelled A - G) are used to select control options. 
-The right hand side of the display shows what each one will do - you can touch the softkey on-screen instead of using these
-buttons. The options for each 
-key change depending on what the console is doing. Softkey commands are shown 
-in the manual like this: <Keys.SoftKey>Edit Times</Keys.SoftKey>.
-
-At the bottom right of the console, the <Keys.HardKey>Locate</Keys.HardKey> button is used to light up and set selected fixtures to a zero position.
+&nbsp;<Keys.Annotation>I</Keys.Annotation> Mit den **Tasten zur Fenstersteuerung** 
+sowie der Taste <Keys.HardKey>View</Keys.HardKey> oben rechts beim Ziffernblock 
+lassen sich Fenster öffnen, schließen und verschieben. Mit der Taste <Keys.HardKey>Latch</Keys.HardKey> 
+kann das gerade aktive Menü eingerastet werden.
 
 
-&nbsp;<Keys.Annotation>K</Keys.Annotation> The **Power button** is used to power the console on and off ensuring correct shutdown. Pressing it will bring up a dialogue asking if you wish to turn off the console. If the software is not running use **Turn Off Console** in the Tools menu instead.
 
-&nbsp;<Keys.Annotation>L</Keys.Annotation> The **Front USB socket** is provided for USB sticks to save and reload shows (further USB sockets fitted on rear).
+&nbsp;<Keys.Annotation>J</Keys.Annotation> Die **Menütasten** (bezeichnet 
+mit A -- G) dienen zur Auswahl verschiedener Steuerungsoptionen. Im Display 
+wird direkt neben jedem Taster die jeweilige Funktion angezeigt, abhängig 
+vom jeweiligen Status des Pultes. Befehle dieser Taster sind in diesem Handbuch 
+blau dargestellt, z.B. <Keys.SoftKey>Edit Times</Keys.SoftKey>.
 
+Mit der Taste <Keys.HardKey>Locate</Keys.HardKey> unten rechts auf dem Pult können die Lampen/Geräte 
+in eine definierte Ausgangsposition (Home) gebracht werden.
+
+
+&nbsp;<Keys.Annotation>K</Keys.Annotation> Mit dem **Ein-/Ausschalter** wird das Pult gestartet und wieder heruntergefahren. 
+Beim Abschalten erfolgt eine Rückfrage, ob das Pult wirklich heruntergefahren werden soll. Alternativ kann man das Pult 
+mit **Turn Off Console** aus dem Tools-Menü herunterfahren.
+
+&nbsp;<Keys.Annotation>L</Keys.Annotation> Es gibt auf der Frontseite eine **USB-Buchse**, an die z.B. ein USB-Stick 
+zum Speichern der Show angeschlossen werden kann. Weitere USB-Anschlüsse befinden sich auf der Rückseite.
 
 ![D3-110 back panel](/docs/images/D3-110-back.png)
 
-&nbsp;<Keys.Annotation>M</Keys.Annotation> An external monitor can be connected to this DisplayPort socket. Only one external monitor can be connected.
+&nbsp;<Keys.Annotation>M</Keys.Annotation> An die DisplayPort-Buchse lässt sich ein externer Bildschirm anschließen; mehr als ein externer Bildschirm wird nicht unterstützt.
 
-&nbsp;<Keys.Annotation>N</Keys.Annotation> USB sockets for backup drive, display touch input, keyboard, mouse or D3 Wing.
+&nbsp;<Keys.Annotation>N</Keys.Annotation> USB-Buchsen zum Anschluss von externen Laufwerken, Touchscreens, Tastatur/Maus oder dem D3-Wing.
 
-&nbsp;<Keys.Annotation>O</Keys.Annotation> EtherCON ports for Art-Net or sACN output, or other network connection.
+&nbsp;<Keys.Annotation>O</Keys.Annotation> EtherCON-Anschlüsse für Art-Net, sACN oder andere Netzwerkanwendungen.
 
-&nbsp;<Keys.Annotation>P</Keys.Annotation> Four optically isolated DMX outputs are provided on 5-pin XLR. Up to 24 universes can be controlled in total (the others on Art-Net or sACN via the network port).
+&nbsp;<Keys.Annotation>P</Keys.Annotation> Vier optogalvanisch getrennte DMX-Anschlüsse als 5-polige XLR-Buchsen. Insgesamt können 24 DMX-Universen gesteuert werden (per DMX, Art-Net und sACN).
 
-&nbsp;<Keys.Annotation>Q</Keys.Annotation> Input for LTC timecode. A signal LED below the socket shows LTC activity.
+&nbsp;<Keys.Annotation>Q</Keys.Annotation> Eingang für LTC (SMPTE)-Timecode. Eine LED darunter zeigt anliegendes Signal an.
 
-&nbsp;<Keys.Annotation>R</Keys.Annotation> Audio input for generating Audio Triggers.
+&nbsp;<Keys.Annotation>R</Keys.Annotation> Audio-Eingang für Audiotrigger.
 
-&nbsp;<Keys.Annotation>S</Keys.Annotation> Mains input and isolation switch.
+&nbsp;<Keys.Annotation>S</Keys.Annotation> Netzanschluss und Netzschalter.
 
 ## D3-010
 
 ![D3-010](/docs/images/D3-010-front.png)
 
-The D3-010 is a compact standalone console with 10 playback faders, designed to operate with an external USB-C touchscreen.
+Das D3-010 ist ein kompaktes eigenständiges Pult mit 10 Playbackfadern zur Verwendung mit einem USB-C-Touchscreen.
 
 
-&nbsp;<Keys.Annotation>A</Keys.Annotation> The **Playback faders** and buttons are the main place to store and play back cues or chases
-but can also be assigned a range of other functions.
-
-
-
-&nbsp;<Keys.Annotation>B</Keys.Annotation> The **Page Select buttons** let you change to a different page of
-playbacks. The bottom of the screen shows information about each
-playback.
+&nbsp;<Keys.Annotation>A</Keys.Annotation> Die **Playbackfader** dienen zum 
+Speichern und Abrufen von Cues (Szenen) und Chasern/Cuelisten (Szenensequenzen). 
 
 
 
-&nbsp;<Keys.Annotation>C</Keys.Annotation> The **Attribute Control wheels** are used to set control values
-(attributes) for the fixtures, and also to set other parameters. The
-bottom right corner of the screen shows information about the parameters and values the wheels are controlling.
+Mit den &nbsp;<Keys.Annotation>B</Keys.Annotation> **Seitenwechseltasten** kann
+man zu verschiedenen Seiten der Playbacks wechseln. Im Touchscreen
+werden Informationen zur Belegung jedes Playbacks eingeblendet.
 
 
 
-&nbsp;<Keys.Annotation>D</Keys.Annotation> The **Attribute select buttons** are used to select which attributes of
-a fixture (e.g. colour, gobo, position) are going to be controlled using
-the Control wheels. The buttons light up to show you which
-attributes are active. 
+&nbsp;<Keys.Annotation>C</Keys.Annotation> Mit den **Encodern** werden 
+sowohl Attribute der Geräte, als auch Geschwindigkeit und Überblendung 
+von Chasern eingestellt. Im Touchscreen unten rechts wird angezeigt, 
+welche Parameter momentan mit welchem Rad verknüpft sind.
 
 
 
-&nbsp;<Keys.Annotation>E</Keys.Annotation> The **Playback control buttons** allow you to control cue lists and chases, and move about in the list.
+&nbsp;<Keys.Annotation>D</Keys.Annotation> Mit den Tastern der 
+**Attributauswahl** werden die Attribute der Geräte
+angewählt (z.B. Farbe, Gobo, Bewegung, Fokus), welche dann durch die
+Drehregler gesteuert werden sollen. Die jeweils aktiven Taster werden
+durch LEDs angezeigt.
 
 
 
-&nbsp;<Keys.Annotation>F</Keys.Annotation> The **Numeric keypad** and other control buttons are used to enter
-values and change controls on the system.
+&nbsp;<Keys.Annotation>E</Keys.Annotation> Sequenzen, also Chaser und 
+Cuelisten, lassen sich mit den Tasten der &nbsp;**Ablaufsteuerung** genauer 
+steuern.
 
 
 
-&nbsp;<Keys.Annotation>G</Keys.Annotation> The **Function buttons** are used to carry out functions such as recording
-cues, copying, saving to disk, etc.
+&nbsp;<Keys.Annotation>F</Keys.Annotation> Mit dem **Ziffern- und Tastenfeld** 
+lassen sich Werte eingeben sowie Einstellungen des Pultes ändern.
 
 
 
-&nbsp;<Keys.Annotation>H</Keys.Annotation> The **Workspace, Macros and Executer** buttons are programmable
-buttons which can be used to store cues such as strobe cues, workspaces 
-(screen layouts), or button macros.
+&nbsp;<Keys.Annotation>G</Keys.Annotation> Mit den **Funktionstasten** sind 
+verschiedene Funktionen verknüpft, etwa Speichern, Kopieren, Speichern auf Disk.
 
 
 
-&nbsp;<Keys.Annotation>I</Keys.Annotation> The **Workspace Window buttons**, along with the <Keys.HardKey>View</Keys.HardKey> button at the top right of the numeric keypad, are used to set which windows are shown on the screen. The <Keys.HardKey>Latch</Keys.HardKey> button bottom right keeps the current menu active.
+&nbsp;<Keys.Annotation>H</Keys.Annotation> Mit den **Macro- und Executor-Tasten** 
+lassen sich Macros, Cues sowie Workspaces (Arbeitsumgebungen) aufrufen.
 
 
 
-&nbsp;<Keys.Annotation>J</Keys.Annotation> The **Menu Softkeys** (labelled A - G) are used to select control options. 
-The right hand side of the display shows what each one will do - you can touch the softkey on-screen instead of using these
-buttons. The options for each 
-key change depending on what the console is doing. Softkey commands are shown 
-in the manual like this: <Keys.SoftKey>Edit Times</Keys.SoftKey>.
-
-At the bottom of the Softkeys, the <Keys.HardKey>Locate</Keys.HardKey> button is used to light up and set selected fixtures to a zero position.
+&nbsp;<Keys.Annotation>I</Keys.Annotation> Mit den **Tasten zur Fenstersteuerung** 
+sowie der Taste <Keys.HardKey>View</Keys.HardKey> oben rechts beim Ziffernblock 
+lassen sich Fenster öffnen, schließen und verschieben. Mit der Taste <Keys.HardKey>Latch</Keys.HardKey> 
+kann das gerade aktive Menü eingerastet werden.
 
 
-&nbsp;<Keys.Annotation>K</Keys.Annotation> The **Fixture Select buttons** are used when programming to step through a range of selected fixtures, turn highlighting on or off, fan the values or select a pattern of fixtures.
 
-&nbsp;<Keys.Annotation>L</Keys.Annotation> The **Syntax Select buttons** are used to form syntax/keypad commands when you are programming.
+&nbsp;<Keys.Annotation>J</Keys.Annotation> Die **Menütasten** (bezeichnet 
+mit A -- G) dienen zur Auswahl verschiedener Steuerungsoptionen. Im Display 
+wird direkt neben jedem Taster die jeweilige Funktion angezeigt, abhängig 
+vom jeweiligen Status des Pultes. Befehle dieser Taster sind in diesem Handbuch 
+blau dargestellt, z.B. <Keys.SoftKey>Edit Times</Keys.SoftKey>.
+
+Mit der Taste <Keys.HardKey>Locate</Keys.HardKey> unten rechts auf dem Pult können die Lampen/Geräte 
+in eine definierte Ausgangsposition (Home) gebracht werden.
+
+&nbsp;<Keys.Annotation>K</Keys.Annotation> Mit den Tasten zur **Geräteauswahl** kann man bei mehreren angewählten Geräten schrittweise durch die Auswahl gehen, Highlight ('Hervorheben') aktivieren/deaktivieren, per Fan Werte aufspreizen, sowie nach Muster auswählen (z.B. gerade/ungerade).
+
+&nbsp;<Keys.Annotation>L</Keys.Annotation> Die **Syntaxtasten** sind erforderlich für die Eingabe von Befehlssequenzen, sowie für spezielle Funktionen.
 
 
 ![D3-010 back panel](/docs/images/D3-010-back.png)
 
-&nbsp;<Keys.Annotation>M</Keys.Annotation> A display can be connected to this DisplayPort socket. Alternatively you can connect a display to the USB-C socket (Q). Only one display can be connected.
+&nbsp;<Keys.Annotation>M</Keys.Annotation> An die DisplayPort-Buchse lässt sich ein externer Bildschirm anschließen, alternativ kann der Anschluss an die USB-C-Buchse (Q) erfolgen; mehr als ein externer Bildschirm wird nicht unterstützt.
 
-&nbsp;<Keys.Annotation>N</Keys.Annotation> USB sockets for keyboard, display touch input, mouse or backup drive.
+&nbsp;<Keys.Annotation>N</Keys.Annotation> USB-Buchsen zum Anschluss von externen Laufwerken, Touchscreens, Tastatur/Maus etc.
 
-&nbsp;<Keys.Annotation>O</Keys.Annotation> Ethernet ports for Art-Net or sACN output, or other network connection.
+&nbsp;<Keys.Annotation>O</Keys.Annotation> EtherCON-Anschlüsse für Art-Net, sACN oder andere Netzwerkanwendungen.
 
-&nbsp;<Keys.Annotation>P</Keys.Annotation> Four optically isolated DMX outputs are provided on 5-pin XLR. Up to 8 universes can be controlled in total (the others on Art-Net or sACN via the network port).
+&nbsp;<Keys.Annotation>P</Keys.Annotation> Vier optogalvanisch getrennte DMX-Anschlüsse als 5-polige XLR-Buchsen. Insgesamt können 8 DMX-Universen gesteuert werden (per DMX, Art-Net und sACN).
 
-&nbsp;<Keys.Annotation>Q</Keys.Annotation> An external touch display can be connected to this USB-C socket. Alternatively you can connect a display to the DisplayPort socket (A). Only one monitor can be connected.
+&nbsp;<Keys.Annotation>Q</Keys.Annotation> An diese USB-C-Buchse kann ein externer Touch-Bildschirm angeschlossen werden, alternativ kann der Anschluss über die DisplayPort-Buchse (A) erfolgen. Es wird nur ein externer Bildschirm unterstützt.
 
-&nbsp;<Keys.Annotation>R</Keys.Annotation> Input for LTC timecode. A signal LED below the socket shows LTC activity.
+&nbsp;<Keys.Annotation>R</Keys.Annotation> Eingang für LTC (SMPTE)-Timecode. Eine LED darunter zeigt anliegendes Signal an.
 
-&nbsp;<Keys.Annotation>S</Keys.Annotation> Mains isolation switch.
+&nbsp;<Keys.Annotation>S</Keys.Annotation> Netzanschluss und Netzschalter.
 
 
 ## D3-Core
 
 ![D3 Core](/docs/images/D3-core-front.png)
 
-The D3 Core is a 1U rack mounted processor that runs Titan as a standalone controller. You can connect a T3 / T3 fader wing to provide controls, or the D3-Touch for simple touch screen installation, or a standard Windows Touch compatible touchscreen can show the full Titan Go interface. You can also control over Ethernet from other automation systems using Avolites WebAPI.
+Der D3 Core ist ein 1 HE großer Prozessor zum eigenständigen Betrieb von Titan. Zur Bedienung kann das T3 oder T3 Wing angeschlossen werden, und zusammen mit dem D3 Touch lassen sich kompakte Installationen realisieren. Bei Verwendung eines normalen Touchscreens lässt sich die gewohnte Titan Go-Oberfläche zum Programmieren verwenden. Ebenso ist die Steuerung von externen Geräten aus über die WebAPI möglich.
 
 ![D3 Core back](/docs/images/D3-core-back.png)
 
-- Four optically isolated DMX outputs are provided on 5-pin XLR. Up to 16 universes can be controlled in total (the others on Art-Net or sACN via the network port).
+- Vier optogalvanisch getrennte DMX-Anschlüsse als 5-polige XLR-Buchsen. Insgesamt können 16 DMX-Universen gesteuert werden (per DMX, Art-Net und sACN).
 
-- A touch display can be connected either to the USB-C socket on the front panel or the DisplayPort socket on the rear panel (using separate USB for touch input). Only one display can be connected.
+- Ein externer Touch-Bildschirm kann entweder an die frontseitige USB-C-Buchse oder an die DisplayPort-Buchse auf der Rückseite angeschlossen werden. Es wird nur ein externer Bildschirm unterstützt.
 
-- An input is provided for LTC timecode. A signal LED below the socket shows LTC activity.
+- Eingang für LTC (SMPTE)-Timecode. Eine LED darunter zeigt anliegendes Signal an.
 
-- A 6.35mm jack socket is provided for GPIO triggering.
+- 6,35mm Klinkenbuchse als GPIO-Triggereingang.
 
 
 ## D3 Touch
 
 ![D3 Touch](/docs/images/D3-touch-front.png)
 
-The D3 Touch is an installation touchscreen giving simple, reliable access to a selection of playbacks on a Titan system. The touchscreen is connected and powered using Power-over-Ethernet or a DC adaptor. Any Titan system apart from T1 can be controlled by the D3 Touch panel.
+Das D3 Touch ist ein Touchscreen für Installationsanwendungen, um einfach Zugriff auf die in Titan programmierten Playbacks zu realisieren. Der D3 Touch wird per Ethernet angeschossen und über PoE oder ein separates Netzteil mit Spannung versorgt. Jedes Titan-System außer dem T1 kann mit dem D3 Touch gesteuert werden.
 
-See the [Remote Control](../remote-control.md) section for details of how to program the D3-Touch panel.
+Für Details zum Programmieren des D3 Touch siehe [Remote Control](../remote-control.md).
 
 ## D3 Wing
 
-The D3 Wing adds 20 additional playback faders and 30
-macro/executor buttons to the main console. It connects by a single USB
-cable to the D3.
+Das D3 Wing ergänzt das Pult um 20 zusätzliche Playbackfadern und 30
+Macro/Executor-Tasten. Es wird einfach mit einem USB-Kabel an das D3 angeschlossen.
 
-It is designed to fit next to the D3-110 or D3-010, but it can be
-used with any of the Avolites Titan console range and also the T2 USB device. It has the same functionality as the T3 wing but with different styling to match the D3 range.
+Von der Größe und Form her ist es die ideale Ergänzung zum D3, kann aber auch als Erweiterung 
+mit jedem anderen Titan-Pult ab dem T2 aufwärts verwendet werden. Es hat die gleichen Funktionen wie das T3 Wing, ist aber in Form und Layout auf das D3 abgestimmt.
 
 ![D3 Wing](/docs/images/D3-wing.png)
 
-If you want to see the legends and function information for the controls on the wing, there is a **Mobile Wing** workspace window - double click <Keys.HardKey>View</Keys.HardKey> and select "Mobile Wing". Using the Context Menu buttons you can select different views for this workspace which combine the playbacks and macro/executor buttons into one screen, or you can display them in separate
-pages.
-
+Zur Anzeige der Belegung der Fader und Tasten auf dem Wing gibt es das Fenster
+"Mobile Wing". Um dieses zu öffnen, drücken Sie zweimal 
+auf <Keys.HardKey>View/Open</Keys.HardKey> und wählen "Mobile Wing". Mit den 
+Kontext-Buttons kann man verschiedene Anzeigearten dieses Fensters wählen, z.B. 
+alles zusammen, nur die Fader, nur die Tasten etc.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/d3.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/d3.md
@@ -1,0 +1,222 @@
+---
+id: d3
+title: D3
+sidebar_label: D3
+description: D3 range - design and features
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+The D3 range includes two consoles, a standalone rack processing unit, a touch controller and 
+a matching fader wing.
+
+## D3-110
+
+![D3-110](/docs/images/D3-110-front.png)
+
+The D3-110 is a compact standalone console with a built in touchscreen and 10 playback faders.
+
+&nbsp;<Keys.Annotation>A</Keys.Annotation> The **Playback faders** and buttons are the main place to store and play back cues or chases
+but can also be assigned a range of other functions.
+
+
+
+&nbsp;<Keys.Annotation>B</Keys.Annotation> The **Page Select buttons** let you change to a different page of
+playbacks. The bottom of the screen shows information about each
+playback.
+
+
+
+&nbsp;<Keys.Annotation>C</Keys.Annotation> The **Attribute Control wheels** are used to set control values
+(attributes) for the fixtures, and also to set other parameters. The
+bottom right corner of the screen shows information about the parameters and values the wheels are controlling.
+
+
+
+&nbsp;<Keys.Annotation>D</Keys.Annotation> The **Attribute select buttons** are used to select which attributes of
+a fixture (e.g. colour, gobo, position) are going to be controlled using
+the Control wheels. The buttons light up to show you which
+attributes are active. 
+
+
+
+&nbsp;<Keys.Annotation>E</Keys.Annotation> The **Playback control buttons** allow you to control cue lists and chases, and move about in the list.
+
+
+
+&nbsp;<Keys.Annotation>F</Keys.Annotation> The **Numeric keypad** and other control buttons are used to enter
+values and change controls on the system.
+
+
+
+&nbsp;<Keys.Annotation>G</Keys.Annotation> The **Function buttons** are used to carry out functions such as recording
+cues, copying, saving to disk, etc.
+
+
+
+&nbsp;<Keys.Annotation>H</Keys.Annotation> The **Workspace, Macros and Executer** buttons are programmable
+buttons which can be used to store cues such as strobe cues, workspaces 
+(screen layouts), or button macros.
+
+
+
+&nbsp;<Keys.Annotation>I</Keys.Annotation> The **Workspace Window buttons**, along with the <Keys.HardKey>View</Keys.HardKey> button at the top right of the numeric keypad, are used to set which windows are shown on the screen. The <Keys.HardKey>Latch</Keys.HardKey> button bottom right keeps the current menu active.
+
+
+
+&nbsp;<Keys.Annotation>J</Keys.Annotation> The **Menu Softkeys** (labelled A - G) are used to select control options. 
+The right hand side of the display shows what each one will do - you can touch the softkey on-screen instead of using these
+buttons. The options for each 
+key change depending on what the console is doing. Softkey commands are shown 
+in the manual like this: <Keys.SoftKey>Edit Times</Keys.SoftKey>.
+
+At the bottom right of the console, the <Keys.HardKey>Locate</Keys.HardKey> button is used to light up and set selected fixtures to a zero position.
+
+
+&nbsp;<Keys.Annotation>K</Keys.Annotation> The **Power button** is used to power the console on and off ensuring correct shutdown. Pressing it will bring up a dialogue asking if you wish to turn off the console. If the software is not running use **Turn Off Console** in the Tools menu instead.
+
+&nbsp;<Keys.Annotation>L</Keys.Annotation> The **Front USB socket** is provided for USB sticks to save and reload shows (further USB sockets fitted on rear).
+
+
+![D3-110 back panel](/docs/images/D3-110-back.png)
+
+&nbsp;<Keys.Annotation>M</Keys.Annotation> An external monitor can be connected to this DisplayPort socket. Only one external monitor can be connected.
+
+&nbsp;<Keys.Annotation>N</Keys.Annotation> USB sockets for backup drive, display touch input, keyboard, mouse or D3 Wing.
+
+&nbsp;<Keys.Annotation>O</Keys.Annotation> EtherCON ports for Art-Net or sACN output, or other network connection.
+
+&nbsp;<Keys.Annotation>P</Keys.Annotation> Four optically isolated DMX outputs are provided on 5-pin XLR. Up to 24 universes can be controlled in total (the others on Art-Net or sACN via the network port).
+
+&nbsp;<Keys.Annotation>Q</Keys.Annotation> Input for LTC timecode. A signal LED below the socket shows LTC activity.
+
+&nbsp;<Keys.Annotation>R</Keys.Annotation> Audio input for generating Audio Triggers.
+
+&nbsp;<Keys.Annotation>S</Keys.Annotation> Mains input and isolation switch.
+
+## D3-010
+
+![D3-010](/docs/images/D3-010-front.png)
+
+The D3-010 is a compact standalone console with 10 playback faders, designed to operate with an external USB-C touchscreen.
+
+
+&nbsp;<Keys.Annotation>A</Keys.Annotation> The **Playback faders** and buttons are the main place to store and play back cues or chases
+but can also be assigned a range of other functions.
+
+
+
+&nbsp;<Keys.Annotation>B</Keys.Annotation> The **Page Select buttons** let you change to a different page of
+playbacks. The bottom of the screen shows information about each
+playback.
+
+
+
+&nbsp;<Keys.Annotation>C</Keys.Annotation> The **Attribute Control wheels** are used to set control values
+(attributes) for the fixtures, and also to set other parameters. The
+bottom right corner of the screen shows information about the parameters and values the wheels are controlling.
+
+
+
+&nbsp;<Keys.Annotation>D</Keys.Annotation> The **Attribute select buttons** are used to select which attributes of
+a fixture (e.g. colour, gobo, position) are going to be controlled using
+the Control wheels. The buttons light up to show you which
+attributes are active. 
+
+
+
+&nbsp;<Keys.Annotation>E</Keys.Annotation> The **Playback control buttons** allow you to control cue lists and chases, and move about in the list.
+
+
+
+&nbsp;<Keys.Annotation>F</Keys.Annotation> The **Numeric keypad** and other control buttons are used to enter
+values and change controls on the system.
+
+
+
+&nbsp;<Keys.Annotation>G</Keys.Annotation> The **Function buttons** are used to carry out functions such as recording
+cues, copying, saving to disk, etc.
+
+
+
+&nbsp;<Keys.Annotation>H</Keys.Annotation> The **Workspace, Macros and Executer** buttons are programmable
+buttons which can be used to store cues such as strobe cues, workspaces 
+(screen layouts), or button macros.
+
+
+
+&nbsp;<Keys.Annotation>I</Keys.Annotation> The **Workspace Window buttons**, along with the <Keys.HardKey>View</Keys.HardKey> button at the top right of the numeric keypad, are used to set which windows are shown on the screen. The <Keys.HardKey>Latch</Keys.HardKey> button bottom right keeps the current menu active.
+
+
+
+&nbsp;<Keys.Annotation>J</Keys.Annotation> The **Menu Softkeys** (labelled A - G) are used to select control options. 
+The right hand side of the display shows what each one will do - you can touch the softkey on-screen instead of using these
+buttons. The options for each 
+key change depending on what the console is doing. Softkey commands are shown 
+in the manual like this: <Keys.SoftKey>Edit Times</Keys.SoftKey>.
+
+At the bottom of the Softkeys, the <Keys.HardKey>Locate</Keys.HardKey> button is used to light up and set selected fixtures to a zero position.
+
+
+&nbsp;<Keys.Annotation>K</Keys.Annotation> The **Fixture Select buttons** are used when programming to step through a range of selected fixtures, turn highlighting on or off, fan the values or select a pattern of fixtures.
+
+&nbsp;<Keys.Annotation>L</Keys.Annotation> The **Syntax Select buttons** are used to form syntax/keypad commands when you are programming.
+
+
+![D3-010 back panel](/docs/images/D3-010-back.png)
+
+&nbsp;<Keys.Annotation>M</Keys.Annotation> A display can be connected to this DisplayPort socket. Alternatively you can connect a display to the USB-C socket (Q). Only one display can be connected.
+
+&nbsp;<Keys.Annotation>N</Keys.Annotation> USB sockets for keyboard, display touch input, mouse or backup drive.
+
+&nbsp;<Keys.Annotation>O</Keys.Annotation> Ethernet ports for Art-Net or sACN output, or other network connection.
+
+&nbsp;<Keys.Annotation>P</Keys.Annotation> Four optically isolated DMX outputs are provided on 5-pin XLR. Up to 8 universes can be controlled in total (the others on Art-Net or sACN via the network port).
+
+&nbsp;<Keys.Annotation>Q</Keys.Annotation> An external touch display can be connected to this USB-C socket. Alternatively you can connect a display to the DisplayPort socket (A). Only one monitor can be connected.
+
+&nbsp;<Keys.Annotation>R</Keys.Annotation> Input for LTC timecode. A signal LED below the socket shows LTC activity.
+
+&nbsp;<Keys.Annotation>S</Keys.Annotation> Mains isolation switch.
+
+
+## D3-Core
+
+![D3 Core](/docs/images/D3-core-front.png)
+
+The D3 Core is a 1U rack mounted processor that runs Titan as a standalone controller. You can connect a T3 / T3 fader wing to provide controls, or the D3-Touch for simple touch screen installation, or a standard Windows Touch compatible touchscreen can show the full Titan Go interface. You can also control over Ethernet from other automation systems using Avolites WebAPI.
+
+![D3 Core back](/docs/images/D3-core-back.png)
+
+- Four optically isolated DMX outputs are provided on 5-pin XLR. Up to 16 universes can be controlled in total (the others on Art-Net or sACN via the network port).
+
+- A touch display can be connected either to the USB-C socket on the front panel or the DisplayPort socket on the rear panel (using separate USB for touch input). Only one display can be connected.
+
+- An input is provided for LTC timecode. A signal LED below the socket shows LTC activity.
+
+- A 6.35mm jack socket is provided for GPIO triggering.
+
+
+## D3 Touch
+
+![D3 Touch](/docs/images/D3-touch-front.png)
+
+The D3 Touch is an installation touchscreen giving simple, reliable access to a selection of playbacks on a Titan system. The touchscreen is connected and powered using Power-over-Ethernet or a DC adaptor. Any Titan system apart from T1 can be controlled by the D3 Touch panel.
+
+See the [Remote Control](../remote-control.md) section for details of how to program the D3-Touch panel.
+
+## D3 Wing
+
+The D3 Wing adds 20 additional playback faders and 30
+macro/executor buttons to the main console. It connects by a single USB
+cable to the D3.
+
+It is designed to fit next to the D3-110 or D3-010, but it can be
+used with any of the Avolites Titan console range and also the T2 USB device. It has the same functionality as the T3 wing but with different styling to match the D3 range.
+
+![D3 Wing](/docs/images/D3-wing.png)
+
+If you want to see the legends and function information for the controls on the wing, there is a **Mobile Wing** workspace window - double click <Keys.HardKey>View</Keys.HardKey> and select "Mobile Wing". Using the Context Menu buttons you can select different views for this workspace which combine the playbacks and macro/executor buttons into one screen, or you can display them in separate
+pages.
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/d7.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/d7.md
@@ -1,0 +1,133 @@
+---
+id: d7
+title: Diamond 7
+sidebar_label: Das Diamond 7
+description: Diamond 7 - console design and features
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+![Diamond7](/docs/images/d7-mainareas.png)
+
+Das Diamond 7 hat die im Folgenden beschriebenen Bereiche. Dabei gibt es zwei Modelle: 
+das D7-330 mit drei Touchscreens und 30 Fadern sowie das hier gezeigte D7-215 mit zwei 
+Touchscreens und 15 Fadern:
+
+&nbsp;<Keys.Annotation>A</Keys.Annotation> Die zwei großen **Touchscreens** (beim D7-330: drei) 
+zeigen den zentralen Arbeitsbereich des Pultes. Es gibt konfigurierbare Fenster mit Buttons für 
+Geräte, Paletten, Gruppen, Playbacks, Macros und mehr. Auch der integrierte Capture-Visualiser, 
+Vorschauen anliegender Videostreams und weitere Informationsfenster können angezeigt werden, wie z.B. 
+die ausgegebenen DMX-Werte oder die Intensitäten der gesteuerten Geräte. Am unteren Rand des 
+rechten Bildschirms wird die aktuelle Funktion der Encoder angezeigt. Am unteren Rand der linken 
+Touchscreens werden die Belegungen der Playbackfader und -tasten dargestellt.
+
+&nbsp;<Keys.Annotation>B</Keys.Annotation> Die **Playbackfader** und **Playback-Drehregler** dienen zur Auswahl und 
+Steuerung von Cues, Cuelisten und Chaser und anderen konfigurierbaren Funktionen. (Das D7-330 verfügt über 
+weitere Fader).
+
+&nbsp;<Keys.Annotation>C</Keys.Annotation> Die **Programmiersektion** enthält alle Steuerelemente 
+zum Einrichten und Programmieren des Pultes. Auf den **Macro/Executor-Tasten** können Playbacks, 
+häufig genutzte Tastenfolgen, Arbeitsumgebungen (Layouts der Displays) oder z.B. Gruppen gespeichert 
+werden. Links neben der Programmiersektion befindet sich die Ablaufsteuerung für Cuelisten.
+
+Beim Diamond 7 sind über den Displays LEDs zur Beleuchtung des Pultes integriert. Darüber hinaus gibt es 
+Buchsen für übliche Schwanenhals-Leuchten, z.B. als Leselicht. Die Helligkeit kann im System-Menü eingestellt werden.
+
+![Diamond7 detail](/docs/images/D7-Detail.png)
+
+## Playbacks
+
+&nbsp;<Keys.Annotation>D</Keys.Annotation> Die motorisierten **Playbackfader** und Tasten dazu 
+sind der wichtigste Platz, um Cues, Chaser und Cuelisten zu speichern, können aber auch 
+andere Funktionen erhalten. Jeder Fader ist mit LED beleuchtet zur Anzeige des Status, 
+die Farbe selbst kann als Halo frei definiert werden. Auf dem Touchscreen oberhalb der Fader 
+wird die momentane Funktion und weitere nützliche Informationen angezeigt.
+
+&nbsp;<Keys.Annotation>E</Keys.Annotation> Mit den **Seitenwechseltasten** kann man 
+zu verschiedenen Seiten der Playbacks wechseln. 
+
+&nbsp;<Keys.Annotation>F</Keys.Annotation>Auf den **Drehreglern** und zugehörigen Tasten lassen sich 
+Cues, Chaser, Cuelisten, aber auch z.B. Gruppen speichern. Auch diese Regler verfügen über 
+LED-Beleuchtung, und die Farbe lässt sich als Halo frei definieren. Im Touchscreen über den Drehreglern 
+wird die aktuelle Belegung und Funktion angezeigt. 
+
+&nbsp;<Keys.Annotation>G</Keys.Annotation> Die **Ablaufsteuerung** steuert die 
+Wiedergabe von Cuelisten. Dazu stehen ein Paar von Motorfadern zur Steuerung des aktuell 
+verbundenen Playbacks oder Masters zur Verfügung.
+
+## Die Programmiersektion
+
+&nbsp;<Keys.Annotation>O</Keys.Annotation> Mit den fünf **Encodern** (Rädern) werden 
+sowohl Attribute der Geräte als auch Geschwindigkeit und Überblendung von Chasern 
+eingestellt. Im Touchscreen oberhalb der Räder wird angezeigt, welche Parameter 
+momentan mit welchem Rad verknüpft sind. Mit den Tasten ganz rechts neben den Encodern 
+lassen sich andere Funktionen auf die Encoder legen, z.B. Fadezeiten, Details von Shapes, 
+oder die Steuerung des Visualisers.
+
+&nbsp;<Keys.Annotation>I</Keys.Annotation> Mit dem **Ziffern- und Tastenfeld** lassen 
+sich Werte eingeben sowie Einstellungen des Pultes ändern.
+
+&nbsp;<Keys.Annotation>J</Keys.Annotation> Mit den Tastern der **Attributauswahl** 
+werden die Attribute der Geräte angewählt (z.B. Farbe, Gobo, Bewegung, Fokus), welche 
+dann durch die Encoder gesteuert werden sollen. Die jeweils aktiven Taster werden 
+durch LEDs angezeigt.
+
+&nbsp;<Keys.Annotation>K</Keys.Annotation> Der **Editor Touchscreen** zeigt das Fenster des 
+Attribut-Editors, mit dem sich schnell und gezielt Einstellungen vornehmen lassen.
+
+&nbsp;<Keys.Annotation>L</Keys.Annotation> Mit den **Funktionstasten** sind verschiedene Funktionen verknüpft, etwa Speichern, Kopieren, Speichern auf Disk. 
+
+&nbsp;<Keys.Annotation>M</Keys.Annotation> Das separate **Intensity-Handrad** steuert 
+stets die Helligkeit der angewählten Geräte.
+
+&nbsp;<Keys.Annotation>N</Keys.Annotation> Auf den **Macrotasten** lassen sich 
+sowohl Playbacks wie z.B. ein Strobe-Cue als auch häufig benutzte Abläufe von 
+Tastendrücken abspeichern, die dann mit einem einzigen Tastendruck abgerufen 
+werden können. Im Display direkt oberhalb der Tasten wird die aktuelle Belegung 
+angezeigt.
+
+## Vorderseite des Pultes
+
+![D7 front controls](/docs/images/D7-Keyboard.png)
+
+An der Vorderseite des Pultes befindet sich eine ausziehbare beleuchtete **Tastatur** 
+z.B. für Legenden oder zum Eingeben von Suchbegriffen. Der **Einschalter** <Keys.Annotation>O</Keys.Annotation> ist rechts neben 
+der Tastatur (sichtbar, wenn diese herausgezogen ist). Ein **USB-C-Anschluss** <Keys.Annotation>P</Keys.Annotation> 
+z.B. für USB-Sticks befindet sich in der Mulde des rechten Griffs.
+
+## Rückseite des Pultes, Anschlüsse
+
+![D7 Back Panel](/docs/images/D7-back.png)
+
+&nbsp;<Keys.Annotation>a</Keys.Annotation> Netzspannungseingang (PowerCON TRUE1)
+
+&nbsp;<Keys.Annotation>b</Keys.Annotation> Netzschalter. Schalten Sie das Pult nicht mit dem 
+Hauptschalter aus, sondern fahren Sie es mit dem Einschalter auf der Vorderseite 
+ordnungsgemäß herunter.
+
+&nbsp;<Keys.Annotation>c</Keys.Annotation> Anschlüsse für Pultleuchten
+
+&nbsp;<Keys.Annotation>d</Keys.Annotation> Unterbrecher für die USV
+
+&nbsp;<Keys.Annotation>e</Keys.Annotation> Weiterer Gigabit EtherCON Netzwerkanschluss.
+
+&nbsp;<Keys.Annotation>f</Keys.Annotation> GPIO-Triggeranschlüsse (SubD).
+
+&nbsp;<Keys.Annotation>g</Keys.Annotation> Schalter zum Ein/Ausschalten des Arbeitslichts auf der Rückseite.
+
+&nbsp;<Keys.Annotation>h</Keys.Annotation> Vier Gigabit EtherCON Netzwerkanschlüsse 
+vom integrierten Netzwerkswitch.
+
+&nbsp;<Keys.Annotation>i</Keys.Annotation> Anschlüsse für zwei weitere Screens (DisplayPort und USB 
+für Touchscreens) sowie USB-Anschlüsse für Peripheriegeräte.
+
+&nbsp;<Keys.Annotation>j</Keys.Annotation> Audio-Eingang zum Triggern.
+
+&nbsp;<Keys.Annotation>k</Keys.Annotation> MIDI In, Thru and Out.
+
+&nbsp;<Keys.Annotation>m</Keys.Annotation> GPIO-Triggeranschluss (Klinkenbuchse).
+
+&nbsp;<Keys.Annotation>n</Keys.Annotation> Anschlüsse für LTC (Timecode) Eingang und Loop.
+
+&nbsp;<Keys.Annotation>o</Keys.Annotation> DMX512-Ausgänge (4 beim D7-215, 8 beim D7-330).

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/d7.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/d7.md
@@ -1,7 +1,7 @@
 ---
 id: d7
 title: Diamond 7
-sidebar_label: Das Diamond 7
+sidebar_label: D7
 description: Diamond 7 - console design and features
 ---
 
@@ -27,7 +27,7 @@ Steuerung von Cues, Cuelisten und Chaser und anderen konfigurierbaren Funktionen
 weitere Fader).
 
 &nbsp;<Keys.Annotation>C</Keys.Annotation> Die **Programmiersektion** enthält alle Steuerelemente 
-zum Einrichten und Programmieren des Pultes. Auf den **Macro/Executor-Tasten** können Playbacks, 
+zum Einrichten und Programmieren des Pultes sowie einen kleinen **Editor-Touchscreen** zur Anzeige der Attribute der Geräte oder der Legenden der Macrotasten. Auf den **Macro/Executor-Tasten** können Playbacks, 
 häufig genutzte Tastenfolgen, Arbeitsumgebungen (Layouts der Displays) oder z.B. Gruppen gespeichert 
 werden. Links neben der Programmiersektion befindet sich die Ablaufsteuerung für Cuelisten.
 
@@ -74,12 +74,15 @@ dann durch die Encoder gesteuert werden sollen. Die jeweils aktiven Taster werde
 durch LEDs angezeigt.
 
 &nbsp;<Keys.Annotation>K</Keys.Annotation> Der **Editor Touchscreen** zeigt das Fenster des 
-Attribut-Editors, mit dem sich schnell und gezielt Einstellungen vornehmen lassen.
+Attribut-Editors, mit dem sich schnell und gezielt Einstellungen vornehmen lassen. Alternativ 
+kann der Screen die Belegung der 10 Macrotasten darunter anzeigen. Zum Wechsel der Anzeige 
+dient die Taste **Screen Mode** rechts neben dem kleinen Display.
 
 &nbsp;<Keys.Annotation>L</Keys.Annotation> Mit den **Funktionstasten** sind verschiedene Funktionen verknüpft, etwa Speichern, Kopieren, Speichern auf Disk. 
 
 &nbsp;<Keys.Annotation>M</Keys.Annotation> Das separate **Intensity-Handrad** steuert 
-stets die Helligkeit der angewählten Geräte.
+stets die Helligkeit der angewählten Geräte, der aktuelle Wert wird in der rechten unteren 
+Ecke des rechten Displays angezeigt.
 
 &nbsp;<Keys.Annotation>N</Keys.Annotation> Auf den **Macrotasten** lassen sich 
 sowohl Playbacks wie z.B. ein Strobe-Cue als auch häufig benutzte Abläufe von 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/diamond.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/diamond.md
@@ -1,0 +1,170 @@
+---
+id: diamond
+title: Diamond 9
+sidebar_label: Das Diamond 9
+description: Diamond 9 - console design and features
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+![Diamond9](/docs/images/Diamond-Main.png)
+
+Das Diamond 9 hat die im Folgenden beschriebenen Bereiche. Dabei gibt es zwei Modelle: das hier gezeigte D9-330 sowie das kleinere D9-215 mit nur zwei großen Touchscreens und weniger Fadern:
+
+&nbsp;<Keys.Annotation>A</Keys.Annotation> Die drei großen **Touchscreens** (beim D9-215: zwei) zeigen 
+Schaltflächen zur Auswahl von Geräten, Paletten und Gruppen. Auf dem rechten Touchscreen wird unten die 
+aktuelle Belegung der Encoder sowie der 15 Macrotasten angezeigt. Am oberen und unteren Rand der linken 
+Touchscreens werden die Belegungen der Playbackfader und -tasten angezeigt.
+
+&nbsp;<Keys.Annotation>B</Keys.Annotation> Die **Playbackfader** und **Playback-Drehregler** dienen zur Auswahl und 
+Steuerung von Cues, Cuelisten und Chaser und anderen konfigurierbaren Funktionen. (Das D9-215 verfügt nur über 
+den rechten Teil der Fader).
+
+&nbsp;<Keys.Annotation>C</Keys.Annotation> Der **System Prompt und Menü-Tasten** verfügen über einen eigenen Touchscreen.
+
+&nbsp;<Keys.Annotation>D</Keys.Annotation> Die **Programmiersektion** enthält alle Steuerelemente 
+zum Einrichten und Programmieren des Pultes. Mit dem darin enthaltenen **Editor-Touchscreen** werden Attributwerte 
+angezeigt und verändert, während auf den **Macro/Executor-Tasten** Playbacks, häufig genutzte Tastenfolgen, 
+Arbeitsumgebungen (Layouts der Displays) oder z.B. Gruppen gespeichert werden können. Links davon befindet sich die 
+Ablaufsteuerung für Cuelisten sowie der T-Griff des Scene Masters.
+
+&nbsp;<Keys.Annotation>E</Keys.Annotation> Drei kleine **Layer-Screens** dienen etwa der Anzeige von NDI-Video-Feeds 
+oder für weitere Arbeitsfenster.
+
+
+
+## Die Touchscreens
+
+![Diamond-F-G](/docs/images/Diamond-F.png)
+
+&nbsp;<Keys.Annotation>F</Keys.Annotation> Die **Arbeitsfenster** auf dem Touchscreen 
+zeigen Buttons für Geräte, Paletten, Gruppen, Speicherplätze, Makros und anderes. 
+Ebenso kann man sich den integrierten Capture Visualiser, Video-Feeds und eine Menge 
+weiterer Informationen anzeigen lassen, z.B. Intensitäten oder DMX-Werte.
+
+
+&nbsp;<Keys.Annotation>G</Keys.Annotation> Der Screen mit **Systemanzeige und Menütasten** 
+ist die Schaltzentrale des Pultes und liefert Informationen über den jeweiligen Zustand. 
+Hier werden diverse Menütasten eingeblendet, abhängig vom momentanen Arbeits- und 
+Programmierablauf. Befehle dieser Buttons sind in diesem Handbuch blau dargestellt, 
+z.B. <Keys.SoftKey>Edit Times</Keys.SoftKey>
+
+
+
+## Playbacks
+
+![Diamond-H](/docs/images/Diamond-H.png)
+
+&nbsp;<Keys.Annotation>H</Keys.Annotation> auf den **Drehreglern** und Tasten oben lassen sich 
+z.B. Cues, Chaser, Cuelisten, aber auch z.B. Gruppen speichern. Der aktuelle Pegel 
+wird durch den Ring um den Regler angezeigt; dessen Farbe wiederum lässt sich als 
+Halo frei definieren. Im Touchscreen direkt unter den Drehreglern wird direkt die 
+aktuelle Belegung und Funktion angezeigt. Weitere solche Drehregler gibt es rechts 
+und links neben den Touchscreens.
+
+&nbsp;<Keys.Annotation>I</Keys.Annotation> Mit den **Seitenwechseltasten** kann man zu verschiedenen Seiten der Playbacks wechseln.
+
+&nbsp;<Keys.Annotation>J</Keys.Annotation> Zwei weitere Sets von **Drehreglern** 
+befinden sich oberhalb der Playbackfader.
+
+&nbsp;<Keys.Annotation>K</Keys.Annotation> Die motorisierten **Playbackfader** und Tasten dazu 
+sind der wichtigste Platz, um Cues, Chaser und Cuelisten zu speichern, können aber auch 
+andere Funktionen erhalten. Auch an diesen Fadern wird der momentane Stand mit farbigen 
+LEDs angezeigt, und die Farbe selbst kann als Halo frei definiert werden. Auf dem 
+Touchscreen oberhalb der Fader wird die momentane Funktion und weitere nützliche 
+Informationen angezeigt.
+
+&nbsp;<Keys.Annotation>L</Keys.Annotation> Mit den **Seitenwechseltasten** kann man 
+zu verschiedenen Seiten der Playbacks wechseln (sowohl für die Fader als auch für 
+die Drehregler).
+
+&nbsp;<Keys.Annotation>M</Keys.Annotation> Auf den **Macrotasten** lassen sich 
+sowohl Playbacks wie z.B. ein Strobe-Cue als auch häufig benutzte Abläufe von 
+Tastendrücken abspeichern, die dann mit einem einzigen Tastendruck abgerufen 
+werden können. Im Display direkt oberhalb der Tasten wird die aktuelle Belegung 
+angezeigt. Außerdem gibt es sechs weitere Macrotasten zwischen den Playbackfadern 
+sowie extra für diese ein kleines Display.
+
+&nbsp;<Keys.Annotation>N</Keys.Annotation> Die **Ablaufsteuerung** steuert die 
+Wiedergabe von Cuelisten. Dazu gehört auch der T-Griff für den Scene Master und ein 
+Paar von Motorfadern zur Steuerung des aktuell verbundenen Playbacks oder Masters.
+
+## Die Programmiersektion
+
+![Diamond-N](/docs/images/Diamond-O.png)
+
+&nbsp;<Keys.Annotation>O</Keys.Annotation> Mit den **Drehreglern** (Encodern) werden 
+sowohl Attribute der Geräte als auch Geschwindigkeit und Überblendung von Chasern 
+eingestellt. Im Touchscreen oberhalb der Räder wird angezeigt, welche Parameter 
+momentan mit welchem Rad verknüpft sind. Mit den Tasten ganz rechts neben den Encodern 
+lassen sich andere Funktionen auf die Encoder legen, z.B. Fadezeiten, Details von Shapes, 
+oder die Steuerung des Visualisers.
+
+&nbsp;<Keys.Annotation>P</Keys.Annotation> Der separate **Editor-Touchscreen** zeigt stets 
+den Attribut-Editor an und ermöglicht damit direkt das Einstellen der gewünschten Werte, 
+z.B. von Farben oder Gobos.
+
+&nbsp;<Keys.Annotation>Q</Keys.Annotation> Mit den **Funktionstasten** sind verschiedene Funktionen verknüpft, etwa Speichern, Kopieren, Speichern auf Disk. 
+
+&nbsp;<Keys.Annotation>R</Keys.Annotation> Mit den Tastern der **Attributauswahl** 
+werden die Attribute der Geräte angewählt (z.B. Farbe, Gobo, Bewegung, Fokus), welche 
+dann durch die Drehregler gesteuert werden sollen. Die jeweils aktiven Taster werden 
+durch LEDs angezeigt.
+
+&nbsp;<Keys.Annotation>S</Keys.Annotation> Mit dem **Ziffern- und Tastenfeld** lassen 
+sich Werte eingeben sowie Einstellungen des Pultes ändern.
+
+&nbsp;<Keys.Annotation>T</Keys.Annotation> Das separate **Intensity-Handrad** und das 
+zugehörige Display steuern stets die Helligkeit der angewählten Geräte.
+
+&nbsp;<Keys.Annotation>U</Keys.Annotation> Der **Trackball** steuert Pan und Tilt der 
+angewählten Geräte, kann aber auch zur Steuerung des Mauszeigers verwendet werden.
+
+## Vorderseite des Pultes
+
+Unter der Handballenauflage an der Vorderseite des Pultes befindet sich der 
+**Einschalter**, ein **USB-Anschluss** z.B. für USB-Sticks, sowie eine ausziehbare 
+beleuchtete **Tastatur** z.B. für Legenden oder zum Eingeben von Suchbegriffen.
+
+Unter der Vorderseite des Pultes sind LEDs als Leselicht, z.B. für Pläne und Notizen, angebracht.
+Zum Ein- und Ausschalten ist der Schalter neben der ausziehbaren Tastatur. Hält man diesen für 
+2..5 Sekunden gedrückt, so wird die rote Hintergrundbeleuchtung an- oder ausgeschaltet.
+
+## Rückseite des Pultes, Anschlüsse
+
+![Diamond Back Panel](/docs/images/Diamond-Back.png)
+
+&nbsp;<Keys.Annotation>a</Keys.Annotation> Netzspannungseingang (PowerCON TRUE1), 
+Hauptschalter und Unterbrecher für die USV. Schalten Sie das Pult nicht mit dem 
+Hauptschalter aus, sondern fahren Sie es mit dem Einschalter auf der Vorderseite 
+ordnungsgemäß herunter.
+
+&nbsp;<Keys.Annotation>b</Keys.Annotation> Zusätzliche USB-Anschlüsse für allgemeine 
+Verwendung.
+
+&nbsp;<Keys.Annotation>c</Keys.Annotation> DMX-Eingang zum Triggern.
+
+&nbsp;<Keys.Annotation>d</Keys.Annotation> Anschlüsse für zwei weitere Screens 
+(HDMI und USB für Touchscreens).
+
+&nbsp;<Keys.Annotation>e</Keys.Annotation> MIDI In, Thru and Out.
+
+&nbsp;<Keys.Annotation>f</Keys.Annotation> Digitaler S/PDIF Audio-Ausgang.
+
+&nbsp;<Keys.Annotation>g</Keys.Annotation> Schalter zum Ein/Ausschalten des Arbeitslichts auf der Rückseite.
+
+&nbsp;<Keys.Annotation>h</Keys.Annotation> Vier Gigabit EtherCON Netzwerkanschlüsse 
+vom integrierten Luminex Netzwerkswitch.
+
+&nbsp;<Keys.Annotation>i</Keys.Annotation> GPIO-Triggeranschlüsse (SubD und separate Klinkenbuchse).
+
+&nbsp;<Keys.Annotation>j</Keys.Annotation> Audio-Eingang zum Triggern.
+
+&nbsp;<Keys.Annotation>k</Keys.Annotation> Anschlüsse für LTC (Timecode) Eingang und Loop.
+
+&nbsp;<Keys.Annotation>m</Keys.Annotation> Weiterer Gigabit EtherCON Netzwerkanschluss.
+
+&nbsp;<Keys.Annotation>n</Keys.Annotation> 10Gb OpticalCON Quad-Anschluss.
+
+&nbsp;<Keys.Annotation>o</Keys.Annotation> Acht DMX512 Ausgänge.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/diamond.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/diamond.md
@@ -1,7 +1,7 @@
 ---
 id: diamond
 title: Diamond 9
-sidebar_label: Das Diamond 9
+sidebar_label: D9
 description: Diamond 9 - console design and features
 ---
 
@@ -29,8 +29,7 @@ angezeigt und verändert, während auf den **Macro/Executor-Tasten** Playbacks, 
 Arbeitsumgebungen (Layouts der Displays) oder z.B. Gruppen gespeichert werden können. Links davon befindet sich die 
 Ablaufsteuerung für Cuelisten sowie der T-Griff des Scene Masters.
 
-&nbsp;<Keys.Annotation>E</Keys.Annotation> Drei kleine **Layer-Screens** dienen etwa der Anzeige von NDI-Video-Feeds 
-oder für weitere Arbeitsfenster.
+&nbsp;<Keys.Annotation>E</Keys.Annotation> Drei kleine **Layer-Screens** dienen der Anzeige von weiteren Arbeitsfenstern.
 
 
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/pearl-expert-and-touch-wing.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/pearl-expert-and-touch-wing.md
@@ -1,0 +1,152 @@
+---
+id: pearl-expert-and-touch-wing
+title: Pearl Expert und Touch Wing
+sidebar_label: Pearl Expert und Touch Wing
+description: Pearl Expert und Touch Wing - console design and features
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+![Pearl Expert](/docs/images/Pearl-Expert.png)
+
+Das Pearl Expert hat vier grundsätzliche Bedienbereiche:
+
+&nbsp;<Keys.Annotation>A</Keys.Annotation> Mit den **Masterfadern** bestimmt 
+man den generellen Ausgangspegel.
+
+&nbsp;<Keys.Annotation>B</Keys.Annotation> Mit den Elementen der Abteilung 
+**Preset Playbacks und Geräte** hat man unmittelbaren Zugriff auf die 
+anzusteuernden Geräte, kann hier aber aucheinzelnen Cues/Cuelisten/Chaser 
+etc. abspeichern.
+
+&nbsp;<Keys.Annotation>C</Keys.Annotation> Mit **Playbacks, Walze und 
+Seitenumschaltung** wird auf die einzelnen Speicherplätze zum Programmieren 
+und Abrufen zugegriffen.
+
+&nbsp;<Keys.Annotation>D</Keys.Annotation> Die **Programmier- und Steuereinheit** 
+dient zum Einrichten des Pultes sowie zum eigentlichen Programmieren.
+
+![Pearl Expert](/docs/images/Pearl-Expert-2.png)
+
+## Bedienoberfläche
+
+&nbsp;<Keys.Annotation>E</Keys.Annotation> Mit den Reglern im Bereich 
+**Geräteanwahl/Presets** lassen sich einzelne
+Dimmer und Geräte steuern. Ebenso können hier auch komplette Bilder und
+Abläufe gespeichert werden. Mit den beiden Tasten unter jedem Regler
+wird der jeweilige Inhalt eingeblendet (Flash/Solo). Jeder Regler bildet
+mit den zugehörigen Tasten eine Bedieneinheit ('Handle').
+
+&nbsp;<Keys.Annotation>F</Keys.Annotation> Mittels der beiden **Auswahlwalzen** 
+lässt sich die Seite für jeweils 10 Playbacks wählen. Die einzelnen 
+Speicherplätze lassen sich auf der Walze beschriften.
+
+&nbsp;<Keys.Annotation>G</Keys.Annotation> Mit den **Masterfadern** 
+lässt sich der globale Ausgangspegel des Pultes
+einstellen; normalerweise wird man diese Regler auf 100% stellen.
+
+&nbsp;<Keys.Annotation>H</Keys.Annotation> Die **Playbacks** mit den zugehörigen 
+Flash-/Solotasten dienen zum Speichern und Abrufen der einzelnen Stimmungen.
+
+&nbsp;<Keys.Annotation>I</Keys.Annotation> Das **Display** ist die 
+Schaltzentrale des Pultes, es bietet wichtige Informationen über den 
+jeweiligen Status.
+
+&nbsp;<Keys.Annotation>J</Keys.Annotation> Die **Encoder (Räder)** dienen 
+zum Einstellen bestimmter Werte, etwa von Attributen der Geräte, 
+Geschwindigkeit von Chasern etc.
+
+&nbsp;<Keys.Annotation>K</Keys.Annotation> Die **Menütasten** (beschriftet 
+mit A -- G) dienen zur Auswahl verschiedener Steuerungsoptionen. Im Display 
+wird direkt neben jedem Taster die jeweilige Funktion angezeigt, abhängig 
+vom jeweiligen Status des Pultes. Befehle dieser Taster sind in diesem 
+Handbuch blau dargestellt, z.B. <Keys.SoftKey>Edit Times</Keys.SoftKey>.
+
+&nbsp;<Keys.Annotation>L</Keys.Annotation> Mit den **Ziffern- und 
+Steuertasten** lassen sich Werte eingeben sowie Einstellungen des Pultes ändern.
+
+&nbsp;<Keys.Annotation>M</Keys.Annotation> Die Tasten zur **Geräte-Seitenwahl** 
+befinden sich oberhalb des Ziffernblocks und gestatten die Auswahl von 
+4 Seiten der Geräte-/Szenenregler (Preset Fader).
+
+&nbsp;<Keys.Annotation>N</Keys.Annotation> Mit den blauen **Funktionstasten** 
+sind verschiedene Funktionen verknüpft, etwa Speichern von Cues, Kopieren, 
+Speichern auf Disk. Ist ein solcher Taster aktiv, so wird das jeweils 
+durch eine LED angezeigt.
+
+&nbsp;<Keys.Annotation>O</Keys.Annotation> Mit den Tastern der 
+**Attributauswahl** werden die Attribute der Geräte
+angewählt (z.B. Farbe, Gobo, Bewegung, Fokus), welche dann durch die
+Encoder gesteuert werden sollen. Die jeweils aktiven Taster werden durch
+LEDs angezeigt. Der untere (rote) Taster erlaubt das 'Locaten'
+(Lokalisieren) von Geräten, indem diese auf eine vordefinierte
+Startposition gesetzt werden.
+
+- Der **Einschalter** befindet sich links vorn unter der Auflage.
+
+- Eine **Tastatur mit Touchpad** befindet sich in einer Schublade vorne am
+Pult.
+
+## Anschlussfeld auf der Rückseite
+
+![Pearl Expert Back Panel](/docs/images/Pearl-Expert-Back-Panel.png)
+
+Sämtliche für das Pult erforderlichen Anschlüsse befinden sich auf der
+Rückseite. Die meisten davon sind selbsterklärend.
+
+&nbsp;<Keys.Annotation>P</Keys.Annotation> Vier DMX-Anschlüsse sowie 
+MIDI Ein- und Ausgang.
+
+&nbsp;<Keys.Annotation>Q</Keys.Annotation> Mit dem Resettaster für die 
+Bedienoberfläche kann die Elektronik der Steueroberfläche zurückgesetzt 
+werden, wenn die Schalter und Regler falsch reagieren. Die Programmlogik 
+(Hauptplatine) wird davon nicht betroffen, allerdings wird die DMX-Ausgabe
+unterbrochen, bis der Neustart erfolgt ist.
+
+&nbsp;<Keys.Annotation>R</Keys.Annotation> Der reservierte USB-Anschluss 
+und Umschalter ist für künftige Erweiterungen vorgesehen. Der Schalter 
+sollte auf "Normal operation" belassen werden.
+
+&nbsp;<Keys.Annotation>S</Keys.Annotation> Der Netzschalter oberhalb 
+des Netzanschlusses trennt das Pult komplett vom Netz. Verwenden Sie 
+diesen Schalter nicht, um das Pult normal auszuschalten, sondern fahren 
+sie es mit dem Einschalttaster vorn links herauf/herunter.
+
+## Das Pearl Expert Touch Wing
+
+![Pearl Expert Touch Wing](/docs/images/Pearl-Expert-Touch-Wing.png)
+
+Das optionale Pearl Expert Touch Wing gestattet mit dem
+berührungsempfindlichen Display und den zusätzlichen Rädern das
+gewohnte Arbeiten zur Auswahl von Geräten, Paletten, Gruppen und zum
+Einstellen von Attributen. Es funktioniert nur mit dem Pearl Expert und
+wird an die rückseitigen gesonderten Buchsen angeschlossen (DVI und
+Sub-D 9-pol, die aber spezielle Signale führen).
+
+&nbsp;<Keys.Annotation>T</Keys.Annotation> Der Hauptbereich des Touch Wings 
+zeigt verschiedene **Arbeitsfenster**. Deren Inhalt, Funktion und Größe 
+lässt sich mit den entsprechenden Tasten unterhalb des Displays steuern.
+
+&nbsp;<Keys.Annotation>U</Keys.Annotation> Die Anordnung der Fenster lässt 
+sich als **Arbeitsumgebung** (Workspace) speichern
+und mit den Schaltflächen rechts wieder abrufen.
+
+Einige Fenster bieten zusätzliche Funktionen; dazu werden oben rechts im
+Display entsprechende **kontextabhängige Schaltflächen** eingeblendet.
+
+&nbsp;<Keys.Annotation>V</Keys.Annotation> Die drei **Encoder (Räder)** 
+übernehmen die Attribut-Steuerung von den Rädern des Pultes, welche dann 
+für die Steuerung von Geschwindigkeit und Crossfade von Chasern zur 
+Verfügung stehen. Betätigen der **Bildlaufschalter** (unterhalb der 
+Räder) schaltet die Räder in den Bildlauf-Modus: damit lässt sich eine 
+Auswahlbox über den Bildschirm bewegen.
+
+&nbsp;<Keys.Annotation>W</Keys.Annotation> Die **Attributanzeige** zeigt 
+die momentan bearbeiteten Attribute mit ihren aktuellen Werten an. Berührt 
+man diese Schaltflächen, so wird das jeweilige Attribut auf seinen Minimal-/
+Maximalwert gesetzt.
+
+&nbsp;<Keys.Annotation>X</Keys.Annotation> Am unteren Rand des Bildschirms 
+befindet sich der Informationsbereich mit Details der aktuell angewählten 
+**Playbacks**.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/quartz.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/quartz.md
@@ -1,0 +1,90 @@
+---
+id: quartz
+title: Das Quartz
+sidebar_label: Das Quartz
+description: Das Quartz - console design and features
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+![Quartz](/docs/images/Quartz.png)
+
+&nbsp;<Keys.Annotation>A</Keys.Annotation> Die **Arbeitsfenster** auf dem 
+Touchscreen zeigen Buttons für Geräte, Paletten, Gruppen, Speicherplätze, 
+Makros und anderes. Ebenso lassen sich hier Attribute einstellen und 
+Informationsfenster einblenden.
+
+&nbsp;<Keys.Annotation>B</Keys.Annotation> Die **Systemanzeige** ist die 
+Schaltzentrale des Pultes und liefert Informationen über den jeweiligen 
+Zustand. Hier werden diverse Hinweisfenster eingeblendet, abhängig vom 
+momentanen Arbeits- und Programmierablauf.
+
+&nbsp;<Keys.Annotation>C</Keys.Annotation> Die **Menütasten** (bezeichnet 
+mit A -- G) dienen zur Auswahl verschiedener Steuerungsoptionen. Im Display 
+wird direkt neben jedem Taster die jeweilige Funktion angezeigt, abhängig 
+vom jeweiligen Status des Pultes. Befehle dieser Taster sind in diesem Handbuch 
+blau dargestellt, z.B. <Keys.SoftKey>Edit Times</Keys.SoftKey>
+
+&nbsp;<Keys.Annotation>D</Keys.Annotation> Die **Playbacks** dienen zum 
+Speichern und Abrufen von Cues (Szenen) und Chasern/Cuelisten (Szenensequenzen). 
+
+Mit den &nbsp;<Keys.Annotation>E</Keys.Annotation> **Seitenwechseltasten** kann
+man zu verschiedenen Seiten der Playbacks wechseln. Im Touchscreen
+werden Informationen zur Belegung jedes Playbacks eingeblendet.
+
+&nbsp;<Keys.Annotation>F</Keys.Annotation> Mit den **Encodern** werden 
+sowohl Attribute der Geräte, als auch Geschwindigkeit und Überblendung 
+von Chasern eingestellt. Im Touchscreen unten rechts wird angezeigt, 
+welche Parameter momentan mit welchem Rad verknüpft sind.
+
+&nbsp;<Keys.Annotation>G</Keys.Annotation> Mit den Tastern der 
+**Attributauswahl** werden die Attribute der Geräte
+angewählt (z.B. Farbe, Gobo, Bewegung, Fokus), welche dann durch die
+Drehregler gesteuert werden sollen. Die jeweils aktiven Taster werden
+durch LEDs angezeigt. Auch Funktionen der Attribute, wie etwa Shapes
+oder Fan, haben separate Tasten.
+
+&nbsp;<Keys.Annotation>H</Keys.Annotation> Sequenzen, also Chaser und 
+Cuelisten, lassen sich mit den Tasten der &nbsp;**Ablaufsteuerung** genauer 
+steuern.
+
+&nbsp;<Keys.Annotation>I</Keys.Annotation> Mit dem **Ziffern- und Tastenfeld** 
+lassen sich Werte eingeben sowie Einstellungen des Pultes ändern.
+
+&nbsp;<Keys.Annotation>J</Keys.Annotation> Mit den **Funktionstasten** sind 
+verschiedene Funktionen verknüpft, etwa Speichern, Kopieren, Speichern auf Disk.
+
+&nbsp;<Keys.Annotation>L</Keys.Annotation> Mit den **Macro- und Executor-Tasten** 
+lassen sich Macros, Cues sowie Workspaces (Arbeitsumgebungen) aufrufen.
+
+&nbsp;<Keys.Annotation>M</Keys.Annotation> Mit den **Tasten zur Fenstersteuerung** 
+lassen sich Fenster öffnen, schließen und verschieben.
+
+&nbsp;<Keys.Annotation>N</Keys.Annotation> In der Nähe der Einschalt-Taste 
+befindet sich ein kleines Loch auf der Frontplatte. Dies ist der **Panel Reset** 
+und kann z.B. mit einer aufgebogenen Büroklammer betätigt werden. Damit 
+werden alle Panels, also Platinen mit Fadern und Tasten, zurückgesetzt, 
+während die Software selbst weiterläuft. Auch die DMX-Ausgabe wird während 
+des Resettens unterbrochen.
+
+## Anschlussfeld auf der Rückseite
+
+![Quartz Connections Panel](/docs/images/Quartz-Connections-Panel.png)
+
+Sämtliche für das Pult erforderlichen Anschlüsse befinden sich auf der
+Rückseite. Die meisten davon sind selbsterklärend.
+
+&nbsp;<Keys.Annotation>O</Keys.Annotation> Der Netzschalter oberhalb des 
+Netzanschlusses trennt das Pult komplett vom Netz. Verwenden Sie diesen 
+Schalter nicht, um das Pult normal auszuschalten.
+
+&nbsp;<Keys.Annotation>P</Keys.Annotation> In der Mitte befinden sich die 
+Anschlüsse für Netzwerk, einen externen DVI-Monitor, ein Kopfhöreranschluss 
+und ein Audio-Eingang für Sound-to-Light.
+
+&nbsp;<Keys.Annotation>Q</Keys.Annotation> Auf der rechten Seite sind die 
+vier DMX-Ausgänge sowie ein MIDI-Eingang.
+
+&nbsp;<Keys.Annotation>R</Keys.Annotation> Der rückseitige USB-Anschluss 
+kann z.B. für ein Wing oder einen Touchscreen verwendet werden.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/sapphire-touch.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/sapphire-touch.md
@@ -1,0 +1,114 @@
+---
+id: sapphire-touch
+title: Das Sapphire Touch
+sidebar_label: Das Sapphire Touch
+description: Das Sapphire Touch - console design and features
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+![Sapphire Touch](/docs/images/Sapphire-Touch.png)Das Sapphire Touch hat vier 
+grundsätzliche Bedienungsbereiche:
+
+&nbsp;<Keys.Annotation>A</Keys.Annotation> Die **Touchscreens** zeigen 
+Schaltflächen zur Auswahl von Geräten, Paletten und Gruppen. Ferner zeigen 
+sie die Bezeichnungen der Playbacks, sowie -- oben rechts -- die aktuelle 
+Menüseite und die Bezeichnungen der variablen Tasten.
+
+&nbsp;<Keys.Annotation>B</Keys.Annotation> Die **Playback-Fader** dienen zur 
+Auswahl und Steuerung von Cues, Cuelisten und Chasern sowie weiterer programmierbarer 
+Funktionen.
+
+&nbsp;<Keys.Annotation>C</Keys.Annotation> Die **Preset-Playbacks** ermöglichen 
+sowohl den Zugriff auf weitere -- unabhängig umgeschaltete -- Cues, als auch 
+das direkte Patchen von Geräten auf diese Fader.
+
+&nbsp;<Keys.Annotation>D</Keys.Annotation> Die **Programmiersektion** schließlich 
+enthält alle Steuerelemente zum Einrichten und Programmieren des Pultes, sowie 20 
+weitere **Macro-/Executor-Tasten**, auf die z.B. häufig benutzte Cues, Paletten oder
+Tastenfolgen gespeichert werden können.
+
+## Bedienoberfläche
+
+![Sapphire Front](/docs/images/Sapphire-Front.png)
+
+&nbsp;<Keys.Annotation>E</Keys.Annotation> Die **Arbeitsfenster** auf den 
+Touchscreens zeigen Tasten für Geräte, Paletten, Gruppen, Speicherplätze, 
+Makros und anderes. Ebenso lassen sich hier Attribute einstellen und 
+Informationsfenster einblenden.
+
+&nbsp;<Keys.Annotation>F</Keys.Annotation> Die **Systemanzeige** ist die 
+Schaltzentrale des Pultes und liefert Informationen über den jeweiligen 
+Zustand. Hier werden diverse Hinweisfenster eingeblendet, abhängig vom 
+momentanen Arbeits- und Programmierablauf.
+
+&nbsp;<Keys.Annotation>G</Keys.Annotation> Die **Menütasten (Schaltflächen)** 
+dienen zur Auswahl verschiedener Steuerungsoptionen. Im Display wird direkt 
+neben jedem Taster die jeweilige Funktion angezeigt, abhängig vom jeweiligen 
+Status des Pultes. Befehle dieser Taster sind in diesem Handbuch blau dargestellt,
+ z.B. <Keys.SoftKey>Edit Times</Keys.SoftKey>
+
+![Sapphire Front 2](/docs/images/Sapphire-Front-2.png)
+
+&nbsp;<Keys.Annotation>H</Keys.Annotation> Die **Preset-Playbacks (oben)** 
+dienen zum Aufruf häufig benutzter Cues/Chaser, sowie zum direkten Patchen 
+von Geräten. Diese Fader können mit den in der Mitte gelegenen <Keys.Annotation>
+I</Keys.Annotation> **Page-Tasten** getrennt von den unteren Playback-Fadern 
+umgeschaltet werden.
+
+&nbsp;<Keys.Annotation>J</Keys.Annotation> Auf den **Makro-Tasten** lassen sich 
+häufig benutzte Abläufe von Tastendrücken abspeichern, und dann mit einem 
+einzigen Tastendruck abrufen. Ebenso können hier Cues etc. abgelegt werden. 
+Im Bildschirm direkt darüber werden die Legenden angezeigt.
+
+&nbsp;<Keys.Annotation>K</Keys.Annotation> Die **Playbackfader** dienen zum 
+Speichern und Abrufen von Cues etc.. Mit den <Keys.Annotation>L</Keys.Annotation> 
+**Seitenauswahltastern** kann man zu verschiedenen Seiten der Playbacks wechseln. Im 
+Touchscreen werden oberhalb der Regler Informationen über jeden einzelnen eingeblendet.
+
+![Sapphire Touch](/docs/images/Sapphire-Touch-2.png)
+
+&nbsp;<Keys.Annotation>M</Keys.Annotation> Mit den **Encodern** (Drehreglern) 
+werden sowohl Attribute der Geräte, als auch Geschwindigkeit und Überblendung 
+der Sequenzen eingestellt. Im Touchscreen oberhalb der Räder wird angezeigt, 
+welche Parameter momentan mit welchem Rad verknüpft sind.
+
+&nbsp;<Keys.Annotation>N</Keys.Annotation> Mit dem **Trackball** steuert man 
+entweder den Mauszeiger oder Pan und Tilt der ausgewählten Geräte.
+
+&nbsp;<Keys.Annotation>O</Keys.Annotation> Mit dem **Ziffern- und Tastenfeld** 
+lassen sich Werte eingeben sowie Einstellungen des Pultes ändern.
+
+&nbsp;<Keys.Annotation>P</Keys.Annotation> Mit den **Funktionstasten** sind 
+verschiedene Funktionen verknüpft, etwa Speichern von Szenen, Kopieren, 
+Speichern auf Disk.
+
+&nbsp;<Keys.Annotation>Q</Keys.Annotation> Mit den Tastern der **Attributauswahl** 
+werden die Attribute der Geräte angewählt (z.B. Farbe, Gobo, Bewegung, Fokus), 
+welche dann durch die Drehregler gesteuert werden sollen. Die jeweils aktiven 
+Taster werden durch LEDs angezeigt. Der untere (rote) Taster erlaubt das 'Locaten'
+(Lokalisieren) von Geräten, indem sie auf eine vordefinierte Startposition gesetzt 
+werden.
+
+![Sapphire Manual Pen Tray](/docs/images/Sapphire-Manual-Pen-Tray.png)
+
+Die gepolsterte **Handauflage** kann geöffnet werden; innen ist nicht nur Stauraum 
+für verschiedenste Utensilien, sondern <Keys.Annotation>S</Keys.Annotation> 
+rechts der Hauptschalter, <Keys.Annotation>R</Keys.Annotation> links Anzeigen für 
+Disk-Aktivitäten, sowie an den beiden Enden jeweils eine USB-Buchse.
+
+## Anschlussfeld auf der Rückseite
+
+![Sapphire Manual Back Panel - Left](/docs/images/Sapphire-Manual-Back-Panel-Left.jpeg)
+
+Sämtliche für das Pult erforderlichen Anschlüsse befinden sich auf der Rückseite.
+
+Links befinden sich die 8 DMX-Ausgänge, MIDI-, Ethernet- und Timecode-Anschlüsse. 
+
+![Sapphire Manual Back Panel - Right](/docs/images/Sapphire-Manual-Back-Panel-Right.jpeg)
+
+Rechts ist jeweils ein USB- und ein DVI-Anschluss zum Verbinden eines optionalen 
+Wings sowie ein weiterer allgemeiner USB-Anschluss.
+
+Der Netzanschluss befindet sich in der Mitte der Rückseite.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/t1-and-t2.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/t1-and-t2.md
@@ -1,0 +1,49 @@
+---
+id: t1-and-t2
+title: T1 und T2
+sidebar_label: T1 und T2
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+T1 und T2 sind USB-Geräte zum Betrieb an einem Windows-Computer (PC oder
+Laptop). Zu den Systemanforderungen siehe [Inbetriebnahme von T3/Titan Mobile und T1/T2](../titan-basics.md#inbetriebnahme-von-t3titan-mobile-und-t1t2). 
+T1 und T2 enthalten jeweils den AvoKey.
+
+Der **T1** gibt ein DMX-Universum per 5pol XLR und über sACN/ArtNet aus (Netzwerkanschluss des Computers). USB-MIDI ist mit dem T1 nicht möglich.
+
+![T1 USB DMX Dongle](/docs/images/T1.png)
+
+Der **T2** kann zwei DMX-Universen auf 5-poligen XLR-Buchsen sowie per sACN/ArtNet über den Netzwerkanschluss des Computers ausgeben und hat eine 3-polige XLR-Buchse als Audio/LTC-Eingang (symmetrisch, 600 Ohm Übertrager zwischen Pan 2 und 3, Pin 1 nicht verbunden). Außerdem erlaubt er die Verwendung von USB-MIDI-Geräten (per USB an den Computer angeschlossen, auf dem Titan läuft), etwa von Faderboards, und kann mit dem T3 Wing oder dem Titan Mobile Faderwing betrieben werden.
+
+![T2 USB DMX Dongle](/docs/images/T2.png)
+
+<Video videoId="wO94RvG6agI" title="T2 USB Interface"></Video>
+
+Der ältere Titan One (nicht mehr angeboten) stellt ebenfalls ein DMX-Universum als 
+5-pol Anschluss sowie als sACN/ArtNet über Netzwerk zur Verfügung. USB-MIDI wird nicht unterstützt.
+
+![Titan One Dongle](/docs/images/titan-one-cabled.png)
+
+> Dieser Titan One - mit fest angebautem Kabel - beinhaltet **keinen** AvoKey; der AvoKey
+  muss separat gekauft und mit einem weiteren USB-Anschluss des Computers verbunden 
+  werden, um Titan Version 12 oder neuer zu betreiben.
+
+## Installieren der Titan-Software
+
+Installieren Sie die Titan PC-Suite (siehe [Inbetriebnahme von T3/Titan Mobile und T1/T2](../titan-basics.md#inbetriebnahme-von-t3titan-mobile-und-t1t2)), bevor das
+Gerät angeschlossen wird, damit die richtigen Treiber installiert und
+verwendet werden. Dort sind auch einige Windows-Einstellungen aufgeführt, die überprüft
+werden sollten, um einen reibungslosen Betrieb zu gewährleisten.
+
+> Die früheren Titan Ones (mit Kabel) enthalten keinen neuen Lizenzdongle. 
+  Zu ihrem Betrieb ist ab Titan Version 12 ein separater Editor AvoKey 
+  erforderlich, der parallel mit einem anderen USB-Anschluss verbunden 
+  werden muss.
+
+T1 und T2 verwenden das Programm Titan Go. Dies beinhaltet sämtliche Funktionen der größeren Pulte, 
+nur die Bedienoberfläche ist etwas anders designet, damit auch hier alle Bedienelemente, die ansonsten 
+auf dem physischen Pult zu finden wären, auf dem Bildschirm präsent sind.
+
+![Titan Go User Interface](/docs/images/Titan-Go-User-Interface.png)

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/t1-and-t2.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/t1-and-t2.md
@@ -11,24 +11,35 @@ T1 und T2 sind USB-Geräte zum Betrieb an einem Windows-Computer (PC oder
 Laptop). Zu den Systemanforderungen siehe [Inbetriebnahme von T3/Titan Mobile und T1/T2](../titan-basics.md#inbetriebnahme-von-t3titan-mobile-und-t1t2). 
 T1 und T2 enthalten jeweils den AvoKey.
 
-Der **T1** gibt ein DMX-Universum per 5pol XLR und über sACN/ArtNet aus (Netzwerkanschluss des Computers). USB-MIDI ist mit dem T1 nicht möglich.
+## T1
+
+Der **T1** gibt mit der Titan Go-Software ein DMX-Universum per 5pol XLR und über sACN/ArtNet aus (Netzwerkanschluss des Computers). Sind Geräte auf mehreren
+Universen gepatcht, so wird das niedrigste Universum ausgegeben. USB-MIDI ist mit dem T1 nicht möglich.
+
+Mit dem T1 kann auch der Titan Simulator gestartet werden. Damit werden alle Universen ausgegeben. In unregelmäßigen Abständen gibt es zwar eine DMX-Störung (Spoiler), aber so kann auch auf mehreren Universen programmiert werden. 
 
 ![T1 USB DMX Dongle](/docs/images/T1.png)
 
-Der **T2** kann zwei DMX-Universen auf 5-poligen XLR-Buchsen sowie per sACN/ArtNet über den Netzwerkanschluss des Computers ausgeben und hat eine 3-polige XLR-Buchse als Audio/LTC-Eingang (symmetrisch, 600 Ohm Übertrager zwischen Pan 2 und 3, Pin 1 nicht verbunden). Außerdem erlaubt er die Verwendung von USB-MIDI-Geräten (per USB an den Computer angeschlossen, auf dem Titan läuft), etwa von Faderboards, und kann mit dem T3 Wing oder dem Titan Mobile Faderwing betrieben werden.
+## T2
+
+Der **T2** kann mit der Titan Go-Software zwei DMX-Universen auf 5-poligen XLR-Buchsen sowie per sACN/ArtNet über den Netzwerkanschluss des Computers ausgeben und hat eine 3-polige XLR-Buchse als Audio/LTC-Eingang (symmetrisch, 600 Ohm Übertrager zwischen Pan 2 und 3, Pin 1 nicht verbunden). Außerdem erlaubt er die Verwendung von USB-MIDI-Geräten (per USB an den Computer angeschlossen, auf dem Titan läuft), etwa von Faderboards, und kann mit dem T3 Wing oder dem Titan Mobile Faderwing betrieben werden (klicken Sie 2x <Keys.HardKey>Open/View</Keys.HardKey> und wählen dann <Keys.SoftKey>Mobile Wing</Keys.SoftKey> zum Öffnen des betreffenden Fensters).
+
+Mit dem T2 kann auch der Titan Simulator gestartet werden. Damit werden alle Universen ausgegeben. In unregelmäßigen Abständen gibt es zwar eine DMX-Störung (Spoiler), aber so kann auch auf mehreren Universen programmiert werden. 
 
 ![T2 USB DMX Dongle](/docs/images/T2.png)
 
 <Video videoId="wO94RvG6agI" title="T2 USB Interface"></Video>
 
+## Titan One dongle
+
 Der ältere Titan One (nicht mehr angeboten) stellt ebenfalls ein DMX-Universum als 
 5-pol Anschluss sowie als sACN/ArtNet über Netzwerk zur Verfügung. USB-MIDI wird nicht unterstützt.
-
-![Titan One Dongle](/docs/images/titan-one-cabled.png)
 
 > Dieser Titan One - mit fest angebautem Kabel - beinhaltet **keinen** AvoKey; der AvoKey
   muss separat gekauft und mit einem weiteren USB-Anschluss des Computers verbunden 
   werden, um Titan Version 12 oder neuer zu betreiben.
+
+![Titan One Dongle](/docs/images/titan-one-cabled.png)
 
 ## Installieren der Titan-Software
 
@@ -47,3 +58,6 @@ nur die Bedienoberfläche ist etwas anders designet, damit auch hier alle Bedien
 auf dem physischen Pult zu finden wären, auf dem Bildschirm präsent sind.
 
 ![Titan Go User Interface](/docs/images/Titan-Go-User-Interface.png)
+
+> Titan Go kann entweder die hier dargestellte Ansicht zeigen oder aber eine pultähnliche Oberfläche ohne Programmiertasten, zur Verwendung mit dem T3. 
+  Die automatische Umschaltung der Ansicht kann durch die Option [Virtual Hardware](../system-settings/user-settings.md#display) in den Systemeinstellungen überschrieben werden.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/t3.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/t3.md
@@ -1,0 +1,109 @@
+---
+id: t3
+title: T3
+sidebar_label: T3
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Das T3 ist ein USB-Panel zum Anschluss an einen Computer mit der Titan Go Software. Siehe [Inbetriebnahme von T3/Titan Mobile und T1/T2](../titan-basics.md#inbetriebnahme-von-t3titan-mobile-und-t1t2). Es verfügt über vier DMX-Anschlüsse, insgesamt (über ArtNet/sACN) können 16 Universen zur Verfügung gestellt werden (kann durch Lizenzen erweitert werden).
+
+![T3](/docs/images/T3-Main.png)
+
+
+
+&nbsp;<Keys.Annotation>A</Keys.Annotation> Die **Playbackfader** und Tasten dienen zum Speichern von Cues, Cuelisten und Chasern, aber auch für eine Reihe weiterer Funktionen.
+
+
+
+&nbsp;<Keys.Annotation>B</Keys.Annotation> Mit den **Tasten zur Seitenumschaltung** kann man die 
+Playbacks auf mehrere Seiten wechseln. Die aktuelle Seite und Belegung wird im unteren Bereich des Displays angezeigt.
+
+
+
+&nbsp;<Keys.Annotation>C</Keys.Annotation> Die **Encoder** dienen zum Einstellen der Attribute/Eigenschaften 
+der Fixtures, aber auch für eine Reihe weiterer Funktionen. In der rechten unteren Ecke des Bildschirms wird 
+die momentane Belegung und die eingestellten Werte der Encoder angezeigt.
+
+
+
+&nbsp;<Keys.Annotation>D</Keys.Annotation> Mit den **Tasten zur Attributauswahl** wählt man die zu 
+steuernden Attribute der Geräte (z.B. Colour/Farbe, Gobo, Position). Die gerade ausgewählte Taste leuchtet auf.
+
+
+
+&nbsp;<Keys.Annotation>E</Keys.Annotation> Mit der **Ablaufsteuerung (Playback Control)** können Chaser und Cuelisten gesteuert bzw. darin navigiert werden.
+
+
+
+&nbsp;<Keys.Annotation>F</Keys.Annotation> Die **Zifferntasten** und die zugehörigen Steuertasten dienen zur Eingabe von Werten, zur Auswahl, und für weitere Funktionen.
+
+
+
+&nbsp;<Keys.Annotation>G</Keys.Annotation> Mit den **Funktionstasten** lassen sich die wichtigsten Befehle und Menüs aufrufen, z.B. Record (speichern), Delete (löschen), Copy (kopieren) usw.
+
+
+
+&nbsp;<Keys.Annotation>H</Keys.Annotation> Die **Workspace/Macro/Executer**-Tasten können mit zahlreichen verschiedenen Funktionen belegt werden; so kann man darauf Cues speichern (z.B. Blinder oder Strobe), Workspaces aufrufen, Macros ausführen, und mehr.
+
+
+
+&nbsp;<Keys.Annotation>I</Keys.Annotation> Die Tasten zur **Fenstersteuerung**, zusammen mit der Taste <Keys.HardKey>View</Keys.HardKey> rechts oberhalb der Zifferntasten, dienen zur genauen Steuerung der Bildschirmanzeige (Öffnen und Positionieren der Fenster etc.). Mit der Taste <Keys.HardKey>Latch</Keys.HardKey> wiederum kann das gerade aktive Menü eingerastet werden.
+
+
+
+&nbsp;<Keys.Annotation>J</Keys.Annotation> Mit den **Menütasten** (mit A - G gekennzeichnet) kann man Menüfunktionen aufrufen/ausführen. 
+Rechts im Bildschirm wird jeweils angezeigt, welche Funktion auf welcher Taste liegt. Verwendet man einen Touchscreen, so kann man alternativ im Display auf die gewünschte Funktion klicken. Die Funktionen und Optionen wechseln je nach Menü. Menüfunktionen, die mit diesen Tasten aufgerufen werden, sind in diesem Manual so dargestellt: <Keys.SoftKey>Edit Times</Keys.SoftKey>.
+
+Unter den Menütasten befindet sich die Taste <Keys.HardKey>Locate</Keys.HardKey>. Damit werden die aktuell angewählten Geräte in einen definierten Ausgangszustand versetzt (Licht an, keine Farbe/Gobo/Effekt, mittlere Position etc.).
+
+
+&nbsp;<Keys.Annotation>K</Keys.Annotation> Mit den Tasten zur **Geräteauswahl** kann man bei mehreren angewählten Geräten schrittweise durch die Auswahl gehen, Highlight ('Hervorheben') aktivieren/deaktivieren, per Fan Werte aufspreizen, sowie nach Muster auswählen (z.B. gerade/ungerade).
+
+&nbsp;<Keys.Annotation>L</Keys.Annotation> Die **Syntaxtasten** sind erforderlich für die Eingabe von Befehlssequenzen, sowie für spezielle Funktionen.
+
+
+## PC Screen Layout
+
+Titan lässt sich am komfortabelsten mit einem Touchscreen bedienen, die Bedienung per Mouse geht aber auch. Es können insgesamt bis zu 3 Monitore verwendet werden (abhängig vom verwendeten PC).
+
+![Titan Go Screen](/docs/images/T3-Screen.png)
+
+
+
+&nbsp;<Keys.Annotation>a</Keys.Annotation> Verschiedene **Arbeitsfenster** können auf dem Bildschirm angezeigt werden; diese enthalten jeweils Buttons (Schaltflächen) zur Auswahl von Geräten, Paletten, Gruppen, Shapes, Attributen etc. Auch der Visualiser wird in einem solchen Fenster angezeigt. Die Fenster können in Größe und Position ganz nach Wunsch verändert werden.
+
+
+&nbsp;<Keys.Annotation>b</Keys.Annotation> Der Bereich **Playback information** zeigt die aktuelle Belegung und Funktion der Playbackfader und zugehörigen Tasten. Zur Auswahl eine Playbacks kann man auch in diesen Bereich klicken.
+
+
+&nbsp;<Keys.Annotation>c</Keys.Annotation> In der **Systemanzeige** (Infobereich) werden hilfreiche Hinweise zur jeweiligen Aktion eingeblendet. Darunter werden je nach gewähltem Fenster verschiedene **kontextabhängige Schaltflächen** angezeigt.
+
+
+&nbsp;<Keys.Annotation>d</Keys.Annotation> Die **Menütasten** korrespondieren mit den ‚echten' Tasten rechts auf dem Pult; die Schaltflächen zeigen die jeweilige Belegung an, und zum Betätigen kann man entweder auf die Schaltfläche klicken oder die jeweilige Taste drücken.
+
+
+&nbsp;<Keys.Annotation>e</Keys.Annotation> Darunter wiederum werden die **Workspaces/Arbeitsumgebungen** angezeigt, und mit den Schaltflächen lässt sich schnell zwischen diesen umschalten.
+
+
+&nbsp;<Keys.Annotation>f</Keys.Annotation> Der Bereich **Wheels display/Encoderbelegung** zeigt die aktuelle Funktion, Belegung und die Werte der Attribut-Räder. Im **Attribut-Status** (IPCGBESFX) wird angezeigt, welche Attribute gerade aktiv und welche modifiziert sind.
+
+
+
+
+## T3 Anschlussfeld
+
+![T3 Connections](/docs/images/T3-Side.png)
+
+
+Sämtliche für das Pult erforderlichen Anschlüsse befinden sich auf der rechten Seite. Die meisten davon sind selbsterklärend.
+
+
+&nbsp;<Keys.Annotation>Q</Keys.Annotation> Es gibt vier optisch isolierte DMX-Anschlüsse als 5-polige XLR-Buchsen. Bis zu 16 Universen können per Art-Net/sACN über den Netzwerkanschluss des Computers gesteuert werden (bis zu 64 mit optionaler Lizenzerweiterung).
+
+
+&nbsp;<Keys.Annotation>R</Keys.Annotation> USB-C für den Anschluss an einen Computer. Der T3 wird auch über USB mit Strom versorgt. Es empfiehlt sich, einen verschraubbaren USB-C-Stecker zu verwenden, um ein versehentliches Lösen zu vermeiden.
+
+
+&nbsp;<Keys.Annotation>S</Keys.Annotation> Eingang für LTC Timecode. Anliegendes Signal wird über eine LED direkt darüber angezeigt.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/t3.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/t3.md
@@ -9,6 +9,8 @@ import Video from '@site/src/components/video.tsx';
 
 Das T3 ist ein USB-Panel zum Anschluss an einen Computer mit der Titan Go Software. Siehe [Inbetriebnahme von T3/Titan Mobile und T1/T2](../titan-basics.md#inbetriebnahme-von-t3titan-mobile-und-t1t2). Es verfügt über vier DMX-Anschlüsse, insgesamt (über ArtNet/sACN) können 16 Universen zur Verfügung gestellt werden (kann durch Lizenzen erweitert werden).
 
+> Bei Interesse an Lizenzen für zusätzliche Universen wenden Sie sich an den Avolites-Support. Ggf. ist außerdem ein TNP (TitanNet Processor) zur Erweiterung der Rechenleistung erforderlich.
+
 ![T3](/docs/images/T3-Main.png)
 
 
@@ -91,6 +93,10 @@ Titan lässt sich am komfortabelsten mit einem Touchscreen bedienen, die Bedienu
 
 
 
+> Bei angeschlossenem T3 zeigt Titan Go eine pultähnliche Oberfläche ohne Programmiertasten, die anderenfalls mit dem T1 oder T2 angezeigt werden. 
+  Die automatische Umschaltung der Ansicht kann durch die Option [Virtual Hardware](../system-settings/user-settings.md#display) in den Systemeinstellungen überschrieben werden.
+
+
 
 ## T3 Anschlussfeld
 
@@ -107,3 +113,22 @@ Sämtliche für das Pult erforderlichen Anschlüsse befinden sich auf der rechte
 
 
 &nbsp;<Keys.Annotation>S</Keys.Annotation> Eingang für LTC Timecode. Anliegendes Signal wird über eine LED direkt darüber angezeigt.
+
+
+## T3 Wing
+
+Das T3 Wing ergänzt das Pult um 20 zusätzliche Playbackfadern und 30
+Macro/Executor-Tasten. Es wird einfach mit einem USB-Kabel an das Pult bzw. den PC, auf dem die Titan-Software läuft, angeschlossen.
+
+Von der Größe und Form her ist es die ideale Ergänzung zum T3, kann aber auch als Erweiterung 
+mit jedem anderen Titan-Pult (ab Version 16) verwendet werden. Ebenso kann es als Faderboard für das T2 dienen.
+
+![T3 Wing](/docs/images/T3-Wing.png)
+
+Zur Anzeige der Belegung der Fader und Tasten auf dem Wing gibt es das Fenster
+"Mobile Wing". Um dieses zu öffnen, drücken Sie zweimal 
+auf <Keys.HardKey>View/Open</Keys.HardKey> und wählen "Mobile Wing". Mit den 
+Kontext-Buttons kann man verschiedene Anzeigearten dieses Fensters wählen, z.B. 
+alles zusammen, nur die Fader, nur die Tasten etc.
+
+Das T3-Wing kann mit Titan-Pulten ab Version 16 verwendet werden. Das D3-Wing verfügt über die gleichen Funktionen wie das T3-Wing, ist aber von Größe und Layout auf das D3 abgestimmt.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/tiger-touch.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/tiger-touch.md
@@ -1,0 +1,110 @@
+---
+id: tiger-touch
+title: Das Tiger Touch
+sidebar_label: Das Tiger Touch
+description: Das Tiger Touch - console design and features
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+![Tiger Touch](/docs/images/Tiger-Touch.png)
+
+Das Tiger Touch hat vier grundsätzliche Bedienungsbereiche:
+
+&nbsp;<Keys.Annotation>A</Keys.Annotation> Der **Touchscreen** zeigt Schaltflächen 
+zur Auswahl von Geräten, Paletten und Gruppen. Ferner zeigt er Bezeichnungen der 
+Playbacks, sowie -- oben rechts -- die aktuelle Menüseite und die Bezeichnungen 
+der variablen Tasten.
+
+&nbsp;<Keys.Annotation>B</Keys.Annotation> Die **Playbacks** dienen zur Auswahl 
+und Steuerung von Bildern und Abläufen: Cues, Cuelisten und Chaser.
+
+&nbsp;<Keys.Annotation>C</Keys.Annotation> Die **festen Playbacks** ermöglichen 
+Zugriff auf weitere -- nicht umgeschaltete -- Speicherplätze, während mit den 
+**Makro-Tastern** häufig benutzte Tastenkombinationen automatisiert werden können.
+
+&nbsp;<Keys.Annotation>D</Keys.Annotation> Die **Programmiersektion** enthält alle
+Steuerelemente zum Einrichten und Programmieren des Pultes.
+
+> Hinweis: das Tiger Touch der ersten Serie sowie das Tiger Touch Pro
+  haben anders angeordnete Tasten.
+
+
+## Bedienoberfläche
+
+![Tiger Touch controls](/docs/images/Tiger-Touch-controls.png)
+
+&nbsp;<Keys.Annotation>E</Keys.Annotation> Die **Arbeitsfenster** auf dem 
+Touchscreen zeigen Tasten für Geräte, Paletten, Gruppen, Speicherplätze, 
+Makros und anderes. Ebenso lassen sich hier Attribute einstellen und 
+Informationsfenster einblenden.
+
+&nbsp;<Keys.Annotation>F</Keys.Annotation> Die **Systemanzeige** ist die 
+Schaltzentrale des Pultes und liefert Informationen über den jeweiligen 
+Zustand. Hier werden diverse Hinweisfenster eingeblendet, abhängig vom 
+momentanen Arbeits- und Programmierablauf.
+
+&nbsp;<Keys.Annotation>G</Keys.Annotation> Die **Menütasten** (bezeichnet 
+mit A -- G) dienen zur Auswahl verschiedener Steuerungsoptionen. Im 
+Display wird direkt neben jedem Taster die jeweilige Funktion angezeigt, 
+abhängig vom jeweiligen Status des Pultes. Befehle dieser Taster sind in 
+diesem Handbuch blau dargestellt, z.B. <Keys.SoftKey>Edit Times</Keys.SoftKey>
+
+&nbsp;<Keys.Annotation>H</Keys.Annotation> Die **festen Playbacks** dienen 
+zum Aufruf häufig benutzter Cues etc. Diese Playbacks sind von der 
+Seitenumschaltung nicht betroffen, jedoch lassen sie sich per Makro umschalten.
+
+&nbsp;<Keys.Annotation>I</Keys.Annotation> Auf den **Makro-Tastern** lassen sich 
+sowohl Cues als auch häufig benutzte Abläufe von Tastendrücken abspeichern, und 
+dann mit einem einzigen Tastendruck abrufen.
+
+![Tiger Touch controls 2](/docs/images/Tiger-Touch-controls-2.png)
+
+&nbsp;<Keys.Annotation>J</Keys.Annotation> Der **Master** (Hauptregler) steuert 
+die Gesamthelligkeit aller über das Pult abgerufenen Szenen. Normalerweise wird 
+man den Regler auf '100%' belassen. Der **DBO-Taster** dient zum unmittelbaren 
+Dunkelschalten.
+
+&nbsp;<Keys.Annotation>K</Keys.Annotation> Die **Playbacks** dienen zum Speichern 
+und Abrufen von Cues und Chasern/Cuelisten. Mit den &nbsp;<Keys.Annotation>
+L</Keys.Annotation> **Seitenauswahltastern** kann man zu verschiedenen Seiten 
+der Playbacks wechseln. Im Touchscreen werden oberhalb der Regler Informationen 
+über jeden einzelnen eingeblendet.
+
+&nbsp;<Keys.Annotation>M</Keys.Annotation> Mit den **Drehreglern** (Encodern) 
+werden sowohl Attribute der Geräte, als auch Geschwindigkeit und Überblendung 
+der Sequenzen eingestellt. Im Touchscreen oberhalb der Räder wird angezeigt, 
+welche Parameter momentan mit welchem Rad verknüpft sind. Betätigen des 
+**Bildlaufschalters** schaltet die Räder in den Bildlauf-Modus: damit lässt 
+sich eine Auswahlbox über den Bildschirm bewegen.
+
+&nbsp;<Keys.Annotation>N</Keys.Annotation> Mit dem **Ziffern- und Tastenfeld** 
+lassen sich Werte eingeben sowie Einstellungen des Pultes ändern.
+
+&nbsp;<Keys.Annotation>O</Keys.Annotation> Mit den **Funktionstasten** sind 
+verschiedene Funktionen verknüpft, etwa Speichern, Kopieren, Speichern auf Disk.
+
+&nbsp;<Keys.Annotation>P</Keys.Annotation> Mit den Tastern der **Attributauswahl** 
+werden die Attribute der Geräte angewählt (z.B. Farbe, Gobo, Bewegung, Fokus), 
+welche dann durch die Drehregler gesteuert werden sollen. Die jeweils aktiven 
+Taster werden durch LEDs angezeigt. Der untere (rote) Taster erlaubt das 'Locaten'
+von Geräten, indem sie auf eine vordefinierte Startposition gesetzt werden.
+
+![Tiger Touch Back Panel](/docs/images/Tiger-Touch-Back-Panel.png)
+
+## Anschlussfeld auf der Rückseite
+
+Sämtliche für das Pult erforderlichen Anschlüsse befinden sich auf der
+Rückseite. Die meisten davon sind selbsterklärend.
+
+&nbsp;<Keys.Annotation>Q</Keys.Annotation> Der Netzschalter oberhalb des 
+Netzanschlusses trennt das Pult komplett vom Netz. Verwenden Sie diesen 
+Schalter nicht, um das Pult normal auszuschalten.
+
+&nbsp;<Keys.Annotation>R</Keys.Annotation> Mit dem Reset-Schalter wird die 
+Elektronik der Bedienelemente zurückgesetzt, während die Software weiterläuft. 
+Zu beachten ist, dass dabei auch die DMX-Ausgabe unterbrochen wird.
+
+&nbsp;<Keys.Annotation>S</Keys.Annotation> Es gibt vier XLR-DMX-Ausgänge, 
+einen SMPTE-Eingang sowie MIDI Ein- und Ausgang.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/tiger-touch.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/tiger-touch.md
@@ -108,3 +108,20 @@ Zu beachten ist, dass dabei auch die DMX-Ausgabe unterbrochen wird.
 
 &nbsp;<Keys.Annotation>S</Keys.Annotation> Es gibt vier XLR-DMX-Ausgänge, 
 einen SMPTE-Eingang sowie MIDI Ein- und Ausgang.
+
+![Tiger Touch Wing](/docs/images/Tiger-Touch-Wing.png)
+
+Das Tiger Touch Wing wird über ein USB-Kabel mit dem jeweiligen Pult 
+verbunden, außerdem ist ein separater Netzanschluss erforderlich. Das
+Wing verfügt über einen integrierten USB-Hub, so dass weitere 2
+USB-Anschlüsse z.B. für eine Tastatur und Mouse zur Verfügung stehen.
+
+Auf der Rückseite kann man mit einem Schalter einstellen, ob das Wing 
+rechts oder links steht. Damit können zwei Wings an eine Konsole angeschlossen werden. 
+Die Schalterstellung wird nur beim Einschalten ausgewertet, damit während der Show keine Störungen auftreten.
+
+Das Tiger Touch Wing ist optisch und mechanisch passend zum Tiger Touch
+designt worden, kann aber auch mit dem D9, Sapphire Touch, Arena und dem Pearl Expert verwendet werden.
+
+> Wird das Tiger Touch Wing mit dem D9-330 verwendet, so werden die Fader und Tasten 
+ganz links auf dem D9 auf das Tiger Touch Wing gespiegelt, haben also die identische Funktion. 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/titan-mobile.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/titan-mobile.md
@@ -1,0 +1,109 @@
+---
+id: titan-mobile
+title: Das Titan Mobile
+sidebar_label: Das Titan Mobile
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Das Titan Mobile ist ein PC-Wing, der mittels USB an einen Computer
+angeschlossen wird, auf dem Titan Go läuft. Zu den 
+Systemanforderungen siehe [Inbetriebnahme von T3/Titan Mobile und T1/T2](../titan-basics.md#inbetriebnahme-von-t3titan-mobile-und-t1t2).
+
+![Titan Mobile](/docs/images/Titan-Mobile.png)
+
+&nbsp;<Keys.Annotation>A</Keys.Annotation> Die **Playbacks** (Speicherplätze, 
+Szenenregler) dienen zum Speichern, zur Auswahl und zur Steuerung von Bildern 
+und Abläufen. &nbsp;<Keys.Annotation>B</Keys.Annotation> Die **Tasten 
+zur Seitenumschaltung** dienen dabei zum Umschalten der Seiten der Szenenregler;
+die jeweilige Belegung wird unten am Bildschirm angezeigt.
+
+&nbsp;<Keys.Annotation>C</Keys.Annotation> Mit den **Encodern** werden die 
+Geräte gesteuert; ebenso werden etwa Zeiten und Überblendwerte eingestellt. 
+Die jeweilige Belegung wird unten rechts im Bildschirm angezeigt.
+
+&nbsp;<Keys.Annotation>D</Keys.Annotation> Mit den Tastern der **Attributauswahl** 
+werden die Attribute der Geräte angewählt (z.B. Farbe, Gobo, Bewegung, Fokus), 
+welche dann durch die Drehregler gesteuert werden sollen. Die jeweils aktiven 
+Taster werden durch LEDs angezeigt. Der untere (rote) Taster erlaubt das 'Locaten'
+(Lokalisieren) von Geräten, indem sie auf eine vordefinierte Startposition gesetzt werden.
+
+&nbsp;<Keys.Annotation>E</Keys.Annotation> Mittels der **Tasten für Chaser und 
+Cuelisten** lassen sich diese starten, stoppen und innerhalb derselben navigieren.
+
+&nbsp;<Keys.Annotation>F</Keys.Annotation> Mit dem **Ziffern- und Tastenfeld** 
+lassen sich Werte eingeben sowie Einstellungen des Pultes ändern.
+
+&nbsp;<Keys.Annotation>G</Keys.Annotation> Mit den blauen **Funktionstasten** 
+sind verschieden Funktionen verknüpft, etwa Speichern von Szenen, Kopieren, 
+Speichern auf Disk.
+
+&nbsp;<Keys.Annotation>H</Keys.Annotation> Die **Macro- und Executortasten** sind 
+frei belegbare Tasten; darauf lassen sich sowohl Cues als auch Makros oder 
+Arbeitsumgebungen (Workspaces) speichern.
+
+&nbsp;<Keys.Annotation>I</Keys.Annotation> Die **Fensterauswahltasten** dienen 
+zum Öffnen und Umschalten der jeweiligen Fenster der Arbeitsumgebung.
+
+&nbsp;<Keys.Annotation>J</Keys.Annotation> Die **Menütasten** (bezeichnet mit 
+A -- G) dienen zur Auswahl verschiedener Steuerungsoptionen. Im Bildschirm 
+wird rechts die jeweilige Funktion angezeigt, abhängig vom jeweiligen Status
+des Pultes. Befehle dieser Taster sind in diesem Handbuch blau dargestellt,
+z.B. <Keys.SoftKey>Edit Times</Keys.SoftKey>
+
+## Der Bildschirm
+
+Das System lässt sich am komfortabelsten mit einem Touchscreen bedienen. 
+Verwenden Sie hingegen eine Maus, so klicken Sie mit der Maus einfach auf 
+die betreffenden Stelle, wenn im Handbuch ‚berühren' steht.
+
+![Titan Mobile Screen](/docs/images/Titan-Mobile-Screen.png)
+
+&nbsp;<Keys.Annotation>K</Keys.Annotation> Verschiedene **Arbeitsfenster** 
+können auf dem Bildschirm angezeigt werden; diese enthalten jeweils Buttons 
+(Schaltflächen) zur Auswahl von Geräten, Paletten, Gruppen, Shapes, Attributen etc. 
+Auch der Visualiser wird in einem solchen Fenster angezeigt.
+
+&nbsp;<Keys.Annotation>L</Keys.Annotation> Die **Menütasten** korrespondieren 
+mit den ‚echten' Tasten rechts auf dem Pult; die Schaltflächen zeigen die 
+jeweilige Belegung an, und zum Betätigen kann man entweder auf die Schaltfläche 
+klicken oder die jeweilige Taste drücken.
+
+&nbsp;<Keys.Annotation>M</Keys.Annotation> Links davon befindet sich der Bereich 
+**Systemanzeige**; hier werden hilfreiche Hinweise zur jeweiligen Aktion 
+eingeblendet. Darunter werden je nach gewähltem Fenster verschiedene 
+**kontextabhängige Schaltflächen** angezeigt.
+
+&nbsp;<Keys.Annotation>N</Keys.Annotation> Darunter wiederum werden die 
+**Arbeitsumgebungen** angezeigt, und mit den Schaltflächen lässt sich schnell 
+zwischen diesen umschalten.
+
+&nbsp;<Keys.Annotation>O</Keys.Annotation> Der Bereich **Rad-Belegung** zeigt 
+die aktuelle Funktion, Belegung und die Werte der Attribut-Räder. Im 
+**Attribut-Status** wird angezeigt, welche Attribute gerade aktiv und welche 
+modifiziert sind.
+
+&nbsp;<Keys.Annotation>P</Keys.Annotation> Unten links schließlich werden die momentanen Belegungen der **Playbacks** angezeigt.
+
+## Titan Mobile Anschlussfeld
+
+![Titan Mobile Connections](/docs/images/Titan-Mobile-Connections.png)
+Sämtliche für das Pult erforderlichen Anschlüsse befinden sich auf der
+rechten Seite. Die meisten davon sind selbsterklärend. 
+
+&nbsp;<Keys.Annotation>Q</Keys.Annotation> Es gibt vier DMX-Anschlüsse 
+sowie einen MIDI-Eingang.
+
+&nbsp;<Keys.Annotation>R</Keys.Annotation> USB-Anschluss. Titan Mobiles der 
+ersten Serie wurden noch mit zwei USB-Buchsen ausgeliefert, von denen aber 
+nur die obere zu verwenden ist. Neuere Titan Mobiles verfügen nur noch über 
+eine USB-Buchse. Normalerweise wird das Pult über USB mit Spannung versorgt. 
+Einige Laptops liefern aber ggf. nicht genügend Strom auf den USB-Anschlüssen; 
+in diesem Fall ist ein separates Netzteil (9 V Gleichspannung) <Keys.Annotation>
+S</Keys.Annotation> vorzusehen. Wenden Sie sich dazu an Avolites oder Ihren 
+Avolites-Händler.
+
+&nbsp;<Keys.Annotation>T</Keys.Annotation> Die Erdungsbuchse (unterhalb des 
+optionalen Netzteilanschlusses) erlaubt es, das Pult separat zu erden, um 
+eventuelle DMX-Probleme zu beheben.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/titan-mobile.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/titan-mobile.md
@@ -7,7 +7,7 @@ sidebar_label: Das Titan Mobile
 import Keys from '@site/src/components/key.ts';
 import Video from '@site/src/components/video.tsx';
 
-Das Titan Mobile ist ein PC-Wing, der mittels USB an einen Computer
+Das Titan Mobile ist ein USB-Panel, das an einen Computer
 angeschlossen wird, auf dem Titan Go läuft. Zu den 
 Systemanforderungen siehe [Inbetriebnahme von T3/Titan Mobile und T1/T2](../titan-basics.md#inbetriebnahme-von-t3titan-mobile-und-t1t2).
 
@@ -107,3 +107,23 @@ Avolites-Händler.
 &nbsp;<Keys.Annotation>T</Keys.Annotation> Die Erdungsbuchse (unterhalb des 
 optionalen Netzteilanschlusses) erlaubt es, das Pult separat zu erden, um 
 eventuelle DMX-Probleme zu beheben.
+
+## Titan Mobile Wing
+
+Das Titan Mobile Fader Wing stellt zusätzlich zum Pult 20 Fader sowie 30
+Macro-/Exekutor-Tasten zur Verfügung. Es wird einfach durch ein
+USB-Kabel mit dem Pult (bei Verwendung des Titan Mobile: mit dem
+Computer, auf dem die Software läuft) verbunden.
+
+Es hat die gleiche Form wie das Titan Mobile und passt perfekt zu
+diesem, kann aber auch mit allen anderen Titan-Pulten sowie dem T2 betrieben werden.
+
+![Titan Mobile Wing](/docs/images/Titan-Mobile-Wing.png)
+
+Zur Anzeige der Belegung der Fader und Tasten auf dem Wing gibt es das Fenster
+"Mobile Wing". Um dieses zu öffnen, drücken Sie zweimal 
+auf <Keys.HardKey>View/Open</Keys.HardKey> und wählen "Mobile Wing". Mit den 
+Kontext-Buttons kann man verschiedene Anzeigearten dieses Fensters wählen, z.B. 
+alles zusammen, nur die Fader, nur die Tasten etc.
+
+> Der Umschalter neben dem USB-Anschluss hat keine Funktion.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/tnp.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/tnp.md
@@ -1,0 +1,40 @@
+---
+id: tnp
+title: Der TNP (Titan Net Processor)
+sidebar_label: Der TNP (Titan Net Processor)
+description: The TitanNet Processor is the insides of a console without the control surface.
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+![TNP](/docs/images/TNP.png)
+
+Der TitanNet Prozessor ist nichts anderes als die Elektronik eines
+Pultes ohne die Fader und Tasten. Er erlaubt es, die Anzahl der
+verwendeten DMX-Linien in einer Show über die 16 Linien hinaus zu
+erweitern, die von einem Pult allein zur Verfügung gestellt werden,
+indem die Rechenarbeit über mehrere Einheiten verteilt wird.
+
+&nbsp;<Keys.Annotation>A</Keys.Annotation> MIDI und SMPTE-Anschlüsse
+
+&nbsp;<Keys.Annotation>B</Keys.Annotation> Netzwerkanschlüsse
+
+&nbsp;<Keys.Annotation>C</Keys.Annotation> Acht DMX-Ausgänge (XLR)
+
+&nbsp;<Keys.Annotation>D</Keys.Annotation> Integrierter Touchscreen
+
+&nbsp;<Keys.Annotation>E</Keys.Annotation> Netzschalter
+
+&nbsp;<Keys.Annotation>F</Keys.Annotation> USB für Tastatur, Maus oder Memory-Stick
+
+Damit lässt sich auch die Betriebssicherheit erhöhen, indem etwa mehrere
+TNPs an der Bühne verwendet werden, während das Pult nur als deren
+Fernsteuerung arbeitet. Der TNP kann ferner auch als eigenständige
+Steuerung arbeiten und Shows laden, die auf einem anderen Titan-Pult
+erstellt wurden; dazu kann auf dem internen Display oder einem extern
+anzuschließenden Touchscreen die Titan Go-Oberfläche verwendet werden.
+Ebenso könnte man sich z.B. in einer Multiuser-Session mit dem TNP
+verbinden und diesen programmieren.
+
+Der Betrieb des TNP ist im Abschnitt [Der Titan Net Processor](../titan-net.md) näher erklärt.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/tnp.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/about-the-consoles/tnp.md
@@ -12,7 +12,7 @@ import Video from '@site/src/components/video.tsx';
 
 Der TitanNet Prozessor ist nichts anderes als die Elektronik eines
 Pultes ohne die Fader und Tasten. Er erlaubt es, die Anzahl der
-verwendeten DMX-Linien in einer Show über die 16 Linien hinaus zu
+verwendeten DMX-Linien in einer Show über die Anzahl an Linien hinaus zu
 erweitern, die von einem Pult allein zur Verfügung gestellt werden,
 indem die Rechenarbeit über mehrere Einheiten verteilt wird.
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/alpha-index.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/alpha-index.md
@@ -1,0 +1,684 @@
+---
+id: alpha-index
+title: Index (Alphabetisch)
+sidebar_label: Index (Alphabetisch)
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+
+
+## A
+[Abruf einer Palette für alle Geräte in einem Cue *(in "Abrufen von Paletten")*](./palettes/using-palettes.md#abruf-einer-palette-für-alle-geräte-in-einem-cue)<br/>
+[Abrufen einer Cueliste *(in "Abrufen")*](./cue-lists/cue-list-playback.md#abrufen-einer-cueliste)<br/>
+[Abrufen einer Tastenfolge (Makro) aus einer Cueliste *(in "Anlegen einer Cueliste")*](./cue-lists/creating-a-cue-list.md#abrufen-einer-tastenfolge-makro-aus-einer-cueliste)<br/>
+[Abrufen eines Chasers *(in "Abrufen")*](./chases/chase-playback.md#abrufen-eines-chasers)<br/>
+[Abrufen eines Cues *(in "Einen Cue verwenden")*](./cues/cue-playback.md#abrufen-eines-cues)<br/>
+[Abrufen eines Palettenwertes *(in "Abrufen von Paletten")*](./palettes/using-palettes.md#abrufen-eines-palettenwertes)<br/>
+[Abrufen per Nummer/Syntax *(in "Abrufen von Paletten")*](./palettes/using-palettes.md#abrufen-per-nummersyntax)<br/>
+[Abrufen von Tasten/Schaltflächen *(in "Abrufen von Paletten")*](./palettes/using-palettes.md#abrufen-von-tastenschaltflächen)<br/>
+[Aktive Geräte/Medienserver *(in "Geräte und Dimmer patchen")*](./patching/patching-new-fixtures-or-dimmers.md#aktive-gerätemedienserver)<br/>
+[Aktualisieren des Personality-Speichers des Pultes *(in "Die Personalities (Gerätedateien)")*](./fixture-personalities.md#aktualisieren-des-personality-speichers-des-pultes)<br/>
+[Aktualisieren gespeicherter Werte und Paletten *(in "Editieren von Cues")*](./cues/editing-cues.md#aktualisieren-gespeicherter-werte-und-paletten)<br/>
+[Aktualisieren von verwendeten Paletten *(in "Editieren von Paletten")*](./palettes/editing-palettes.md#aktualisieren-von-verwendeten-paletten)<br/>
+[Allgemeine Hinweise *(in "Der Pixelmapper")*](./effects/pixel-mapper.md#allgemeine-hinweise)<br/>
+[Andere Parameter bei Movinglights etc. einstellen *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#andere-parameter-bei-movinglights-etc.-einstellen)
+  
+## Ä
+[Ändern der DMX-Adresse im Patch-Menü *(in "Das Patch ändern")*](./patching/changing-the-patch.md#ändern-der-dmx-adresse-im-patch-menü)<br/>
+[Ändern der DMX-Adresse in der Patch-Ansicht *(in "Das Patch ändern")*](./patching/changing-the-patch.md#ändern-der-dmx-adresse-in-der-patch-ansicht)<br/>
+[Ändern der Einstellungen des Luminex-Switches im D9 *(in "Pulte im Netzwerk betreiben")*](./networking/connecting-the-arena-to-a-network.md#ändern-der-einstellungen-des-luminex-switches-im-d9)<br/>
+[Ändern der Gerätereihenfolge eines Shapes *(in "Ändern von Shapes und Effekten")*](./effects/editing-shapes-and-effects.md#ändern-der-gerätereihenfolge-eines-shapes)<br/>
+[Ändern der IP-Adresse des Titan Network Switch (TNS) beim D7 oder Arena *(in "Pulte im Netzwerk betreiben")*](./networking/connecting-the-arena-to-a-network.md#ändern-der-ip-adresse-des-titan-network-switch-tns-beim-d7-oder-arena)<br/>
+[Ändern der Reihenfolge der Geräte *(in "Zeiten für Cues")*](./cues/cue-timing.md#ändern-der-reihenfolge-der-geräte)<br/>
+[Ändern der Richtung eines Chasers *(in "Abrufen")*](./chases/chase-playback.md#ändern-der-richtung-eines-chasers)<br/>
+[Ändern der Verteilung eines Shapes (mehrere Geräte) *(in "Der Shape-Generator")*](./effects/shape-generator.md#ändern-der-verteilung-eines-shapes-mehrere-geräte)<br/>
+[Ändern der Zeiten einer laufenden Cueliste *(in "Editieren")*](./cue-lists/editing-cue-lists.md#ändern-der-zeiten-einer-laufenden-cueliste)<br/>
+[Ändern der Zugehörigkeit zu Playback-Gruppen *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#ändern-der-zugehörigkeit-zu-playback-gruppen)<br/>
+[Ändern des Inhalts einer Palette *(in "Editieren von Paletten")*](./palettes/editing-palettes.md#ändern-des-inhalts-einer-palette)<br/>
+[Ändern des Locate-Wertes *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#ändern-des-locate-wertes)<br/>
+[Ändern eines Chasers mit der Unfold-Funktion *(in "Editieren eines Chasers")*](./chases/editing-a-chase.md#ändern-eines-chasers-mit-der-unfold-funktion)<br/>
+[Ändern eines gerade laufenden Shapes *(in "Ändern von Shapes und Effekten")*](./effects/editing-shapes-and-effects.md#ändern-eines-gerade-laufenden-shapes)<br/>
+[Ändern gespeicherter Shapes und Effekte *(in "Ändern von Shapes und Effekten")*](./effects/editing-shapes-and-effects.md#ändern-gespeicherter-shapes-und-effekte)<br/>
+[Ändern von Größe und Geschwindigkeit *(in "Der Shape-Generator")*](./effects/shape-generator.md#ändern-von-größe-und-geschwindigkeit)<br/>
+[Ändern von Shape-Parametern im Effekt-Editor *(in "Keyframe-Shapes")*](./effects/key-frame-shapes.md#ändern-von-shape-parametern-im-effekt-editor)<br/>
+[Ändern von Shapes mit Include *(in "Ändern von Shapes und Effekten")*](./effects/editing-shapes-and-effects.md#ändern-von-shapes-mit-include)
+  
+## A
+[Anfordern einer neuen Gerätedatei *(in "Die Personalities (Gerätedateien)")*](./fixture-personalities.md#anfordern-einer-neuen-gerätedatei)<br/>
+[Animationen *(in "Der Pixelmapper")*](./effects/pixel-mapper.md#animationen)<br/>
+[Anlegen eines Cues *(in "Erstellen eines Cues")*](./cues/creating-a-cue.md#anlegen-eines-cues)<br/>
+[Anlegen eines Layouts *(in "Layouts")*](./controlling-fixtures/layouts.md#anlegen-eines-layouts)<br/>
+[Anordnen der Elemente in einem Layout *(in "Layouts")*](./controlling-fixtures/layouts.md#anordnen-der-elemente-in-einem-layout)<br/>
+[Anordnen von Geräten aus dem Visualiser *(in "Layouts")*](./controlling-fixtures/layouts.md#anordnen-von-geräten-aus-dem-visualiser)<br/>
+[Anschließen externer Steuerungen *(in "Externe Trigger")*](./running-the-show/midi-dmx-or-audio-triggering.md#anschließen-externer-steuerungen)<br/>
+[Anschlussfeld auf der Rückseite *(in "Das Arena")*](./about-the-consoles/arena.md#anschlussfeld-auf-der-rückseite)<br/>
+[Anschlussfeld auf der Rückseite *(in "Das Quartz")*](./about-the-consoles/quartz.md#anschlussfeld-auf-der-rückseite)<br/>
+[Anschlussfeld auf der Rückseite *(in "Das Sapphire Touch")*](./about-the-consoles/sapphire-touch.md#anschlussfeld-auf-der-rückseite)<br/>
+[Anschlussfeld auf der Rückseite *(in "Das Tiger Touch")*](./about-the-consoles/tiger-touch.md#anschlussfeld-auf-der-rückseite)<br/>
+[Anschlussfeld auf der Rückseite *(in "Pearl Expert und Touch Wing")*](./about-the-consoles/pearl-expert-and-touch-wing.md#anschlussfeld-auf-der-rückseite)<br/>
+[Anwählen von Dimmern/Geräten nach (Kanal-)Nummer *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#anwählen-von-dimmerngeräten-nach-kanal-nummer)<br/>
+[Anzahl und Größe der Schaltflächen/Raster *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#anzahl-und-größe-der-schaltflächenraster)<br/>
+[Anzeige der Cues: Playback View und Cue View *(in "Editieren von Cues")*](./cues/editing-cues.md#anzeige-der-cues-playback-view-und-cue-view)<br/>
+[Anzeige nur der relevanten Paletten *(in "Abrufen von Paletten")*](./palettes/using-palettes.md#anzeige-nur-der-relevanten-paletten)<br/>
+[Anzeige weiterer Patch-Details *(in "Das Patch ändern")*](./patching/changing-the-patch.md#anzeige-weiterer-patch-details)<br/>
+[Anzeigen der aktiven Playbacks *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#anzeigen-der-aktiven-playbacks)<br/>
+[Anzeigen der aktuell laufenden Playbacks *(in "Einen Cue verwenden")*](./cues/cue-playback.md#anzeigen-der-aktuell-laufenden-playbacks)<br/>
+[Anzeigen der Playbacks, die die Palette verwenden *(in "Editieren von Paletten")*](./palettes/editing-palettes.md#anzeigen-der-playbacks,-die-die-palette-verwenden)<br/>
+[Anzeigen und Ändern einer Palette *(in "Editieren von Paletten")*](./palettes/editing-palettes.md#anzeigen-und-ändern-einer-palette)<br/>
+[Anzeigeoptionen für das Playback Groups-Fenster *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#anzeigeoptionen-für-das-playback-groups-fenster)<br/>
+[Anzeigeoptionen für den Tracking View *(in "Editieren")*](./cue-lists/editing-cue-lists.md#anzeigeoptionen-für-den-tracking-view)<br/>
+[Arbeitsweise des Pultes beim Programmieren *(in "Erstellen eines Cues")*](./cues/creating-a-cue.md#arbeitsweise-des-pultes-beim-programmieren)<br/>
+[Art-Net-Eigenschaften *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#art-net-eigenschaften)<br/>
+[Assign Masters *(in "Das System-Menü")*](./system-settings/the-system-menu.md#assign-masters)<br/>
+[Attribute invertieren *(in "Erweiterte Funktionen")*](./patching/fixture-personality-options.md#attribute-invertieren)<br/>
+[Attribute limitieren *(in "Erweiterte Funktionen")*](./patching/fixture-personality-options.md#attribute-limitieren)<br/>
+[Attribute mit "Off" deaktivieren *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#attribute-mit-off-deaktivieren)<br/>
+[Attribute zum Speichern in Paletten *(in "Erstellen von Paletten")*](./palettes/creating-palettes.md#attribute-zum-speichern-in-paletten)<br/>
+[Attributgruppen -- IPCGBES-FX *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#attributgruppen----ipcgbes-fx)<br/>
+[Attribut-Speichermaske bei Cues *(in "Erstellen eines Cues")*](./cues/creating-a-cue.md#attribut-speichermaske-bei-cues)<br/>
+[Audio-Trigger (Sound to Light) *(in "Externe Trigger")*](./running-the-show/midi-dmx-or-audio-triggering.md#audio-trigger-sound-to-light)<br/>
+[Aufzeichnen eine Timeline im Live-Betrieb *(in "Eine Timeline speichern")*](./timelines/creating-a-timeline.md#aufzeichnen-eine-timeline-im-live-betrieb)<br/>
+[Auswahl der IP-Adresse und Subnetzmaske *(in "Grundlagen der IP-Adressierung")*](./networking/a-quick-guide-to-ip-addressing.md#auswahl-der-ip-adresse-und-subnetzmaske)<br/>
+[Auswahl des Pultes in der App *(in "Einrichten der Fernsteuerung")*](./remote-control/setting-up-the-remote.md#auswahl-des-pultes-in-der-app)<br/>
+[Auswahl mit den Pfeiltasten *(in "Wiedergeben und Editieren von Timelines")*](./timelines/running-and-editing-timelines.md#auswahl-mit-den-pfeiltasten)<br/>
+[Auswahl- und Flashtaste *(in "Die Tasten der Konsole")*](./titan-basics/front-panel-buttons.md#auswahl--und-flashtaste)<br/>
+[Auswahl und Positionierung der Arbeitsfenster *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster)<br/>
+[Auswahl von Geräten in einem Cue *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#auswahl-von-geräten-in-einem-cue)<br/>
+[Auswählen der Trigger *(in "Wiedergeben und Editieren von Timelines")*](./timelines/running-and-editing-timelines.md#auswählen-der-trigger)<br/>
+[Auswählen von Geräten *(in "Verwenden der Titan Remote-App")*](./remote-control/operating-the-remote.md#auswählen-von-geräten)<br/>
+[Auto-Gruppen *(in "Geräte-Gruppen")*](./controlling-fixtures/fixture-groups.md#auto-gruppen)<br/>
+[Autoloading: Laden eines externen Cues *(in "Anlegen einer Cueliste")*](./cue-lists/creating-a-cue-list.md#autoloading-laden-eines-externen-cues)<br/>
+[Automatisches Patchen in Capture *(in "Geräte und Dimmer patchen")*](./patching/patching-new-fixtures-or-dimmers.md#automatisches-patchen-in-capture)<br/>
+[Automatisches Vereinfachen *(in "Eine Timeline speichern")*](./timelines/creating-a-timeline.md#automatisches-vereinfachen)<br/>
+[Autosave -- Automatisches Speichern *(in "Laden und Sichern von Shows")*](./titan-basics/loading-and-saving-shows.md#autosave----automatisches-speichern)
+  
+## B
+[Bänke und Clips mit speziellen Funktionen *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#bänke-und-clips-mit-speziellen-funktionen)<br/>
+[Beat und Cycles (Durchläufe) *(in "Der Shape-Generator")*](./effects/shape-generator.md#beat-und-cycles-durchläufe)<br/>
+[Beats *(in "Der Shape-Generator")*](./effects/shape-generator.md#beats)<br/>
+[Bedienoberfläche *(in "Das Arena")*](./about-the-consoles/arena.md#bedienoberfläche)<br/>
+[Bedienoberfläche *(in "Das Sapphire Touch")*](./about-the-consoles/sapphire-touch.md#bedienoberfläche)<br/>
+[Bedienoberfläche *(in "Das Tiger Touch")*](./about-the-consoles/tiger-touch.md#bedienoberfläche)<br/>
+[Bedienoberfläche *(in "Pearl Expert und Touch Wing")*](./about-the-consoles/pearl-expert-and-touch-wing.md#bedienoberfläche)<br/>
+[Beispiel 1: Gerade/ungerade *(in "Pixelmapper - Beispiele")*](./effects/pixel-mapper-examples.md#beispiel-1-geradeungerade)<br/>
+[Beispiel 2 -- Pseudo-Zufallsfolge *(in "Pixelmapper - Beispiele")*](./effects/pixel-mapper-examples.md#beispiel-2----pseudo-zufallsfolge)<br/>
+[Beispiel 3 -- Winkel (oder 'wenn einfach grade einfach langweilig ist') *(in "Pixelmapper - Beispiele")*](./effects/pixel-mapper-examples.md#beispiel-3----winkel-oder-'wenn-einfach-grade-einfach-langweilig-ist')<br/>
+[Beispiel für ein einfaches Art-Net-System *(in "Steuern von Geräten über Netzwerk")*](./networking/controlling-fixtures-over-a-network.md#beispiel-für-ein-einfaches-art-net-system)<br/>
+[Bereits gepatchte Personalities aktualisieren *(in "Das Patch ändern")*](./patching/changing-the-patch.md#bereits-gepatchte-personalities-aktualisieren)<br/>
+[Bildschirmtastatur *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#bildschirmtastatur)<br/>
+[Blind *(in "Playback-Optionen")*](./cues/playback-options.md#blind)<br/>
+[Blind-Modus *(in "Erstellen eines Cues")*](./cues/creating-a-cue.md#blind-modus)<br/>
+[Blind-Modus *(in "Steuern der Show")*](./running-the-show.md#blind-modus)<br/>
+[Block-Cues und Follow-On-Cues *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#block-cues-und-follow-on-cues)<br/>
+[BPM-Master per Pioneer DJ triggern *(in "Pioneer ProDJ-Decks mit Titan verknüpfen")*](./running-the-show/linking-pioneerdj-system-to-titan.md#bpm-master-per-pioneer-dj-triggern)<br/>
+[Button-Halo *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#button-halo)
+  
+## C
+[Capture Darstellungs-Optionen *(in "Das Rig einrichten")*](./capture-visualiser/setting-up-the-rig.md#capture-darstellungs-optionen)<br/>
+[Chases *(in "Key Profiles - Tastenbelegungen")*](./system-settings/key-profiles.md#chases)<br/>
+[Clear -- Löschen des Programmers und der Geräteauswahl *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#clear----löschen-des-programmers-und-der-geräteauswahl)<br/>
+[Clear *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#clear)<br/>
+[Clear-Funktionen *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#clear-funktionen)<br/>
+[Clear-Optionen *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#clear-optionen)<br/>
+[Compatibility windows -- die 'Kompatibilitätsfenster' *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#compatibility-windows----die-'kompatibilitätsfenster')<br/>
+[Console Legend *(in "Das System-Menü")*](./system-settings/the-system-menu.md#console-legend)<br/>
+[Copy, Move -- Kopieren, Verschieben in Cuelisten *(in "Titan Befehlsreferenz")*](./titan-reference.md#copy,-move----kopieren,-verschieben-in-cuelisten)<br/>
+[Cross Fade HTP *(in "Playback-Optionen")*](./cues/playback-options.md#cross-fade-htp)<br/>
+[Cue Links Disabled *(in "Chaser-Optionen")*](./chases/chase-options.md#cue-links-disabled)<br/>
+[Cue Links Disabled: *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#cue-links-disabled)<br/>
+[Cue Lists -- Cuelisten *(in "Titan Befehlsreferenz")*](./titan-reference.md#cue-lists----cuelisten)<br/>
+[Cue Lists *(in "Key Profiles - Tastenbelegungen")*](./system-settings/key-profiles.md#cue-lists)<br/>
+[Cue Release *(in "Chaser-Optionen")*](./chases/chase-options.md#cue-release)<br/>
+[Cue Release *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#cue-release)<br/>
+[Cue View *(in "Editieren von Cues")*](./cues/editing-cues.md#cue-view)<br/>
+[Cues *(in "Key Profiles - Tastenbelegungen")*](./system-settings/key-profiles.md#cues)<br/>
+[Cues live editieren *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#cues-live-editieren)<br/>
+[Cues und Cuelisten abfahren *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#cues-und-cuelisten-abfahren)<br/>
+[Cues wiederverwenden - die 'Include'-Funktion *(in "Editieren von Cues")*](./cues/editing-cues.md#cues-wiederverwenden---die-'include'-funktion)<br/>
+[Cues zu Chasern/Cuelisten umwandeln *(in "Erstellen eines Cues")*](./cues/creating-a-cue.md#cues-zu-chaserncuelisten-umwandeln)<br/>
+[Cursor *(in "Einführung in Timelines")*](./timelines.md#cursor)<br/>
+[Curve *(in "Playback-Optionen")*](./cues/playback-options.md#curve)<br/>
+[Cycles *(in "Der Shape-Generator")*](./effects/shape-generator.md#cycles)
+  
+## D
+[Das ausgewählte Gerät bei Fix+1/Fix-1 hervorheben *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#das-ausgewählte-gerät-bei-fix+1fix-1-hervorheben)<br/>
+[Das Clear-Menü *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#das-clear-menü)<br/>
+[Das Fenster "Intensity View" *(in "Anzeigen/Verändern von Attribut-Werten")*](./controlling-fixtures/viewing-and-editing-fixture-values.md#das-fenster-intensity-view)<br/>
+[Das Fenster 'Attribut-Editor' *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#das-fenster-'attribut-editor')<br/>
+[Das Fenster 'DMX View' *(in "Das Patch ändern")*](./patching/changing-the-patch.md#das-fenster-'dmx-view')<br/>
+[Das Fenster Pixel Mapper Preview *(in "Der Pixelmapper")*](./effects/pixel-mapper.md#das-fenster-pixel-mapper-preview)<br/>
+[Das Fenster Playback View *(in "Editieren")*](./cue-lists/editing-cue-lists.md#das-fenster-playback-view)<br/>
+[Das Fenster Synergy Fixtures *(in "Einrichtung")*](./synergy/setting-up.md#das-fenster-synergy-fixtures)<br/>
+[Das Pearl Expert Touch Wing *(in "Pearl Expert und Touch Wing")*](./about-the-consoles/pearl-expert-and-touch-wing.md#das-pearl-expert-touch-wing)<br/>
+[Das PioneerDJ-Fenster *(in "Pioneer ProDJ-Decks mit Titan verknüpfen")*](./running-the-show/linking-pioneerdj-system-to-titan.md#das-pioneerdj-fenster)<br/>
+[Das Pult beschriften *(in "Steuern der Show")*](./running-the-show.md#das-pult-beschriften)<br/>
+[Das Pult sperren *(in "Steuern der Show")*](./running-the-show.md#das-pult-sperren)<br/>
+[Deaktivieren eines Cues *(in "Editieren")*](./cue-lists/editing-cue-lists.md#deaktivieren-eines-cues)<br/>
+[Deaktivieren einzelner Geräte mit Off *(in "Einen Cue verwenden")*](./cues/cue-playback.md#deaktivieren-einzelner-geräte-mit-off)<br/>
+[Deaktivieren von Attributen in Cues mit "Off" *(in "Editieren von Cues")*](./cues/editing-cues.md#deaktivieren-von-attributen-in-cues-mit-off)<br/>
+[Delay In/Fade In/Fade Out *(in "Playback-Optionen")*](./cues/playback-options.md#delay-infade-infade-out)<br/>
+[Delete -- Löschen *(in "Titan Befehlsreferenz")*](./titan-reference.md#delete----löschen)<br/>
+[Den Patch vom Pult nach Capture übertragen *(in "Mit einer externen Capture-Vollversion verbinden")*](./capture-visualiser/linking-the-console-to-stand-alone-capture.md#den-patch-vom-pult-nach-capture-übertragen)<br/>
+[Den Patch von Capture ins Pult übertragen *(in "Mit einer externen Capture-Vollversion verbinden")*](./capture-visualiser/linking-the-console-to-stand-alone-capture.md#den-patch-von-capture-ins-pult-übertragen)<br/>
+[Den Programmer releasen *(in "Einen Cue verwenden")*](./cues/cue-playback.md#den-programmer-releasen)<br/>
+[Den Titan Simulator installieren *(in "Der Titan Simulator")*](./titan-basics/titan-simulator.md#den-titan-simulator-installieren)<br/>
+[Der Bildschirm *(in "Das Titan Mobile")*](./about-the-consoles/titan-mobile.md#der-bildschirm)<br/>
+[Der Reiter Key Profiles (Tastenprofile) *(in "Show Library - das Show-Verzeichnis")*](./titan-basics/show-library.md#der-reiter-key-profiles-tastenprofile)<br/>
+[Der Reiter Show Library *(in "Show Library - das Show-Verzeichnis")*](./titan-basics/show-library.md#der-reiter-show-library)<br/>
+[Der Reiter Users (Benutzer) *(in "Show Library - das Show-Verzeichnis")*](./titan-basics/show-library.md#der-reiter-users-benutzer)<br/>
+[Der Trackball (Diamond 9 und Sapphire Touch) *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#der-trackball-diamond-9-und-sapphire-touch)<br/>
+[Die Anzeige sperren *(in "TNP im Stand-Alone-Pultbetrieb")*](./titan-net/tnp-console-mode.md#die-anzeige-sperren)<br/>
+[Die Anzeige wählen *(in "TNP im Stand-Alone-Pultbetrieb")*](./titan-net/tnp-console-mode.md#die-anzeige-wählen)<br/>
+[Die Capture-Show löschen *(in "Capture Show-Daten")*](./capture-visualiser/capture-show-files.md#die-capture-show-löschen)<br/>
+[Die Kontext-Schaltflächen/Buttons *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#die-kontext-schaltflächenbuttons)<br/>
+[Die Menütasten *(in "Andere Bereiche der Anzeige")*](./titan-basics/other-parts-of-the-touch-screen.md#die-menütasten)<br/>
+[Die ML-Menü-Taste *(in "Weitere Optionen")*](./controlling-fixtures/advanced-options.md#die-ml-menü-taste)<br/>
+[Die Patch-Ansicht (Patch View) *(in "Das Patch ändern")*](./patching/changing-the-patch.md#die-patch-ansicht-patch-view)<br/>
+[Die Personality editieren *(in "Erweiterte Funktionen")*](./patching/fixture-personality-options.md#die-personality-editieren)<br/>
+[Die Programmiersektion *(in "Diamond 7")*](./about-the-consoles/d7.md#die-programmiersektion)<br/>
+[Die Programmiersektion *(in "Diamond 9")*](./about-the-consoles/diamond.md#die-programmiersektion)<br/>
+[Die Show speichern *(in "Laden und Sichern von Shows")*](./titan-basics/loading-and-saving-shows.md#die-show-speichern)<br/>
+[Die Tastenbelegung wechseln *(in "Key Profiles - Tastenbelegungen")*](./system-settings/key-profiles.md#die-tastenbelegung-wechseln)<br/>
+[Die Touchscreens *(in "Diamond 9")*](./about-the-consoles/diamond.md#die-touchscreens)<br/>
+[Die Tracks konfigurieren *(in "Das Fenster Set-Liste")*](./running-the-show/set-list-window.md#die-tracks-konfigurieren)<br/>
+[Die Übersichtsleiste *(in "Einführung in Timelines")*](./timelines.md#die-übersichtsleiste)<br/>
+[Die Übersichtsleiste *(in "Wiedergeben und Editieren von Timelines")*](./timelines/running-and-editing-timelines.md#die-übersichtsleiste)<br/>
+[Die Werkzeugleiste *(in "Andere Bereiche der Anzeige")*](./titan-basics/other-parts-of-the-touch-screen.md#die-werkzeugleiste)<br/>
+[Dimmer und Geräte zum Steuern auswählen *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#dimmer-und-geräte-zum-steuern-auswählen)<br/>
+[Dimmer/Shutter *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#dimmershutter)<br/>
+[Dimmer-Handrad (Nur beim Diamond 9 und Diamond 7) *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#dimmer-handrad-nur-beim-diamond-9-und-diamond-7)<br/>
+[Dimmerwerte setzen *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#dimmerwerte-setzen)<br/>
+[Direkt in den Venue Mode starten *(in "Steuern der Show")*](./running-the-show.md#direkt-in-den-venue-mode-starten)<br/>
+[Direktanwahl eines Schrittes *(in "Abrufen")*](./chases/chase-playback.md#direktanwahl-eines-schrittes)<br/>
+[Direkte Eingabe für Attributwerte *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#direkte-eingabe-für-attributwerte)<br/>
+[Direktes Clearen einzelner Attribute *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#direktes-clearen-einzelner-attribute)<br/>
+[Display *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#display)<br/>
+[Display Setup - Bildschirmeinrichtung *(in "Das System-Menü")*](./system-settings/the-system-menu.md#display-setup---bildschirmeinrichtung)<br/>
+[Display-Ansicht speichern *(in "Steuern der Show")*](./running-the-show.md#display-ansicht-speichern)<br/>
+[DMX anschließen *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#dmx-anschließen)<br/>
+[DMX Merge -- Network DMX Node Settings *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#dmx-merge----network-dmx-node-settings)<br/>
+[DMX Settings *(in "Das System-Menü")*](./system-settings/the-system-menu.md#dmx-settings)<br/>
+[DMX-Eigenschaften *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#dmx-eigenschaften)<br/>
+[DMX-Overview *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#dmx-overview)
+  
+## E
+[Editieren der Zeiten im Programmer *(in "Zeiten für Cues")*](./cues/cue-timing.md#editieren-der-zeiten-im-programmer)<br/>
+[Editieren einer Cueliste mit 'Unfold' *(in "Editieren")*](./cue-lists/editing-cue-lists.md#editieren-einer-cueliste-mit-'unfold')<br/>
+[Editieren einer Cueliste während des Programmierens *(in "Editieren")*](./cue-lists/editing-cue-lists.md#editieren-einer-cueliste-während-des-programmierens)<br/>
+[Editieren einer laufenden Cueliste *(in "Editieren")*](./cue-lists/editing-cue-lists.md#editieren-einer-laufenden-cueliste)<br/>
+[Editieren einer Timeline *(in "Wiedergeben und Editieren von Timelines")*](./timelines/running-and-editing-timelines.md#editieren-einer-timeline)<br/>
+[Editieren eines Cues durch Verschmelzen (Merge) *(in "Editieren von Cues")*](./cues/editing-cues.md#editieren-eines-cues-durch-verschmelzen-merge)<br/>
+[Editieren getrackter Cues mit dem Tracking View *(in "Editieren")*](./cue-lists/editing-cue-lists.md#editieren-getrackter-cues-mit-dem-tracking-view)<br/>
+[Editieren mit den Wheels *(in "Wiedergeben und Editieren von Timelines")*](./timelines/running-and-editing-timelines.md#editieren-mit-den-wheels)<br/>
+[Editieren von Frames *(in "Keyframe-Shapes")*](./effects/key-frame-shapes.md#editieren-von-frames)<br/>
+[Editieren von Werten im Cue View *(in "Editieren von Cues")*](./cues/editing-cues.md#editieren-von-werten-im-cue-view)<br/>
+[Editieren von Werten im Fenster Cue View *(in "Editieren")*](./cue-lists/editing-cue-lists.md#editieren-von-werten-im-fenster-cue-view)<br/>
+[Effect Speed Multiplier *(in "Playback-Optionen")*](./cues/playback-options.md#effect-speed-multiplier)<br/>
+[Effects (Effekte) *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#effects-effekte)<br/>
+[Effekte und Layer kombinieren *(in "Pixelmapper - Beispiele")*](./effects/pixel-mapper-examples.md#effekte-und-layer-kombinieren)<br/>
+[Ein CITP-Beispiel *(in "Verwenden von Geräten mit CITP")*](./networking/using-active-fixtures.md#ein-citp-beispiel)<br/>
+[Eine Cueliste deaktivieren *(in "Abrufen")*](./cue-lists/cue-list-playback.md#eine-cueliste-deaktivieren)<br/>
+[Eine Cueliste verschieben oder kopieren *(in "Kopieren, verschieben, verlinken, löschen")*](./cue-lists/copying-moving-linking-and-deleting.md#eine-cueliste-verschieben-oder-kopieren)<br/>
+[Eine Gruppe speichern *(in "Geräte-Gruppen")*](./controlling-fixtures/fixture-groups.md#eine-gruppe-speichern)<br/>
+[Eine Show zum automatischen Starten festlegen *(in "Laden und Sichern von Shows")*](./titan-basics/loading-and-saving-shows.md#eine-show-zum-automatischen-starten-festlegen)<br/>
+[Eine Timeline per Timecode steuern *(in "Wiedergeben und Editieren von Timelines")*](./timelines/running-and-editing-timelines.md#eine-timeline-per-timecode-steuern)<br/>
+[Eine Timeline testen *(in "Wiedergeben und Editieren von Timelines")*](./timelines/running-and-editing-timelines.md#eine-timeline-testen)<br/>
+[Einen Chaser mit Quick Build erstellen *(in "Erstellen eines Chasers")*](./chases/creating-a-chase.md#einen-chaser-mit-quick-build-erstellen)<br/>
+[Einen Chaser programmieren *(in "Erstellen eines Chasers")*](./chases/creating-a-chase.md#einen-chaser-programmieren)<br/>
+[Einen Chaser verschieben oder kopieren *(in "Kopieren, verschieben, verlinken, löschen")*](./chases/copying-moving-linking-and-deleting.md#einen-chaser-verschieben-oder-kopieren)<br/>
+[Einen Chaser zum Editieren öffnen *(in "Editieren eines Chasers")*](./chases/editing-a-chase.md#einen-chaser-zum-editieren-öffnen)<br/>
+[Einen Cue löschen *(in "Kopieren, verschieben, verlinken, löschen")*](./cues/copying-moving-linking-and-deleting.md#einen-cue-löschen)<br/>
+[Einen Keyframe-Shape erzeugen *(in "Keyframe-Shapes")*](./effects/key-frame-shapes.md#einen-keyframe-shape-erzeugen)<br/>
+[Einen Keyframe-Shape in einen Cue speichern *(in "Keyframe-Shapes")*](./effects/key-frame-shapes.md#einen-keyframe-shape-in-einen-cue-speichern)<br/>
+[Einen Master releasen *(in "Einen Cue verwenden")*](./cues/cue-playback.md#einen-master-releasen)<br/>
+[Einen Monitor anschließen *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#einen-monitor-anschließen)<br/>
+[Einen Plan als Hintergrund eines Layouts laden *(in "Layouts")*](./controlling-fixtures/layouts.md#einen-plan-als-hintergrund-eines-layouts-laden)<br/>
+[Einen Shape erstellen *(in "Der Shape-Generator")*](./effects/shape-generator.md#einen-shape-erstellen)<br/>
+[Einen Shape umkehren *(in "Ändern von Shapes und Effekten")*](./effects/editing-shapes-and-effects.md#einen-shape-umkehren)<br/>
+[Eingeben von Attributwerten mit den @-Tasten *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#eingeben-von-attributwerten-mit-den--tasten)<br/>
+[Eingeben von Überblendzeiten für einzelne Attribute *(in "Zeiten für Cues")*](./cues/cue-timing.md#eingeben-von-überblendzeiten-für-einzelne-attribute)<br/>
+[Eingeschränkter Zugriff mit dem Venue Mode *(in "Steuern der Show")*](./running-the-show.md#eingeschränkter-zugriff-mit-dem-venue-mode)<br/>
+[Einrichten der DMX-Ausgänge *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#einrichten-der-dmx-ausgänge)<br/>
+[Einrichten der DMX-Ausgänge *(in "Steuern von Geräten über Netzwerk")*](./networking/controlling-fixtures-over-a-network.md#einrichten-der-dmx-ausgänge)<br/>
+[Einrichten der externen Steuerung *(in "Externe Trigger")*](./running-the-show/midi-dmx-or-audio-triggering.md#einrichten-der-externen-steuerung)<br/>
+[Einrichten der Show in Ai *(in "Einrichtung")*](./synergy/setting-up.md#einrichten-der-show-in-ai)<br/>
+[Einrichten eines MIDI Faderboards mit dem T2 *(in "Externe Trigger")*](./running-the-show/midi-dmx-or-audio-triggering.md#einrichten-eines-midi-faderboards-mit-dem-t2)<br/>
+[Einrichten von Synergy *(in "Einrichtung")*](./synergy/setting-up.md#einrichten-von-synergy)<br/>
+[Einschalten und Ausschalten *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#einschalten-und-ausschalten)<br/>
+[Einstellen der IP-Adresse des Pultes *(in "Steuern von Geräten über Netzwerk")*](./networking/controlling-fixtures-over-a-network.md#einstellen-der-ip-adresse-des-pultes)<br/>
+[Einstellen von Attributen mit den Encodern *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#einstellen-von-attributen-mit-den-encodern)<br/>
+[Einstellen von Überblendzeiten und Geräteversatz *(in "Zeiten für Cues")*](./cues/cue-timing.md#einstellen-von-überblendzeiten-und-geräteversatz)<br/>
+[Einzeln durch die Geräte einer Auswahl durchschalten *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#einzeln-durch-die-geräte-einer-auswahl-durchschalten)<br/>
+[Einzelne Cues mit Include in den Programmer laden *(in "Editieren")*](./cue-lists/editing-cue-lists.md#einzelne-cues-mit-include-in-den-programmer-laden)<br/>
+[Elemente *(in "Der Pixelmapper")*](./effects/pixel-mapper.md#elemente)<br/>
+[Elemente in Formen anordnen *(in "Layouts")*](./controlling-fixtures/layouts.md#elemente-in-formen-anordnen)<br/>
+[Elemente manuell anordnen *(in "Layouts")*](./controlling-fixtures/layouts.md#elemente-manuell-anordnen)<br/>
+[Elemente zum Layout hinzufügen *(in "Layouts")*](./controlling-fixtures/layouts.md#elemente-zum-layout-hinzufügen)<br/>
+[Entfernen oder Hinzufügen von Geräten *(in "Ändern von Shapes und Effekten")*](./effects/editing-shapes-and-effects.md#entfernen-oder-hinzufügen-von-geräten)<br/>
+[Erstellen einer Effekt-Palette *(in "Erstellen von Paletten")*](./palettes/creating-palettes.md#erstellen-einer-effekt-palette)<br/>
+[Erstellen einer Palette mit Zeiten *(in "Erstellen von Paletten")*](./palettes/creating-palettes.md#erstellen-einer-palette-mit-zeiten)<br/>
+[Erstellen einer Playback-Gruppe *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#erstellen-einer-playback-gruppe)<br/>
+[Erstellen einer Set-Liste *(in "Das Fenster Set-Liste")*](./running-the-show/set-list-window.md#erstellen-einer-set-liste)<br/>
+[Erstellen und Ändern von Tastenbelegungen *(in "Key Profiles - Tastenbelegungen")*](./system-settings/key-profiles.md#erstellen-und-ändern-von-tastenbelegungen)<br/>
+[Exchange Mapping *(in "Das Patch ändern")*](./patching/changing-the-patch.md#exchange-mapping)
+  
+## F
+[Fade Modes *(in "Zeiten für Cues")*](./cues/cue-timing.md#fade-modes)<br/>
+[Fader Mode *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#fader-mode)<br/>
+[Fader Mode *(in "Playback-Optionen")*](./cues/playback-options.md#fader-mode)<br/>
+[Fan-Kurven *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#fan-kurven)<br/>
+[Fan-Modus *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#fan-modus)<br/>
+[Fan-Teile *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#fan-teile)<br/>
+[Farbmischung: Channel *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#farbmischung-channel)<br/>
+[Farbmischung: Filters *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#farbmischung-filters)<br/>
+[Farbmischung: HSI/RGB/CMY *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#farbmischung-hsirgbcmy)<br/>
+[Farbmischung: Picker *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#farbmischung-picker)<br/>
+[Fehler der Personalities an Avolites berichten *(in "Die Personalities (Gerätedateien)")*](./fixture-personalities.md#fehler-der-personalities-an-avolites-berichten)<br/>
+[Fenster-Einstellungen *(in "Anzeigen/Verändern von Attribut-Werten")*](./controlling-fixtures/viewing-and-editing-fixture-values.md#fenster-einstellungen)<br/>
+[Feste Playbacks (Nur Tiger Touch) *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#feste-playbacks-nur-tiger-touch)<br/>
+[Filtern -- Nur einzelne Spalten anzeigen *(in "Editieren von Cues")*](./cues/editing-cues.md#filtern----nur-einzelne-spalten-anzeigen)<br/>
+[Filtern der angezeigten Geräte *(in "Anzeigen/Verändern von Attribut-Werten")*](./controlling-fixtures/viewing-and-editing-fixture-values.md#filtern-der-angezeigten-geräte)<br/>
+[Fire First Cue *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#fire-first-cue)<br/>
+[Fixture Offset -- Geräte-Offset *(in "Erweiterte Funktionen")*](./patching/fixture-personality-options.md#fixture-offset----geräte-offset)<br/>
+[Fixture Overlap - Geräte-Überlappung *(in "Zeiten bei Chasern")*](./chases/chase-timing.md#fixture-overlap---geräte-überlappung)<br/>
+[Fixture Overlap - Geräteversatz *(in "Zeiten für Cuelisten")*](./cue-lists/cue-list-timing.md#fixture-overlap---geräteversatz)<br/>
+[Fixture Overlap *(in "Playback-Optionen")*](./cues/playback-options.md#fixture-overlap)<br/>
+[Fixtures - Geräte *(in "Titan Befehlsreferenz")*](./titan-reference.md#fixtures---geräte)<br/>
+[Fixtures *(in "Key Profiles - Tastenbelegungen")*](./system-settings/key-profiles.md#fixtures)<br/>
+[Fixtures aus Gruppenlayouts per Record hinzufügen *(in "Layouts")*](./controlling-fixtures/layouts.md#fixtures-aus-gruppenlayouts-per-record-hinzufügen)<br/>
+[Fixtures per Copy hinzufügen *(in "Layouts")*](./controlling-fixtures/layouts.md#fixtures-per-copy-hinzufügen)<br/>
+[Flash Fade In / Flash Fade Out *(in "Playback-Optionen")*](./cues/playback-options.md#flash-fade-in--flash-fade-out)<br/>
+[Flash- und Swop-Tasten *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#flash--und-swop-tasten)<br/>
+[Flip *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#flip)<br/>
+[Formatting (Formate) *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#formatting-formate)<br/>
+[Funktionen der Layout-Anzeige *(in "Layouts")*](./controlling-fixtures/layouts.md#funktionen-der-layout-anzeige)
+  
+## G
+[General (Allgemein) *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#general-allgemein)<br/>
+[Geparkte Geräte *(in "Geräte und Dimmer patchen")*](./patching/patching-new-fixtures-or-dimmers.md#geparkte-geräte)<br/>
+[Geräte anwählen *(in "Mit Capture visualisieren")*](./capture-visualiser/visualising-using-capture.md#geräte-anwählen)<br/>
+[Geräte auf Startposition setzen (Locate) *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#geräte-auf-startposition-setzen-locate)<br/>
+[Geräte aus einer Gruppe entfernen *(in "Geräte-Gruppen")*](./controlling-fixtures/fixture-groups.md#geräte-aus-einer-gruppe-entfernen)<br/>
+[Geräte austauschen *(in "Das Patch ändern")*](./patching/changing-the-patch.md#geräte-austauschen)<br/>
+[Geräte ein- und ausschalten *(in "Weitere Optionen")*](./controlling-fixtures/advanced-options.md#geräte-ein--und-ausschalten)<br/>
+[Geräte mit mehreren Zellen (Sub-Fixtures) *(in "Geräte und Dimmer patchen")*](./patching/patching-new-fixtures-or-dimmers.md#geräte-mit-mehreren-zellen-sub-fixtures)<br/>
+[Geräte mit mehreren Zellen/Subfixtures *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#geräte-mit-mehreren-zellensubfixtures)<br/>
+[Geräte mit Zellen (Sub Fixtures) *(in "Titan Befehlsreferenz")*](./titan-reference.md#geräte-mit-zellen-sub-fixtures)<br/>
+[Geräte miteinander abgleichen *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#geräte-miteinander-abgleichen)<br/>
+[Geräte oder Attribute fixieren (Freeze) *(in "Erweiterte Funktionen")*](./patching/fixture-personality-options.md#geräte-oder-attribute-fixieren-freeze)<br/>
+[Geräte suchen und finden *(in "Geräte und Dimmer patchen")*](./patching/patching-new-fixtures-or-dimmers.md#geräte-suchen-und-finden)<br/>
+[Geräte/Fixtures hinzufügen und einrichten *(in "Das Rig einrichten")*](./capture-visualiser/setting-up-the-rig.md#gerätefixtures-hinzufügen-und-einrichten)<br/>
+[Geräteauswahl nach Muster *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#geräteauswahl-nach-muster)<br/>
+[Gerätedarstellung *(in "Layouts")*](./controlling-fixtures/layouts.md#gerätedarstellung)<br/>
+[Geräte-Optionen im Visualiser *(in "Das Rig einrichten")*](./capture-visualiser/setting-up-the-rig.md#geräte-optionen-im-visualiser)<br/>
+[Gerätereihenfolge *(in "Geräte-Gruppen")*](./controlling-fixtures/fixture-groups.md#gerätereihenfolge)<br/>
+[Gerätereihenfolge und -anordnung in den Gruppen *(in "Geräte-Gruppen")*](./controlling-fixtures/fixture-groups.md#gerätereihenfolge-und--anordnung-in-den-gruppen)<br/>
+[Gerätetasten und -buttons *(in "Geräte und Dimmer patchen")*](./patching/patching-new-fixtures-or-dimmers.md#gerätetasten-und--buttons)<br/>
+[Geschwindigkeit und Überblendung einstellen *(in "Abrufen")*](./chases/chase-playback.md#geschwindigkeit-und-überblendung-einstellen)<br/>
+[Globale Release-Maske *(in "Einen Cue verwenden")*](./cues/cue-playback.md#globale-release-maske)<br/>
+[Globale Zeiten für Chaser *(in "Zeiten bei Chasern")*](./chases/chase-timing.md#globale-zeiten-für-chaser)<br/>
+[Groups *(in "Key Profiles - Tastenbelegungen")*](./system-settings/key-profiles.md#groups)<br/>
+[Gruppenlayout *(in "Geräte-Gruppen")*](./controlling-fixtures/fixture-groups.md#gruppenlayout)<br/>
+[Gruppenmaster *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#gruppenmaster)
+  
+## H
+[Halo für Fixture-Buttons *(in "Das Patch ändern")*](./patching/changing-the-patch.md#halo-für-fixture-buttons)<br/>
+[Handle Paging *(in "Playback-Optionen")*](./cues/playback-options.md#handle-paging)<br/>
+[Handle Worlds *(in "Mehrbenutzer-Betrieb")*](./titan-basics/multi-user-operation.md#handle-worlds)<br/>
+[Handles *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#handles)<br/>
+[Herunterfahren erzwingen *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#herunterfahren-erzwingen)<br/>
+[Herunterladen der Personalities bei Avolites *(in "Die Personalities (Gerätedateien)")*](./fixture-personalities.md#herunterladen-der-personalities-bei-avolites)<br/>
+[Hintergrundbild für den Sperrbildschirm *(in "Steuern der Show")*](./running-the-show.md#hintergrundbild-für-den-sperrbildschirm)<br/>
+[Hochladen von Content mit dem Media Browser *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#hochladen-von-content-mit-dem-media-browser)<br/>
+[HTP und LTP *(in "Einen Cue verwenden")*](./cues/cue-playback.md#htp-und-ltp)
+  
+## I
+[Im Notfall *(in "Die Personalities (Gerätedateien)")*](./fixture-personalities.md#im-notfall)<br/>
+[Importieren von Markern *(in "Eine Timeline speichern")*](./timelines/creating-a-timeline.md#importieren-von-markern)<br/>
+[Improvisieren (Busking) mit Paletten *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#improvisieren-busking-mit-paletten)<br/>
+[Inbetriebnahme von T3/Titan Mobile und T1/T2 *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#inbetriebnahme-von-t3titan-mobile-und-t1t2)<br/>
+[Include --  in den Speicher laden *(in "Titan Befehlsreferenz")*](./titan-reference.md#include-----in-den-speicher-laden)<br/>
+[Individuelle Einblendzeiten für Attribute *(in "Zeiten für Cuelisten")*](./cue-lists/cue-list-timing.md#individuelle-einblendzeiten-für-attribute)<br/>
+[Individuelle Zeiten pro Schritt *(in "Zeiten bei Chasern")*](./chases/chase-timing.md#individuelle-zeiten-pro-schritt)<br/>
+[Installationshinweise *(in "Wiederherstellen/Neuinstallation")*](./system-settings/recovering-reinstalling-the-console.md#installationshinweise)<br/>
+[Installieren der Titan-Software *(in "T1 und T2")*](./about-the-consoles/t1-and-t2.md#installieren-der-titan-software)
+  
+## K
+[Kameras einrichten (Ansichten) *(in "Das Rig einrichten")*](./capture-visualiser/setting-up-the-rig.md#kameras-einrichten-ansichten)<br/>
+[Kameras/Ansichten *(in "Mit Capture visualisieren")*](./capture-visualiser/visualising-using-capture.md#kamerasansichten)<br/>
+[Kennlinien für Geräte und Attribute *(in "Erweiterte Funktionen")*](./patching/fixture-personality-options.md#kennlinien-für-geräte-und-attribute)<br/>
+[Key Profile *(in "Playback-Optionen")*](./cues/playback-options.md#key-profile)<br/>
+[Key Profiles - Tastenprofile *(in "Das System-Menü")*](./system-settings/the-system-menu.md#key-profiles---tastenprofile)<br/>
+[Key Profiles -- Tastenprofile *(in "Die Tasten der Konsole")*](./titan-basics/front-panel-buttons.md#key-profiles----tastenprofile)<br/>
+[Key Profiles (Tastenprofile) *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#key-profiles-tastenprofile)<br/>
+[Keypad -- Tastatur *(in "Verwenden der Titan Remote-App")*](./remote-control/operating-the-remote.md#keypad----tastatur)<br/>
+[Kill Point *(in "Playback-Optionen")*](./cues/playback-options.md#kill-point)<br/>
+[Kompakte Track-Ansicht *(in "Wiedergeben und Editieren von Timelines")*](./timelines/running-and-editing-timelines.md#kompakte-track-ansicht)<br/>
+[Komplexe Effekte *(in "Keyframe-Shapes")*](./effects/key-frame-shapes.md#komplexe-effekte)<br/>
+[Konventionen in diesem Handbuch *(in "Einführung")*](./introduction.md#konventionen-in-diesem-handbuch)<br/>
+[Kopieren eines Cues *(in "Kopieren, verschieben, verlinken, löschen")*](./cues/copying-moving-linking-and-deleting.md#kopieren-eines-cues)<br/>
+[Kopieren oder verschieben einer Palette *(in "Paletten kopieren, verschieben oder löschen")*](./palettes/copying-moving-and-deleting-palettes.md#kopieren-oder-verschieben-einer-palette)<br/>
+[Kopieren oder Verschieben eines gepatchten Gerätes *(in "Kopieren, Verschieben und Löschen")*](./patching/copying-moving-and-deleting-fixtures.md#kopieren-oder-verschieben-eines-gepatchten-gerätes)<br/>
+[Kopieren, Verschieben und Löschen einzelner Cues *(in "Editieren")*](./cue-lists/editing-cue-lists.md#kopieren,-verschieben-und-löschen-einzelner-cues)<br/>
+[Kopieren, Verschieben, Löschen von Cues *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#kopieren,-verschieben,-löschen-von-cues)<br/>
+[Kopieren/Verschieben von Playbacks in einer Timeline *(in "Wiedergeben und Editieren von Timelines")*](./timelines/running-and-editing-timelines.md#kopierenverschieben-von-playbacks-in-einer-timeline)<br/>
+[Kreative Gruppenlayouts *(in "Pixelmapper - Beispiele")*](./effects/pixel-mapper-examples.md#kreative-gruppenlayouts)
+  
+## L
+[Laden einer Show *(in "Laden und Sichern von Shows")*](./titan-basics/loading-and-saving-shows.md#laden-einer-show)<br/>
+[Laden eines Chase-Schritts mit Include *(in "Editieren eines Chasers")*](./chases/editing-a-chase.md#laden-eines-chase-schritts-mit-include)<br/>
+[Layer steuern mit dem Attribut-Editor *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#layer-steuern-mit-dem-attribut-editor)<br/>
+[LEDs *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#leds)<br/>
+[Legenden aus Capture-Screenshots erzeugen *(in "Mit einer externen Capture-Vollversion verbinden")*](./capture-visualiser/linking-the-console-to-stand-alone-capture.md#legenden-aus-capture-screenshots-erzeugen)<br/>
+[Legenden und Bezeichnungen *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#legenden-und-bezeichnungen)<br/>
+[Legenden/Bezeichnungen eingeben *(in "Das Patch ändern")*](./patching/changing-the-patch.md#legendenbezeichnungen-eingeben)<br/>
+[Lightmap: Pixelmapping mit Video-Content *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#lightmap-pixelmapping-mit-video-content)<br/>
+[Linking *(in "Chaser-Optionen")*](./chases/chase-options.md#linking)<br/>
+[Lock -- den TNP sperren *(in "TNP im Slave-Betrieb")*](./titan-net/tnp-slave-mode.md#lock----den-tnp-sperren)<br/>
+[Lock *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#lock)<br/>
+[Lock und Venue Mode -- das Pult ganz oder teilweise sperren *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#lock-und-venue-mode----das-pult-ganz-oder-teilweise-sperren)<br/>
+[Lokale (individuelle) Release-Maske *(in "Einen Cue verwenden")*](./cues/cue-playback.md#lokale-individuelle-release-maske)<br/>
+[Loop Action *(in "Chaser-Optionen")*](./chases/chase-options.md#loop-action)<br/>
+[Loop Action *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#loop-action)<br/>
+[Löschen einer Cueliste *(in "Kopieren, verschieben, verlinken, löschen")*](./cue-lists/copying-moving-linking-and-deleting.md#löschen-einer-cueliste)<br/>
+[Löschen eines Chasers *(in "Kopieren, verschieben, verlinken, löschen")*](./chases/copying-moving-linking-and-deleting.md#löschen-eines-chasers)<br/>
+[Löschen eines gepatchten Gerätes *(in "Kopieren, Verschieben und Löschen")*](./patching/copying-moving-and-deleting-fixtures.md#löschen-eines-gepatchten-gerätes)<br/>
+[Löschen eines Schrittes aus einem Chaser *(in "Kopieren, verschieben, verlinken, löschen")*](./chases/copying-moving-linking-and-deleting.md#löschen-eines-schrittes-aus-einem-chaser)<br/>
+[Löschen von Paletten *(in "Paletten kopieren, verschieben oder löschen")*](./palettes/copying-moving-and-deleting-palettes.md#löschen-von-paletten)<br/>
+[Löschen von Playbacks in einer Timeline *(in "Wiedergeben und Editieren von Timelines")*](./timelines/running-and-editing-timelines.md#löschen-von-playbacks-in-einer-timeline)<br/>
+[Löschen von Shapes *(in "Ändern von Shapes und Effekten")*](./effects/editing-shapes-and-effects.md#löschen-von-shapes)
+  
+## M
+[Macros -- Tastenfolgen *(in "Die Tasten der Konsole")*](./titan-basics/front-panel-buttons.md#macros----tastenfolgen)<br/>
+[Macros *(in "Key Profiles - Tastenbelegungen")*](./system-settings/key-profiles.md#macros)<br/>
+[Macros *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#macros)<br/>
+[Macros zur Playback-Steuerung *(in "Das Fenster Set-Liste")*](./running-the-show/set-list-window.md#macros-zur-playback-steuerung)<br/>
+[Manuelle Geräteüberlappung beim Palettenabruf *(in "Arbeiten mit Zeiten in Paletten")*](./palettes/timing-with-palettes.md#manuelle-geräteüberlappung-beim-palettenabruf)<br/>
+[Manuelle Steuerung der Schritte *(in "Abrufen")*](./chases/chase-playback.md#manuelle-steuerung-der-schritte)<br/>
+[Master für Speed (Geschwindigkeit) und Size (Größe) *(in "Einen Cue verwenden")*](./cues/cue-playback.md#master-für-speed-geschwindigkeit-und-size-größe)<br/>
+[Master mit den Encodern steuern *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#master-mit-den-encodern-steuern)<br/>
+[Master-Fader *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#master-fader)<br/>
+[Master-Parameter für Effekte *(in "Der Pixelmapper")*](./effects/pixel-mapper.md#master-parameter-für-effekte)<br/>
+[Masterregler für Pixelmapper-Layer *(in "Der Pixelmapper")*](./effects/pixel-mapper.md#masterregler-für-pixelmapper-layer)<br/>
+[Masters *(in "Key Profiles - Tastenbelegungen")*](./system-settings/key-profiles.md#masters)<br/>
+[Master-Zeit und Overlap für Paletten *(in "Arbeiten mit Zeiten in Paletten")*](./palettes/timing-with-palettes.md#master-zeit-und-overlap-für-paletten)<br/>
+[Match Surface Resolution *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#match-surface-resolution)<br/>
+[Matrix-Effekte mit dem Pixelmapper erstellen *(in "Der Pixelmapper")*](./effects/pixel-mapper.md#matrix-effekte-mit-dem-pixelmapper-erstellen)<br/>
+[Medienserver/Active Fixtures *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#medienserveractive-fixtures)<br/>
+[Mergen/verschmelzen einzelner Werte *(in "Editieren")*](./cue-lists/editing-cue-lists.md#mergenverschmelzen-einzelner-werte)<br/>
+[MIDI Show Control *(in "Externe Trigger")*](./running-the-show/midi-dmx-or-audio-triggering.md#midi-show-control)<br/>
+[Mini-Display (Nur beim Arena) *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#mini-display-nur-beim-arena)<br/>
+[Modul-Eigenschaften der DMX-Ausgabe *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#modul-eigenschaften-der-dmx-ausgabe)<br/>
+[Move In Dark (MID) - Funktionen *(in "Abrufen")*](./cue-lists/cue-list-playback.md#move-in-dark-mid---funktionen)<br/>
+[Move In Dark *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#move-in-dark)
+  
+## N
+[Navigieren in der Timeline mit den Encodern *(in "Einführung in Timelines")*](./timelines.md#navigieren-in-der-timeline-mit-den-encodern)<br/>
+[Nested palettes -- Verknüpfte Paletten *(in "Erstellen von Paletten")*](./palettes/creating-palettes.md#nested-palettes----verknüpfte-paletten)<br/>
+[Network DMX Node Settings *(in "Das System-Menü")*](./system-settings/the-system-menu.md#network-dmx-node-settings)<br/>
+[Network Settings - Netzwerkeinstellungen *(in "Das System-Menü")*](./system-settings/the-system-menu.md#network-settings---netzwerkeinstellungen)<br/>
+[Netzanschluss *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#netzanschluss)<br/>
+[Netzwerkeinstellungen *(in "TNP im Slave-Betrieb")*](./titan-net/tnp-slave-mode.md#netzwerkeinstellungen)<br/>
+[Nicht ausgewählte Geräte ausblenden (Remainder Dim) *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#nicht-ausgewählte-geräte-ausblenden-remainder-dim)<br/>
+[Node-Einstellungen *(in "TNP im Slave-Betrieb")*](./titan-net/tnp-slave-mode.md#node-einstellungen)
+  
+## O
+[Offset einstellen *(in "Timeline-Optionen")*](./timelines/timeline-options.md#offset-einstellen)<br/>
+[Optionen für BPM-Master *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#optionen-für-bpm-master)<br/>
+[Optionen für Playback-Gruppen *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#optionen-für-playback-gruppen)<br/>
+[Options *(in "Key Profiles - Tastenbelegungen")*](./system-settings/key-profiles.md#options)<br/>
+[Optische Anschlüsse (D9 und Arena) *(in "Pulte im Netzwerk betreiben")*](./networking/connecting-the-arena-to-a-network.md#optische-anschlüsse-d9-und-arena)
+  
+## P
+[Paletten beschriften und bemalen *(in "Erstellen von Paletten")*](./palettes/creating-palettes.md#paletten-beschriften-und-bemalen)<br/>
+[Paletten mit gespeicherten Zeiten *(in "Arbeiten mit Zeiten in Paletten")*](./palettes/timing-with-palettes.md#paletten-mit-gespeicherten-zeiten)<br/>
+[Palettenseiten *(in "Abrufen von Paletten")*](./palettes/using-palettes.md#palettenseiten)<br/>
+[Palettes *(in "Key Profiles - Tastenbelegungen")*](./system-settings/key-profiles.md#palettes)<br/>
+[Palettes *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#palettes)<br/>
+[Pan und Tilt vertauschen *(in "Erweiterte Funktionen")*](./patching/fixture-personality-options.md#pan-und-tilt-vertauschen)<br/>
+[Parameter für einzelne Frames *(in "Keyframe-Shapes")*](./effects/key-frame-shapes.md#parameter-für-einzelne-frames)<br/>
+[Patchen mit Hilfe von RDM *(in "Geräte und Dimmer patchen")*](./patching/patching-new-fixtures-or-dimmers.md#patchen-mit-hilfe-von-rdm)<br/>
+[Patchen von Dimmern *(in "Geräte und Dimmer patchen")*](./patching/patching-new-fixtures-or-dimmers.md#patchen-von-dimmern)<br/>
+[Patchen von Movinglights *(in "Geräte und Dimmer patchen")*](./patching/patching-new-fixtures-or-dimmers.md#patchen-von-movinglights)<br/>
+[Patching (Patch-Optionen) *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#patching-patch-optionen)<br/>
+[PC Screen Layout *(in "T3")*](./about-the-consoles/t3.md#pc-screen-layout)<br/>
+[PC-Suite (Titan Go, Titan Simulator) *(in "Mehrbenutzer-Betrieb")*](./titan-basics/multi-user-operation.md#pc-suite-titan-go,-titan-simulator)<br/>
+[Phasensteuerung von Keyframe-Shapes durch Ai *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#phasensteuerung-von-keyframe-shapes-durch-ai)<br/>
+[Pioneer Bridge auf dem Pult *(in "Pioneer ProDJ-Decks mit Titan verknüpfen")*](./running-the-show/linking-pioneerdj-system-to-titan.md#pioneer-bridge-auf-dem-pult)<br/>
+[Pioneer Bridge auf einem separaten Computer *(in "Pioneer ProDJ-Decks mit Titan verknüpfen")*](./running-the-show/linking-pioneerdj-system-to-titan.md#pioneer-bridge-auf-einem-separaten-computer)<br/>
+[Pixelmapper-Effekte mit Mask FX stoppen *(in "Der Pixelmapper")*](./effects/pixel-mapper.md#pixelmapper-effekte-mit-mask-fx-stoppen)<br/>
+[Play Order *(in "Chaser-Optionen")*](./chases/chase-options.md#play-order)<br/>
+[Playback-Gruppen *(in "Einen Cue verwenden")*](./cues/cue-playback.md#playback-gruppen)<br/>
+[Playback-Gruppen *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#playback-gruppen)<br/>
+[Playbacks *(in "Diamond 7")*](./about-the-consoles/d7.md#playbacks)<br/>
+[Playbacks *(in "Diamond 9")*](./about-the-consoles/diamond.md#playbacks)<br/>
+[Playbacks seitenweise releasen *(in "Einen Cue verwenden")*](./cues/cue-playback.md#playbacks-seitenweise-releasen)<br/>
+[Playbacks steuern *(in "TNP im Stand-Alone-Pultbetrieb")*](./titan-net/tnp-console-mode.md#playbacks-steuern)<br/>
+[Playbacks, Gruppen und Macros hinzufügen *(in "Layouts")*](./controlling-fixtures/layouts.md#playbacks,-gruppen-und-macros-hinzufügen)<br/>
+[Position *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#position)<br/>
+[Position Overlay *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#position-overlay)<br/>
+[Priorität der Playbacks *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#priorität-der-playbacks)<br/>
+[Priority *(in "Playback-Optionen")*](./cues/playback-options.md#priority)<br/>
+[Programmieren einer Cueliste *(in "Anlegen einer Cueliste")*](./cue-lists/creating-a-cue-list.md#programmieren-einer-cueliste)<br/>
+[Programmieren mit mehreren Benutzern *(in "Mehrbenutzer-Betrieb")*](./titan-basics/multi-user-operation.md#programmieren-mit-mehreren-benutzern)<br/>
+[Programmieren von Cues *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#programmieren-von-cues)<br/>
+[Pulte für den Backup-Betrieb einrichten *(in "Backup und Mehrbenutzerbetrieb")*](./running-the-show/linking-consoles-for-multi-user-or-backup.md#pulte-für-den-backup-betrieb-einrichten)<br/>
+[Pulte für den Mehrbenutzerbetrieb einrichten *(in "Backup und Mehrbenutzerbetrieb")*](./running-the-show/linking-consoles-for-multi-user-or-backup.md#pulte-für-den-mehrbenutzerbetrieb-einrichten)<br/>
+[Pulte mit Motorfadern *(in "Einen Cue verwenden")*](./cues/cue-playback.md#pulte-mit-motorfadern)<br/>
+[Pulte ohne Motorfader *(in "Einen Cue verwenden")*](./cues/cue-playback.md#pulte-ohne-motorfader)
+  
+## Q
+[Quick Build -- Cues schnellspeichern *(in "Erstellen eines Cues")*](./cues/creating-a-cue.md#quick-build----cues-schnellspeichern)<br/>
+[Quick Palettes -- Schnelle Paletten ohne ausgewählte Geräte *(in "Abrufen von Paletten")*](./palettes/using-palettes.md#quick-palettes----schnelle-paletten-ohne-ausgewählte-geräte)
+  
+## R
+[Range mapping -- Zuweisen von Bereichen *(in "Das Patch ändern")*](./patching/changing-the-patch.md#range-mapping----zuweisen-von-bereichen)<br/>
+[Rasteroptionen *(in "Layouts")*](./controlling-fixtures/layouts.md#rasteroptionen)<br/>
+[Rate- und BPM-Master *(in "Zeiten bei Chasern")*](./chases/chase-timing.md#rate--und-bpm-master)<br/>
+[Raum und Bühne *(in "Das Rig einrichten")*](./capture-visualiser/setting-up-the-rig.md#raum-und-bühne)<br/>
+[Record -- Speichern *(in "Titan Befehlsreferenz")*](./titan-reference.md#record----speichern)<br/>
+[Recover -- Show Wiederherstellen *(in "Laden und Sichern von Shows")*](./titan-basics/loading-and-saving-shows.md#recover----show-wiederherstellen)<br/>
+[Reihenfolge und Priorität beim Abruf *(in "Pixelmapper - Beispiele")*](./effects/pixel-mapper-examples.md#reihenfolge-und-priorität-beim-abruf)<br/>
+[Release *(in "Einen Cue verwenden")*](./cues/cue-playback.md#release)<br/>
+[Release *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#release)<br/>
+[Release Mask (Release einzelner Attribute) *(in "Einen Cue verwenden")*](./cues/cue-playback.md#release-mask-release-einzelner-attribute)<br/>
+[Release Mask *(in "Playback-Optionen")*](./cues/playback-options.md#release-mask)<br/>
+[Release Time *(in "Playback-Optionen")*](./cues/playback-options.md#release-time)<br/>
+[RJ45-Netzwerk-Anschlüsse *(in "Pulte im Netzwerk betreiben")*](./networking/connecting-the-arena-to-a-network.md#rj45-netzwerk-anschlüsse)<br/>
+[Rückseite des Pultes, Anschlüsse *(in "Diamond 7")*](./about-the-consoles/d7.md#rückseite-des-pultes,-anschlüsse)<br/>
+[Rückseite des Pultes, Anschlüsse *(in "Diamond 9")*](./about-the-consoles/diamond.md#rückseite-des-pultes,-anschlüsse)<br/>
+[Run On Startup *(in "Playback-Optionen")*](./cues/playback-options.md#run-on-startup)
+  
+## S
+[sACN-Eigenschaften *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#sacn-eigenschaften)<br/>
+[Sample Region Overlay *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#sample-region-overlay)<br/>
+[Scene Master *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#scene-master)<br/>
+[Schaltflächen für die Einrichtung der Fenster *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#schaltflächen-für-die-einrichtung-der-fenster)<br/>
+[Schnellspeichern *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#schnellspeichern)<br/>
+[Schnellspeichern *(in "Erstellen von Paletten")*](./palettes/creating-palettes.md#schnellspeichern)<br/>
+[Schrittfolge und Versatz *(in "Zeiten für Cuelisten")*](./cue-lists/cue-list-timing.md#schrittfolge-und-versatz)<br/>
+[Selbsterstellte Gerätedateien *(in "Die Personalities (Gerätedateien)")*](./fixture-personalities.md#selbsterstellte-gerätedateien)<br/>
+[Select If -- Bedingte Auswahl *(in "Titan Befehlsreferenz")*](./titan-reference.md#select-if----bedingte-auswahl)<br/>
+[Setup *(in "TNP im Slave-Betrieb")*](./titan-net/tnp-slave-mode.md#setup)<br/>
+[Shape & Effect Speed *(in "Playback-Optionen")*](./cues/playback-options.md#shape-&-effect-speed)<br/>
+[Shape Behaviour *(in "Playback-Optionen")*](./cues/playback-options.md#shape-behaviour)<br/>
+[Shape Size *(in "Playback-Optionen")*](./cues/playback-options.md#shape-size)<br/>
+[Shape Tracking *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#shape-tracking)<br/>
+[Shape-Richtung *(in "Der Shape-Generator")*](./effects/shape-generator.md#shape-richtung)<br/>
+[Shapes im Fadermodus *(in "Spezielle Optionen")*](./effects/advanced-options.md#shapes-im-fadermodus)<br/>
+[Shapes mit Gruppen verknüpft *(in "Ändern von Shapes und Effekten")*](./effects/editing-shapes-and-effects.md#shapes-mit-gruppen-verknüpft)<br/>
+[Shapes neu synchronisieren *(in "Ändern von Shapes und Effekten")*](./effects/editing-shapes-and-effects.md#shapes-neu-synchronisieren)<br/>
+[Shapes stoppen mit Mask FX *(in "Der Shape-Generator")*](./effects/shape-generator.md#shapes-stoppen-mit-mask-fx)<br/>
+[Shapes und Effekte *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#shapes-und-effekte)<br/>
+[Shape-Verhalten: Overlay oder LTP *(in "Der Shape-Generator")*](./effects/shape-generator.md#shape-verhalten-overlay-oder-ltp)<br/>
+[Show Video Overlay *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#show-video-overlay)<br/>
+[Shows exportieren *(in "Capture Show-Daten")*](./capture-visualiser/capture-show-files.md#shows-exportieren)<br/>
+[Shows importieren *(in "Capture Show-Daten")*](./capture-visualiser/capture-show-files.md#shows-importieren)<br/>
+[Shows laden und speichern, weitere Einstellungen *(in "TNP im Stand-Alone-Pultbetrieb")*](./titan-net/tnp-console-mode.md#shows-laden-und-speichern,-weitere-einstellungen)<br/>
+[Shows zum Importieren mappen *(in "Show Library - das Show-Verzeichnis")*](./titan-basics/show-library.md#shows-zum-importieren-mappen)<br/>
+[Shutterblenden/Keystone *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#shutterblendenkeystone)<br/>
+[Sichern der Show *(in "Steuern der Show")*](./running-the-show.md#sichern-der-show)<br/>
+[Sichern existierender Shows auf USB-Sticks *(in "Laden und Sichern von Shows")*](./titan-basics/loading-and-saving-shows.md#sichern-existierender-shows-auf-usb-sticks)<br/>
+[Size Source *(in "Playback-Optionen")*](./cues/playback-options.md#size-source)<br/>
+[Snap -- Fangptionen *(in "Wiedergeben und Editieren von Timelines")*](./timelines/running-and-editing-timelines.md#snap----fangptionen)<br/>
+[Software-Lizenzierung *(in "Wiederherstellen/Neuinstallation")*](./system-settings/recovering-reinstalling-the-console.md#software-lizenzierung)<br/>
+[Spawn und Pre-Spool -- 'Aufspreizen' und 'Vorspulen' *(in "Pixelmapper - Beispiele")*](./effects/pixel-mapper-examples.md#spawn-und-pre-spool----'aufspreizen'-und-'vorspulen')<br/>
+[Speed *(in "Playback-Optionen")*](./cues/playback-options.md#speed)<br/>
+[Speed Multiplier *(in "Chaser-Optionen")*](./chases/chase-options.md#speed-multiplier)<br/>
+[Speed Source *(in "Playback-Optionen")*](./cues/playback-options.md#speed-source)<br/>
+[Speed- und Size-Master *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#speed--und-size-master)<br/>
+[Speed-Faktoren *(in "Zeiten bei Chasern")*](./chases/chase-timing.md#speed-faktoren)<br/>
+[Speichermodus/Record Mode *(in "Anlegen einer Cueliste")*](./cue-lists/creating-a-cue-list.md#speichermodusrecord-mode)<br/>
+[Speichern der Arbeitsumgebung *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#speichern-der-arbeitsumgebung)<br/>
+[Speichern einer Palette *(in "Erstellen von Paletten")*](./palettes/creating-palettes.md#speichern-einer-palette)<br/>
+[Speichern von Paletten, Gruppen und Cues *(in "Verwenden der Titan Remote-App")*](./remote-control/operating-the-remote.md#speichern-von-paletten,-gruppen-und-cues)<br/>
+[Speichern von Shapes in Paletten *(in "Der Shape-Generator")*](./effects/shape-generator.md#speichern-von-shapes-in-paletten)<br/>
+[Speichern von Zeiten für Attribute und Geräte *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#speichern-von-zeiten-für-attribute-und-geräte)<br/>
+[Start Time & Duration (Startzeit und Dauer) *(in "Timeline-Optionen")*](./timelines/timeline-options.md#start-time-&-duration-startzeit-und-dauer)<br/>
+[Steuerelemente für Shape und Layer *(in "Keyframe-Shapes")*](./effects/key-frame-shapes.md#steuerelemente-für-shape-und-layer)<br/>
+[Steuern einer Cueliste per Timecode *(in "Zeiten für Cuelisten")*](./cue-lists/cue-list-timing.md#steuern-einer-cueliste-per-timecode)<br/>
+[Steuern von Attributen *(in "Verwenden der Titan Remote-App")*](./remote-control/operating-the-remote.md#steuern-von-attributen)<br/>
+[Stromversorgung und USV *(in "Pulte im Netzwerk betreiben")*](./networking/connecting-the-arena-to-a-network.md#stromversorgung-und-usv)<br/>
+[Synergy Settings *(in "Das System-Menü")*](./system-settings/the-system-menu.md#synergy-settings)
+  
+## T
+[T1/T2 *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#t1t2)<br/>
+[T3 Anschlussfeld *(in "T3")*](./about-the-consoles/t3.md#t3-anschlussfeld)<br/>
+[T3 Wing *(in "Fader Wings")*](./about-the-consoles/fader-wings.md#t3-wing)<br/>
+[T3/Titan Mobile *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#t3titan-mobile)<br/>
+[Tab "Effects *(in "Chaser-Optionen")*](./chases/chase-options.md#tab-effects)<br/>
+[Tab "Effects" *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#tab-effects)<br/>
+[Tab "Effects" *(in "Playback-Optionen")*](./cues/playback-options.md#tab-effects)<br/>
+[Tab "Fader" *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#tab-fader)<br/>
+[Tab "Fader" *(in "Playback-Optionen")*](./cues/playback-options.md#tab-fader)<br/>
+[Tab "Fader" *(in "Timeline-Optionen")*](./timelines/timeline-options.md#tab-fader)<br/>
+[Tab "Handle" *(in "Chaser-Optionen")*](./chases/chase-options.md#tab-handle)<br/>
+[Tab "Handle" *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#tab-handle)<br/>
+[Tab "Handle" *(in "Playback-Optionen")*](./cues/playback-options.md#tab-handle)<br/>
+[Tab "Handle" *(in "Timeline-Optionen")*](./timelines/timeline-options.md#tab-handle)<br/>
+[Tab "Playback" *(in "Chaser-Optionen")*](./chases/chase-options.md#tab-playback)<br/>
+[Tab "Playback" *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#tab-playback)<br/>
+[Tab "Playback" *(in "Playback-Optionen")*](./cues/playback-options.md#tab-playback)<br/>
+[Tab "Release" *(in "Chaser-Optionen")*](./chases/chase-options.md#tab-release)<br/>
+[Tab "Release" *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#tab-release)<br/>
+[Tab "Release" *(in "Playback-Optionen")*](./cues/playback-options.md#tab-release)<br/>
+[Tab "Release" *(in "Timeline-Optionen")*](./timelines/timeline-options.md#tab-release)<br/>
+[Tab "Timecode" *(in "Timeline-Optionen")*](./timelines/timeline-options.md#tab-timecode)<br/>
+[Tab "Timeline" *(in "Timeline-Optionen")*](./timelines/timeline-options.md#tab-timeline)<br/>
+[Tab "Times" *(in "Chaser-Optionen")*](./chases/chase-options.md#tab-times)<br/>
+[Tab "Times" *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#tab-times)<br/>
+[Tab "Times" *(in "Playback-Optionen")*](./cues/playback-options.md#tab-times)<br/>
+[Tab "Times" *(in "Timeline-Optionen")*](./timelines/timeline-options.md#tab-times)<br/>
+[Tabellenansicht *(in "Einführung in Timelines")*](./timelines.md#tabellenansicht)<br/>
+[Tabellen-Ansicht *(in "Wiedergeben und Editieren von Timelines")*](./timelines/running-and-editing-timelines.md#tabellen-ansicht)<br/>
+[Tastatursyntax für Cuelisten *(in "Anlegen einer Cueliste")*](./cue-lists/creating-a-cue-list.md#tastatursyntax-für-cuelisten)<br/>
+[Tastenbelegungen für einzelne Speicherplätze *(in "Key Profiles - Tastenbelegungen")*](./system-settings/key-profiles.md#tastenbelegungen-für-einzelne-speicherplätze)<br/>
+[Tastenfunktionen *(in "Key Profiles - Tastenbelegungen")*](./system-settings/key-profiles.md#tastenfunktionen)<br/>
+[Tastenkombinationen *(in "Die Tasten der Konsole")*](./titan-basics/front-panel-buttons.md#tastenkombinationen)<br/>
+[Tastenkombinationen zur Fensterauswahl *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#tastenkombinationen-zur-fensterauswahl)<br/>
+[Tastenprofile für Cuelisten *(in "Abrufen")*](./cue-lists/cue-list-playback.md#tastenprofile-für-cuelisten)<br/>
+[Teile aus anderen Shows importieren *(in "Laden und Sichern von Shows")*](./titan-basics/loading-and-saving-shows.md#teile-aus-anderen-shows-importieren)<br/>
+[Temporäre Release-Maske *(in "Einen Cue verwenden")*](./cues/cue-playback.md#temporäre-release-maske)<br/>
+[Tiger Touch Wing *(in "Fader Wings")*](./about-the-consoles/fader-wings.md#tiger-touch-wing)<br/>
+[Time -- Optionen für Zeiten *(in "Timeline-Optionen")*](./timelines/timeline-options.md#time----optionen-für-zeiten)<br/>
+[Timecode *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#timecode)<br/>
+[Timecode Source *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#timecode-source)<br/>
+[Timecode verbinden und steuern *(in "Einführung in Timelines")*](./timelines.md#timecode-verbinden-und-steuern)<br/>
+[Timecode-Quelle wählen *(in "Einführung in Timelines")*](./timelines.md#timecode-quelle-wählen)<br/>
+[Timeline *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#timeline)<br/>
+[Times -- Zeiten *(in "Titan Befehlsreferenz")*](./titan-reference.md#times----zeiten)<br/>
+[Times (Zeiten) *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#times-zeiten)<br/>
+[Titan Healthcheck -- die Eigendiagnose *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#titan-healthcheck----die-eigendiagnose)<br/>
+[Titan Mobile Anschlussfeld *(in "Das Titan Mobile")*](./about-the-consoles/titan-mobile.md#titan-mobile-anschlussfeld)<br/>
+[Titan Mobile Wing *(in "Fader Wings")*](./about-the-consoles/fader-wings.md#titan-mobile-wing)<br/>
+[Titan Telemetry *(in "Das System-Menü")*](./system-settings/the-system-menu.md#titan-telemetry)<br/>
+[Titan und das Pioneer-System verbinden *(in "Pioneer ProDJ-Decks mit Titan verknüpfen")*](./running-the-show/linking-pioneerdj-system-to-titan.md#titan-und-das-pioneer-system-verbinden)<br/>
+[TitanNet Security - Netzwerksicherheit *(in "Das System-Menü")*](./system-settings/the-system-menu.md#titannet-security---netzwerksicherheit)<br/>
+[Titan-Pult steuert Geräte über Art-Net (und ggf. über DMX) *(in "Grundlagen der IP-Adressierung")*](./networking/a-quick-guide-to-ip-addressing.md#titan-pult-steuert-geräte-über-art-net-und-ggf.-über-dmx)<br/>
+[Titan-Pult und TNP, alle Ausgänge Standard-DMX *(in "Grundlagen der IP-Adressierung")*](./networking/a-quick-guide-to-ip-addressing.md#titan-pult-und-tnp,-alle-ausgänge-standard-dmx)<br/>
+[Titan-Pult und TNP, Ausgang über Art-Net (und DMX) *(in "Grundlagen der IP-Adressierung")*](./networking/a-quick-guide-to-ip-addressing.md#titan-pult-und-tnp,-ausgang-über-art-net-und-dmx)<br/>
+[Tools *(in "TNP im Slave-Betrieb")*](./titan-net/tnp-slave-mode.md#tools)<br/>
+[Trackball (nur beim Diamond 9 und Sapphire Touch) *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#trackball-nur-beim-diamond-9-und-sapphire-touch)<br/>
+[Tracking *(in "Abrufen")*](./cue-lists/cue-list-playback.md#tracking)<br/>
+[Tracking *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#tracking)<br/>
+[Tracking von Shapes in Cuelisten *(in "Anlegen einer Cueliste")*](./cue-lists/creating-a-cue-list.md#tracking-von-shapes-in-cuelisten)<br/>
+[Tracks *(in "Einführung in Timelines")*](./timelines.md#tracks)<br/>
+[Tracks mit Workspace und Macros verknüpfen *(in "Das Fenster Set-Liste")*](./running-the-show/set-list-window.md#tracks-mit-workspace-und-macros-verknüpfen)<br/>
+[Trigger *(in "Einführung in Timelines")*](./timelines.md#trigger)<br/>
+[Trigger manuell hinzufügen *(in "Eine Timeline speichern")*](./timelines/creating-a-timeline.md#trigger-manuell-hinzufügen)<br/>
+[Triggers *(in "Das System-Menü")*](./system-settings/the-system-menu.md#triggers)
+  
+## Ü
+[Überschreiben von Palettenzeiten *(in "Arbeiten mit Zeiten in Paletten")*](./palettes/timing-with-palettes.md#überschreiben-von-palettenzeiten)<br/>
+[Übersicht über die Kanäle: Das 'Channel Grid'-Fenster *(in "Anzeigen/Verändern von Attribut-Werten")*](./controlling-fixtures/viewing-and-editing-fixture-values.md#übersicht-über-die-kanäle-das-'channel-grid'-fenster)
+  
+## U
+[Umschalten zwischen Layouts *(in "Layouts")*](./controlling-fixtures/layouts.md#umschalten-zwischen-layouts)<br/>
+[Undo/Redo -- Rückgängig machen/Wiederholen *(in "Andere Bereiche der Anzeige")*](./titan-basics/other-parts-of-the-touch-screen.md#undoredo----rückgängig-machenwiederholen)<br/>
+[Unter Verwendung der 'Unfold'-Funktion *(in "Zeiten bei Chasern")*](./chases/chase-timing.md#unter-verwendung-der-'unfold'-funktion)<br/>
+[Unter Verwendung des 'Playback View'-Fensters: *(in "Zeiten bei Chasern")*](./chases/chase-timing.md#unter-verwendung-des-'playback-view'-fensters)<br/>
+[Update und Cue-Tracking *(in "Editieren")*](./cue-lists/editing-cue-lists.md#update-und-cue-tracking)<br/>
+[Update-Modus *(in "Editieren")*](./cue-lists/editing-cue-lists.md#update-modus)<br/>
+[Updaten der Personalities der Titan PC Suite (T1, T2, T3, Titan Mobile und Titan Simulator) *(in "Die Personalities (Gerätedateien)")*](./fixture-personalities.md#updaten-der-personalities-der-titan-pc-suite-t1,-t2,-t3,-titan-mobile-und-titan-simulator)<br/>
+[Updaten der Personalities eines Pultes *(in "Die Personalities (Gerätedateien)")*](./fixture-personalities.md#updaten-der-personalities-eines-pultes)<br/>
+[Updaten der Titan PC-Suite (Titan Go und Titan Simulator) *(in "Aktualisieren der Software")*](./system-settings/upgrading-the-software.md#updaten-der-titan-pc-suite-titan-go-und-titan-simulator)<br/>
+[Updaten eine Pultes mit dem Recovery Installer *(in "Aktualisieren der Software")*](./system-settings/upgrading-the-software.md#updaten-eine-pultes-mit-dem-recovery-installer)<br/>
+[Updaten eines Pultes per Upgrade-Datei *(in "Aktualisieren der Software")*](./system-settings/upgrading-the-software.md#updaten-eines-pultes-per-upgrade-datei)<br/>
+[Updaten von Cues *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#updaten-von-cues)<br/>
+[Upgraden der Panel-Firmware per USB Expert *(in "Aktualisieren der Software")*](./system-settings/upgrading-the-software.md#upgraden-der-panel-firmware-per-usb-expert)<br/>
+[User Settings - Benutzereinstellungen *(in "Das System-Menü")*](./system-settings/the-system-menu.md#user-settings---benutzereinstellungen)<br/>
+[Users -- Benutzer *(in "Mehrbenutzer-Betrieb")*](./titan-basics/multi-user-operation.md#users----benutzer)
+  
+## V
+[Verbinden des Mobilgeräts *(in "Einrichten der Fernsteuerung")*](./remote-control/setting-up-the-remote.md#verbinden-des-mobilgeräts)<br/>
+[Verbinden eines Playbacks mit der Steuerung *(in "Abrufen")*](./chases/chase-playback.md#verbinden-eines-playbacks-mit-der-steuerung)<br/>
+[Verbinden mit anderen TitanNet-Sessions *(in "Mehrbenutzer-Betrieb")*](./titan-basics/multi-user-operation.md#verbinden-mit-anderen-titannet-sessions)<br/>
+[Verbinden mit einem Ai-Server *(in "Einrichtung")*](./synergy/setting-up.md#verbinden-mit-einem-ai-server)<br/>
+[Verbinden mit Prism Zero *(in "Einrichtung")*](./synergy/setting-up.md#verbinden-mit-prism-zero)<br/>
+[Vergeben von Attribut-Zeiten für einzelne Schritte *(in "Zeiten bei Chasern")*](./chases/chase-timing.md#vergeben-von-attribut-zeiten-für-einzelne-schritte)<br/>
+[Vergeben von Bezeichnern für einzelne Schritte *(in "Anlegen einer Cueliste")*](./cue-lists/creating-a-cue-list.md#vergeben-von-bezeichnern-für-einzelne-schritte)<br/>
+[Vergeben von Legenden und Halos für Tracks *(in "Wiedergeben und Editieren von Timelines")*](./timelines/running-and-editing-timelines.md#vergeben-von-legenden-und-halos-für-tracks)<br/>
+[Verlagerung und Layer-Eigenschaften *(in "Pixelmapper - Beispiele")*](./effects/pixel-mapper-examples.md#verlagerung-und-layer-eigenschaften)<br/>
+[Verriegeln der Seitenumschaltung *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#verriegeln-der-seitenumschaltung)<br/>
+[Verschieben eines Cues *(in "Kopieren, verschieben, verlinken, löschen")*](./cues/copying-moving-linking-and-deleting.md#verschieben-eines-cues)<br/>
+[Verwenden der 'Move'-Funktion *(in "Steuern der Show")*](./running-the-show.md#verwenden-der-'move'-funktion)<br/>
+[Verwenden des Titan Simulator *(in "Der Titan Simulator")*](./titan-basics/titan-simulator.md#verwenden-des-titan-simulator)<br/>
+[Verwenden des Virtuellen Panels mit dem Pult *(in "Der Titan Simulator")*](./titan-basics/titan-simulator.md#verwenden-des-virtuellen-panels-mit-dem-pult)<br/>
+[Verwenden von Faderwings *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#verwenden-von-faderwings)<br/>
+[Verwenden von Geräte-Gruppen *(in "Geräte-Gruppen")*](./controlling-fixtures/fixture-groups.md#verwenden-von-geräte-gruppen)<br/>
+[Verwenden von Shapes in Cues *(in "Der Shape-Generator")*](./effects/shape-generator.md#verwenden-von-shapes-in-cues)<br/>
+[Verwenden von Shapes und Effekten in Cues *(in "Erstellen eines Cues")*](./cues/creating-a-cue.md#verwenden-von-shapes-und-effekten-in-cues)<br/>
+[Verwendung des Layout-Editors mit Synergy *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#verwendung-des-layout-editors-mit-synergy)<br/>
+[Video-Vorschau (nur beim Diamond 9) *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#video-vorschau-nur-beim-diamond-9)<br/>
+[Virtuelle Fader *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#virtuelle-fader)<br/>
+[Visualiser *(in "Andere Bereiche der Anzeige")*](./titan-basics/other-parts-of-the-touch-screen.md#visualiser)<br/>
+[Vorderseite des Pultes *(in "Diamond 7")*](./about-the-consoles/d7.md#vorderseite-des-pultes)<br/>
+[Vorderseite des Pultes *(in "Diamond 9")*](./about-the-consoles/diamond.md#vorderseite-des-pultes)<br/>
+[Vorschau mit dem Media Viewer *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#vorschau-mit-dem-media-viewer)
+  
+## W
+[Wechsel der Playback-Seiten *(in "Einen Cue verwenden")*](./cues/cue-playback.md#wechsel-der-playback-seiten)<br/>
+[Weitere Anschlussmöglichkeiten *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#weitere-anschlussmöglichkeiten)<br/>
+[Weitere Optionen zu Zeiten *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#weitere-optionen-zu-zeiten)<br/>
+[Weitere Release-Optionen *(in "Einen Cue verwenden")*](./cues/cue-playback.md#weitere-release-optionen)<br/>
+[Weitere Werkzeuge des Layout-Editors *(in "Pixelmapper - Beispiele")*](./effects/pixel-mapper-examples.md#weitere-werkzeuge-des-layout-editors)<br/>
+[Weiterführende Informationen zu Art-Net *(in "Steuern von Geräten über Netzwerk")*](./networking/controlling-fixtures-over-a-network.md#weiterführende-informationen-zu-art-net)<br/>
+[Wenn das Netzwerk Verbindung zum Internet hat *(in "Grundlagen der IP-Adressierung")*](./networking/a-quick-guide-to-ip-addressing.md#wenn-das-netzwerk-verbindung-zum-internet-hat)<br/>
+[Werkzeugbuttons *(in "Einführung in Timelines")*](./timelines.md#werkzeugbuttons)<br/>
+[Werte für Release / Power On programmieren *(in "Einen Cue verwenden")*](./cues/cue-playback.md#werte-für-release--power-on-programmieren)<br/>
+[Werte in mehreren Cues gleichzeitig aktualisieren *(in "Editieren")*](./cue-lists/editing-cue-lists.md#werte-in-mehreren-cues-gleichzeitig-aktualisieren)<br/>
+[Wheels *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#wheels)<br/>
+[Windows-Einstellungen für die Titan PC-Suite *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#windows-einstellungen-für-die-titan-pc-suite)<br/>
+[Wipe (Löschen) *(in "Das System-Menü")*](./system-settings/the-system-menu.md#wipe-löschen)
+  
+## X
+[XFade *(in "Chaser-Optionen")*](./chases/chase-options.md#xfade)
+  
+## Z
+[Zeit- und Überblendoptionen für Cuelisten *(in "Zeiten für Cuelisten")*](./cue-lists/cue-list-timing.md#zeit--und-überblendoptionen-für-cuelisten)<br/>
+[Zeit-Optionen *(in "Zeiten bei Chasern")*](./chases/chase-timing.md#zeit-optionen)<br/>
+[Zu steuernde Geräte auswählen *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#zu-steuernde-geräte-auswählen)<br/>
+[Zufallseffekte *(in "Pixelmapper - Beispiele")*](./effects/pixel-mapper-examples.md#zufallseffekte)<br/>
+[Zurücksetzen der Geräteoptionen auf Vorgabewerte *(in "Erweiterte Funktionen")*](./patching/fixture-personality-options.md#zurücksetzen-der-geräteoptionen-auf-vorgabewerte)

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/alpha-index.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/alpha-index.md
@@ -28,9 +28,9 @@ import Video from '@site/src/components/video.tsx';
 ## Ä
 [Ändern der DMX-Adresse im Patch-Menü *(in "Das Patch ändern")*](./patching/changing-the-patch.md#ändern-der-dmx-adresse-im-patch-menü)<br/>
 [Ändern der DMX-Adresse in der Patch-Ansicht *(in "Das Patch ändern")*](./patching/changing-the-patch.md#ändern-der-dmx-adresse-in-der-patch-ansicht)<br/>
-[Ändern der Einstellungen des Luminex-Switches im D9 *(in "Pulte im Netzwerk betreiben")*](./networking/connecting-the-arena-to-a-network.md#ändern-der-einstellungen-des-luminex-switches-im-d9)<br/>
+[Ändern der Einstellungen des Luminex-Switches im D9 (erste Serie) *(in "Pulte im Netzwerk betreiben")*](./networking/connecting-the-arena-to-a-network.md#ändern-der-einstellungen-des-luminex-switches-im-d9-erste-serie)<br/>
 [Ändern der Gerätereihenfolge eines Shapes *(in "Ändern von Shapes und Effekten")*](./effects/editing-shapes-and-effects.md#ändern-der-gerätereihenfolge-eines-shapes)<br/>
-[Ändern der IP-Adresse des Titan Network Switch (TNS) beim D7 oder Arena *(in "Pulte im Netzwerk betreiben")*](./networking/connecting-the-arena-to-a-network.md#ändern-der-ip-adresse-des-titan-network-switch-tns-beim-d7-oder-arena)<br/>
+[Ändern der IP-Adresse des Titan Network Switch (TNS) beim D9 (ab 2025), D7 oder Arena *(in "Pulte im Netzwerk betreiben")*](./networking/connecting-the-arena-to-a-network.md#ändern-der-ip-adresse-des-titan-network-switch-tns-beim-d9-ab-2025,-d7-oder-arena)<br/>
 [Ändern der Reihenfolge der Geräte *(in "Zeiten für Cues")*](./cues/cue-timing.md#ändern-der-reihenfolge-der-geräte)<br/>
 [Ändern der Richtung eines Chasers *(in "Abrufen")*](./chases/chase-playback.md#ändern-der-richtung-eines-chasers)<br/>
 [Ändern der Verteilung eines Shapes (mehrere Geräte) *(in "Der Shape-Generator")*](./effects/shape-generator.md#ändern-der-verteilung-eines-shapes-mehrere-geräte)<br/>
@@ -70,7 +70,7 @@ import Video from '@site/src/components/video.tsx';
 [Anzeigeoptionen für das Playback Groups-Fenster *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#anzeigeoptionen-für-das-playback-groups-fenster)<br/>
 [Anzeigeoptionen für den Tracking View *(in "Editieren")*](./cue-lists/editing-cue-lists.md#anzeigeoptionen-für-den-tracking-view)<br/>
 [Arbeitsweise des Pultes beim Programmieren *(in "Erstellen eines Cues")*](./cues/creating-a-cue.md#arbeitsweise-des-pultes-beim-programmieren)<br/>
-[Art-Net-Eigenschaften *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#art-net-eigenschaften)<br/>
+[Art-Net-Eigenschaften *(in "DMX-Einstellungen")*](./system-settings/dmx-output-mapping.md#art-net-eigenschaften)<br/>
 [Assign Masters *(in "Das System-Menü")*](./system-settings/the-system-menu.md#assign-masters)<br/>
 [Attribute invertieren *(in "Erweiterte Funktionen")*](./patching/fixture-personality-options.md#attribute-invertieren)<br/>
 [Attribute limitieren *(in "Erweiterte Funktionen")*](./patching/fixture-personality-options.md#attribute-limitieren)<br/>
@@ -143,6 +143,11 @@ import Video from '@site/src/components/video.tsx';
 [Cycles *(in "Der Shape-Generator")*](./effects/shape-generator.md#cycles)
   
 ## D
+[D3 Touch *(in "D3")*](./about-the-consoles/d3.md#d3-touch)<br/>
+[D3 Wing *(in "D3")*](./about-the-consoles/d3.md#d3-wing)<br/>
+[D3-010 *(in "D3")*](./about-the-consoles/d3.md#d3-010)<br/>
+[D3-110 *(in "D3")*](./about-the-consoles/d3.md#d3-110)<br/>
+[D3-Core *(in "D3")*](./about-the-consoles/d3.md#d3-core)<br/>
 [Das ausgewählte Gerät bei Fix+1/Fix-1 hervorheben *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#das-ausgewählte-gerät-bei-fix+1fix-1-hervorheben)<br/>
 [Das Clear-Menü *(in "Anwählen von Geräten und Dimmern")*](./controlling-fixtures.md#das-clear-menü)<br/>
 [Das Fenster "Intensity View" *(in "Anzeigen/Verändern von Attribut-Werten")*](./controlling-fixtures/viewing-and-editing-fixture-values.md#das-fenster-intensity-view)<br/>
@@ -158,6 +163,7 @@ import Video from '@site/src/components/video.tsx';
 [Deaktivieren eines Cues *(in "Editieren")*](./cue-lists/editing-cue-lists.md#deaktivieren-eines-cues)<br/>
 [Deaktivieren einzelner Geräte mit Off *(in "Einen Cue verwenden")*](./cues/cue-playback.md#deaktivieren-einzelner-geräte-mit-off)<br/>
 [Deaktivieren von Attributen in Cues mit "Off" *(in "Editieren von Cues")*](./cues/editing-cues.md#deaktivieren-von-attributen-in-cues-mit-off)<br/>
+[Default-Ausgangskonfiguration *(in "DMX-Einstellungen")*](./system-settings/dmx-output-mapping.md#default-ausgangskonfiguration)<br/>
 [Delay In/Fade In/Fade Out *(in "Playback-Optionen")*](./cues/playback-options.md#delay-infade-infade-out)<br/>
 [Delete -- Löschen *(in "Titan Befehlsreferenz")*](./titan-reference.md#delete----löschen)<br/>
 [Den Patch vom Pult nach Capture übertragen *(in "Mit einer externen Capture-Vollversion verbinden")*](./capture-visualiser/linking-the-console-to-stand-alone-capture.md#den-patch-vom-pult-nach-capture-übertragen)<br/>
@@ -197,11 +203,11 @@ import Video from '@site/src/components/video.tsx';
 [Display *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#display)<br/>
 [Display Setup - Bildschirmeinrichtung *(in "Das System-Menü")*](./system-settings/the-system-menu.md#display-setup---bildschirmeinrichtung)<br/>
 [Display-Ansicht speichern *(in "Steuern der Show")*](./running-the-show.md#display-ansicht-speichern)<br/>
+[DMX /sACN Input *(in "DMX-Einstellungen")*](./system-settings/dmx-output-mapping.md#dmx-sacn-input)<br/>
 [DMX anschließen *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#dmx-anschließen)<br/>
-[DMX Merge -- Network DMX Node Settings *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#dmx-merge----network-dmx-node-settings)<br/>
+[DMX Merge -- Network DMX Node Settings *(in "DMX-Einstellungen")*](./system-settings/dmx-output-mapping.md#dmx-merge----network-dmx-node-settings)<br/>
 [DMX Settings *(in "Das System-Menü")*](./system-settings/the-system-menu.md#dmx-settings)<br/>
-[DMX-Eigenschaften *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#dmx-eigenschaften)<br/>
-[DMX-Overview *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#dmx-overview)
+[DMX-Overview *(in "DMX-Einstellungen")*](./system-settings/dmx-output-mapping.md#dmx-overview)
   
 ## E
 [Editieren der Zeiten im Programmer *(in "Zeiten für Cues")*](./cues/cue-timing.md#editieren-der-zeiten-im-programmer)<br/>
@@ -219,6 +225,7 @@ import Video from '@site/src/components/video.tsx';
 [Effects (Effekte) *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#effects-effekte)<br/>
 [Effekte und Layer kombinieren *(in "Pixelmapper - Beispiele")*](./effects/pixel-mapper-examples.md#effekte-und-layer-kombinieren)<br/>
 [Ein CITP-Beispiel *(in "Verwenden von Geräten mit CITP")*](./networking/using-active-fixtures.md#ein-citp-beispiel)<br/>
+[Ein Touch-Panel verbinden *(in "Verwenden von Touch-Panels")*](./remote-control/programming-touch-panels.md#ein-touch-panel-verbinden)<br/>
 [Eine Cueliste deaktivieren *(in "Abrufen")*](./cue-lists/cue-list-playback.md#eine-cueliste-deaktivieren)<br/>
 [Eine Cueliste verschieben oder kopieren *(in "Kopieren, verschieben, verlinken, löschen")*](./cue-lists/copying-moving-linking-and-deleting.md#eine-cueliste-verschieben-oder-kopieren)<br/>
 [Eine Gruppe speichern *(in "Geräte-Gruppen")*](./controlling-fixtures/fixture-groups.md#eine-gruppe-speichern)<br/>
@@ -240,7 +247,7 @@ import Video from '@site/src/components/video.tsx';
 [Eingeben von Attributwerten mit den @-Tasten *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#eingeben-von-attributwerten-mit-den--tasten)<br/>
 [Eingeben von Überblendzeiten für einzelne Attribute *(in "Zeiten für Cues")*](./cues/cue-timing.md#eingeben-von-überblendzeiten-für-einzelne-attribute)<br/>
 [Eingeschränkter Zugriff mit dem Venue Mode *(in "Steuern der Show")*](./running-the-show.md#eingeschränkter-zugriff-mit-dem-venue-mode)<br/>
-[Einrichten der DMX-Ausgänge *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#einrichten-der-dmx-ausgänge)<br/>
+[Einrichten der DMX-Ausgänge *(in "DMX-Einstellungen")*](./system-settings/dmx-output-mapping.md#einrichten-der-dmx-ausgänge)<br/>
 [Einrichten der DMX-Ausgänge *(in "Steuern von Geräten über Netzwerk")*](./networking/controlling-fixtures-over-a-network.md#einrichten-der-dmx-ausgänge)<br/>
 [Einrichten der externen Steuerung *(in "Externe Trigger")*](./running-the-show/midi-dmx-or-audio-triggering.md#einrichten-der-externen-steuerung)<br/>
 [Einrichten der Show in Ai *(in "Einrichtung")*](./synergy/setting-up.md#einrichten-der-show-in-ai)<br/>
@@ -410,7 +417,7 @@ import Video from '@site/src/components/video.tsx';
 [Mergen/verschmelzen einzelner Werte *(in "Editieren")*](./cue-lists/editing-cue-lists.md#mergenverschmelzen-einzelner-werte)<br/>
 [MIDI Show Control *(in "Externe Trigger")*](./running-the-show/midi-dmx-or-audio-triggering.md#midi-show-control)<br/>
 [Mini-Display (Nur beim Arena) *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#mini-display-nur-beim-arena)<br/>
-[Modul-Eigenschaften der DMX-Ausgabe *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#modul-eigenschaften-der-dmx-ausgabe)<br/>
+[Modul-Eigenschaften der DMX-Ausgabe *(in "DMX-Einstellungen")*](./system-settings/dmx-output-mapping.md#modul-eigenschaften-der-dmx-ausgabe)<br/>
 [Move In Dark (MID) - Funktionen *(in "Abrufen")*](./cue-lists/cue-list-playback.md#move-in-dark-mid---funktionen)<br/>
 [Move In Dark *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#move-in-dark)
   
@@ -446,6 +453,7 @@ import Video from '@site/src/components/video.tsx';
 [PC Screen Layout *(in "T3")*](./about-the-consoles/t3.md#pc-screen-layout)<br/>
 [PC-Suite (Titan Go, Titan Simulator) *(in "Mehrbenutzer-Betrieb")*](./titan-basics/multi-user-operation.md#pc-suite-titan-go,-titan-simulator)<br/>
 [Phasensteuerung von Keyframe-Shapes durch Ai *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#phasensteuerung-von-keyframe-shapes-durch-ai)<br/>
+[Physische DMX-Eigenschaften *(in "DMX-Einstellungen")*](./system-settings/dmx-output-mapping.md#physische-dmx-eigenschaften)<br/>
 [Pioneer Bridge auf dem Pult *(in "Pioneer ProDJ-Decks mit Titan verknüpfen")*](./running-the-show/linking-pioneerdj-system-to-titan.md#pioneer-bridge-auf-dem-pult)<br/>
 [Pioneer Bridge auf einem separaten Computer *(in "Pioneer ProDJ-Decks mit Titan verknüpfen")*](./running-the-show/linking-pioneerdj-system-to-titan.md#pioneer-bridge-auf-einem-separaten-computer)<br/>
 [Pixelmapper-Effekte mit Mask FX stoppen *(in "Der Pixelmapper")*](./effects/pixel-mapper.md#pixelmapper-effekte-mit-mask-fx-stoppen)<br/>
@@ -464,6 +472,8 @@ import Video from '@site/src/components/video.tsx';
 [Programmieren einer Cueliste *(in "Anlegen einer Cueliste")*](./cue-lists/creating-a-cue-list.md#programmieren-einer-cueliste)<br/>
 [Programmieren mit mehreren Benutzern *(in "Mehrbenutzer-Betrieb")*](./titan-basics/multi-user-operation.md#programmieren-mit-mehreren-benutzern)<br/>
 [Programmieren von Cues *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#programmieren-von-cues)<br/>
+[Programmieren von Macros für das Touch-Panel *(in "Verwenden von Touch-Panels")*](./remote-control/programming-touch-panels.md#programmieren-von-macros-für-das-touch-panel)<br/>
+[Programmieren von Playbacks für das Touch-Panel *(in "Verwenden von Touch-Panels")*](./remote-control/programming-touch-panels.md#programmieren-von-playbacks-für-das-touch-panel)<br/>
 [Pulte für den Backup-Betrieb einrichten *(in "Backup und Mehrbenutzerbetrieb")*](./running-the-show/linking-consoles-for-multi-user-or-backup.md#pulte-für-den-backup-betrieb-einrichten)<br/>
 [Pulte für den Mehrbenutzerbetrieb einrichten *(in "Backup und Mehrbenutzerbetrieb")*](./running-the-show/linking-consoles-for-multi-user-or-backup.md#pulte-für-den-mehrbenutzerbetrieb-einrichten)<br/>
 [Pulte mit Motorfadern *(in "Einen Cue verwenden")*](./cues/cue-playback.md#pulte-mit-motorfadern)<br/>
@@ -492,7 +502,7 @@ import Video from '@site/src/components/video.tsx';
 [Run On Startup *(in "Playback-Optionen")*](./cues/playback-options.md#run-on-startup)
   
 ## S
-[sACN-Eigenschaften *(in "DMX-Ausgänge einrichten")*](./system-settings/dmx-output-mapping.md#sacn-eigenschaften)<br/>
+[sACN-Eigenschaften *(in "DMX-Einstellungen")*](./system-settings/dmx-output-mapping.md#sacn-eigenschaften)<br/>
 [Sample Region Overlay *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#sample-region-overlay)<br/>
 [Scene Master *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#scene-master)<br/>
 [Schaltflächen für die Einrichtung der Fenster *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#schaltflächen-für-die-einrichtung-der-fenster)<br/>
@@ -536,6 +546,7 @@ import Video from '@site/src/components/video.tsx';
 [Speichern von Paletten, Gruppen und Cues *(in "Verwenden der Titan Remote-App")*](./remote-control/operating-the-remote.md#speichern-von-paletten,-gruppen-und-cues)<br/>
 [Speichern von Shapes in Paletten *(in "Der Shape-Generator")*](./effects/shape-generator.md#speichern-von-shapes-in-paletten)<br/>
 [Speichern von Zeiten für Attribute und Geräte *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#speichern-von-zeiten-für-attribute-und-geräte)<br/>
+[Sperren/Entsperren des Touch-Panels *(in "Verwenden von Touch-Panels")*](./remote-control/programming-touch-panels.md#sperrenentsperren-des-touch-panels)<br/>
 [Start Time & Duration (Startzeit und Dauer) *(in "Timeline-Optionen")*](./timelines/timeline-options.md#start-time-&-duration-startzeit-und-dauer)<br/>
 [Steuerelemente für Shape und Layer *(in "Keyframe-Shapes")*](./effects/key-frame-shapes.md#steuerelemente-für-shape-und-layer)<br/>
 [Steuern einer Cueliste per Timecode *(in "Zeiten für Cuelisten")*](./cue-lists/cue-list-timing.md#steuern-einer-cueliste-per-timecode)<br/>
@@ -544,9 +555,11 @@ import Video from '@site/src/components/video.tsx';
 [Synergy Settings *(in "Das System-Menü")*](./system-settings/the-system-menu.md#synergy-settings)
   
 ## T
+[T1 *(in "T1 und T2")*](./about-the-consoles/t1-and-t2.md#t1)<br/>
 [T1/T2 *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#t1t2)<br/>
+[T2 *(in "T1 und T2")*](./about-the-consoles/t1-and-t2.md#t2)<br/>
 [T3 Anschlussfeld *(in "T3")*](./about-the-consoles/t3.md#t3-anschlussfeld)<br/>
-[T3 Wing *(in "Fader Wings")*](./about-the-consoles/fader-wings.md#t3-wing)<br/>
+[T3 Wing *(in "T3")*](./about-the-consoles/t3.md#t3-wing)<br/>
 [T3/Titan Mobile *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#t3titan-mobile)<br/>
 [Tab "Effects *(in "Chaser-Optionen")*](./chases/chase-options.md#tab-effects)<br/>
 [Tab "Effects" *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#tab-effects)<br/>
@@ -581,7 +594,6 @@ import Video from '@site/src/components/video.tsx';
 [Tastenprofile für Cuelisten *(in "Abrufen")*](./cue-lists/cue-list-playback.md#tastenprofile-für-cuelisten)<br/>
 [Teile aus anderen Shows importieren *(in "Laden und Sichern von Shows")*](./titan-basics/loading-and-saving-shows.md#teile-aus-anderen-shows-importieren)<br/>
 [Temporäre Release-Maske *(in "Einen Cue verwenden")*](./cues/cue-playback.md#temporäre-release-maske)<br/>
-[Tiger Touch Wing *(in "Fader Wings")*](./about-the-consoles/fader-wings.md#tiger-touch-wing)<br/>
 [Time -- Optionen für Zeiten *(in "Timeline-Optionen")*](./timelines/timeline-options.md#time----optionen-für-zeiten)<br/>
 [Timecode *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#timecode)<br/>
 [Timecode Source *(in "Cuelisten-Optionen")*](./cue-lists/cue-list-options.md#timecode-source)<br/>
@@ -592,7 +604,8 @@ import Video from '@site/src/components/video.tsx';
 [Times (Zeiten) *(in "User Settings - Benutzereinstellungen")*](./system-settings/user-settings.md#times-zeiten)<br/>
 [Titan Healthcheck -- die Eigendiagnose *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#titan-healthcheck----die-eigendiagnose)<br/>
 [Titan Mobile Anschlussfeld *(in "Das Titan Mobile")*](./about-the-consoles/titan-mobile.md#titan-mobile-anschlussfeld)<br/>
-[Titan Mobile Wing *(in "Fader Wings")*](./about-the-consoles/fader-wings.md#titan-mobile-wing)<br/>
+[Titan Mobile Wing *(in "Das Titan Mobile")*](./about-the-consoles/titan-mobile.md#titan-mobile-wing)<br/>
+[Titan One dongle *(in "T1 und T2")*](./about-the-consoles/t1-and-t2.md#titan-one-dongle)<br/>
 [Titan Telemetry *(in "Das System-Menü")*](./system-settings/the-system-menu.md#titan-telemetry)<br/>
 [Titan und das Pioneer-System verbinden *(in "Pioneer ProDJ-Decks mit Titan verknüpfen")*](./running-the-show/linking-pioneerdj-system-to-titan.md#titan-und-das-pioneer-system-verbinden)<br/>
 [TitanNet Security - Netzwerksicherheit *(in "Das System-Menü")*](./system-settings/the-system-menu.md#titannet-security---netzwerksicherheit)<br/>
@@ -646,7 +659,7 @@ import Video from '@site/src/components/video.tsx';
 [Verwenden der 'Move'-Funktion *(in "Steuern der Show")*](./running-the-show.md#verwenden-der-'move'-funktion)<br/>
 [Verwenden des Titan Simulator *(in "Der Titan Simulator")*](./titan-basics/titan-simulator.md#verwenden-des-titan-simulator)<br/>
 [Verwenden des Virtuellen Panels mit dem Pult *(in "Der Titan Simulator")*](./titan-basics/titan-simulator.md#verwenden-des-virtuellen-panels-mit-dem-pult)<br/>
-[Verwenden von Faderwings *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#verwenden-von-faderwings)<br/>
+[Verwenden von DMX/sACN-Eingang *(in "Attributwerte ändern")*](./controlling-fixtures/changing-fixture-attributes.md#verwenden-von-dmxsacn-eingang)<br/>
 [Verwenden von Geräte-Gruppen *(in "Geräte-Gruppen")*](./controlling-fixtures/fixture-groups.md#verwenden-von-geräte-gruppen)<br/>
 [Verwenden von Shapes in Cues *(in "Der Shape-Generator")*](./effects/shape-generator.md#verwenden-von-shapes-in-cues)<br/>
 [Verwenden von Shapes und Effekten in Cues *(in "Erstellen eines Cues")*](./cues/creating-a-cue.md#verwenden-von-shapes-und-effekten-in-cues)<br/>
@@ -654,11 +667,12 @@ import Video from '@site/src/components/video.tsx';
 [Video-Vorschau (nur beim Diamond 9) *(in "Arbeitsfenster")*](./titan-basics/workspace-windows.md#video-vorschau-nur-beim-diamond-9)<br/>
 [Virtuelle Fader *(in "Steuern der Wiedergabe")*](./running-the-show/playback-controls.md#virtuelle-fader)<br/>
 [Visualiser *(in "Andere Bereiche der Anzeige")*](./titan-basics/other-parts-of-the-touch-screen.md#visualiser)<br/>
+[Visualiser DMX *(in "DMX-Einstellungen")*](./system-settings/dmx-output-mapping.md#visualiser-dmx)<br/>
 [Vorderseite des Pultes *(in "Diamond 7")*](./about-the-consoles/d7.md#vorderseite-des-pultes)<br/>
-[Vorderseite des Pultes *(in "Diamond 9")*](./about-the-consoles/diamond.md#vorderseite-des-pultes)<br/>
-[Vorschau mit dem Media Viewer *(in "Arbeiten mit Synergy")*](./synergy/operating-synergy.md#vorschau-mit-dem-media-viewer)
+[Vorderseite des Pultes *(in "Diamond 9")*](./about-the-consoles/diamond.md#vorderseite-des-pultes)
   
 ## W
+[WebAPI *(in "Externe Trigger")*](./running-the-show/midi-dmx-or-audio-triggering.md#webapi)<br/>
 [Wechsel der Playback-Seiten *(in "Einen Cue verwenden")*](./cues/cue-playback.md#wechsel-der-playback-seiten)<br/>
 [Weitere Anschlussmöglichkeiten *(in "Anschließen des Pultes, erste Schritte")*](./titan-basics.md#weitere-anschlussmöglichkeiten)<br/>
 [Weitere Optionen zu Zeiten *(in "Tipps für Theater-Programmierer")*](./cue-lists/theatre-programming.md#weitere-optionen-zu-zeiten)<br/>

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/capture-visualiser.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/capture-visualiser.md
@@ -1,0 +1,25 @@
+---
+id: capture-visualiser
+title: Der Capture-Visualiser
+sidebar_label: Der Capture-Visualiser
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Zur Visualisierung haben die Titan-Pulte Capture integriert. Damit
+lassen sich die Lichtstimmungen realistisch simulieren -- eine große
+Hilfe etwa zum Vorprogrammieren oder zum schnellen Anbringen von
+Änderungen im Blind-Modus.
+
+Dieses Kapitel enthält auch einen Abschnitt zum [Verbinden des Pultes mit
+der Capture-Vollversion auf einem externen Computer](capture-visualiser/linking-the-console-to-stand-alone-capture.md). Damit können auch
+große Setups dargestellt werden, während die interne Version aus
+Performance-Gründen etwas limitiert ist. 
+
+![Capture Visualiser Workspace Window](/docs/images/Capture-Visualiser-Workspace-Window.png)
+
+Zum Aufrufen des Visualisers wählen Sie <Keys.SoftKey>Capture Visualiser</Keys.SoftKey> aus dem
+Menü <Keys.SoftKey>Open Workspace Window</Keys.SoftKey> (siehe [Arbeitsfenster](titan-basics/workspace-windows.md)).
+
+> Beim Vorprogrammieren ist die **Verwendung von Paletten** unbedingt zu empfehlen: in der Realität wird es immer Abweichungen vom Modell geben, und mit Paletten sind die Änderungen deutlich schneller gemacht, als wenn man erst viele Cues einzeln ändern müsste.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/capture-visualiser/capture-show-files.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/capture-visualiser/capture-show-files.md
@@ -1,0 +1,63 @@
+---
+id: capture-show-files
+title: Capture Show-Daten
+sidebar_label: Capture Show-Daten
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Die Capture-Bühne wird automatisch mit in der Titan-Show gespeichert. Sie
+kann aber auch exportiert und importiert werden, um sie unabhängig von
+Titan in Capture zu verwenden. Ebenso können damit einzelne
+Capture-Shows unabhängig in mehreren Titan-Shows verwendet werden.
+
+Zum Exportieren/Importieren wählen Sie den Reiter **Show** im 
+Fenster <Keys.SoftKey>Capture Visualiser Settings</Keys.SoftKey>.
+
+## Shows exportieren
+
+Exportierte Shows können in andere Titan-Shows importiert werden. Ebenso
+können Sie in Capture geöffnet werden, um sie weiter zu bearbeiten oder
+Unterlagen zur Dokumentation auszudrucken.
+
+## Shows importieren
+
+Shows aus der Capture-Vollversion können importiert werden, etwa für
+größere Setups oder kompliziertes Rigging.
+
+Zum Importieren müssen die Dateien im richtigen Verzeichnis sein:
+- Im Titan-Showverzeichnis (normalerweise `Documents\Titan\Shows`).
+- Im Stammverzeichnis eines USB-Sticks.
+
+> Der interne Capture-Visualiser in v14 und v15 verwendet Capture 2020 *(Titan v12 und v13 
+  verwendete Capture 2018, frühere Titan-Versionen verwendeten Capture Atlas)*. Capture-Setups 
+  aus neueren Versionen können nicht importiert werden. Exportieren Sie also die richtige 
+  Version mit **Export for Capture 2020** in der Capture-Vollversion.
+
+Beim Importieren kompletter Shows aus der Capture-Vollversion
+muss sichergestellt sein, dass das Patch stimmt. Das Patch aus
+importierten Shows kann nicht im integrierten Capture-Visualiser
+verändert werden.
+
+Beim Importieren muss die Funktion **Auto Update** im Fenster Capture Settings deaktiviert 
+werden. Ansonsten würde Titan die importierten Fixtures neu anordnen und verschieben.
+
+Einige Fixtures und andere Elemente aus dem externen Capture
+funktionieren möglicherweise nicht mit dem internen Capture-Visualiser.
+Daher empfiehlt es sich in der Regel, die Geräte wie beschrieben auf dem
+Pult bei aktivierter [Auto-Patch-Funktion](../patching/patching-new-fixtures-or-dimmers.md#automatisches-patchen-in-capture) 
+zu patchen, damit die richtigen Gerätetypen ausgewählt werden. Diese müssen dann allerdings 
+neu positioniert werden.
+
+## Die Capture-Show löschen
+
+Unten auf dem Reiter **Show** gibt es den Button <Keys.SoftKey>Wipe</Keys.SoftKey>, mit dem die
+aktuelle Capture-Show gelöscht wird.
+
+Ist die Option **Auto Update** aktiv (**On**, Vorgabewert), 
+so werden die in Titan gepatchten Geräte wieder neu in Capture aktiviert.
+
+Wurden Geräte gepatcht, für die erst später die Darstellung in Capture 
+hinzugefügt wurde, so wählen Sie <Keys.SoftKey>Edit Fixtures</Keys.SoftKey> <Keys.SoftKey>Update
+Personality</Keys.SoftKey> aus dem [Menü Patch](../patching/changing-the-patch.md#bereits-gepatchte-personalities-aktualisieren). Damit werden die bereits gepatchten Fixtures auch in Capture angezeigt.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/capture-visualiser/capture-show-files.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/capture-visualiser/capture-show-files.md
@@ -30,10 +30,10 @@ Zum Importieren müssen die Dateien im richtigen Verzeichnis sein:
 - Im Titan-Showverzeichnis (normalerweise `Documents\Titan\Shows`).
 - Im Stammverzeichnis eines USB-Sticks.
 
-> Der interne Capture-Visualiser in v14 und v15 verwendet Capture 2020 *(Titan v12 und v13 
+> Der interne Capture-Visualiser verwendet Capture 2024 *(in Titan v14-v18 wurde Capture 2020 verwendet, Titan v12 und v13 
   verwendete Capture 2018, frühere Titan-Versionen verwendeten Capture Atlas)*. Capture-Setups 
   aus neueren Versionen können nicht importiert werden. Exportieren Sie also die richtige 
-  Version mit **Export for Capture 2020** in der Capture-Vollversion.
+  Version mit **Export for Capture 2024** in der Capture-Vollversion.
 
 Beim Importieren kompletter Shows aus der Capture-Vollversion
 muss sichergestellt sein, dass das Patch stimmt. Das Patch aus

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/capture-visualiser/linking-the-console-to-stand-alone-capture.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/capture-visualiser/linking-the-console-to-stand-alone-capture.md
@@ -1,0 +1,94 @@
+---
+id: linking-the-console-to-stand-alone-capture
+title: Mit einer externen Capture-Vollversion verbinden
+sidebar_label: Mit einer externen Capture-Vollversion verbinden
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Um in den Genuss des vollen Capture-Funktionsumfangs zu kommen, muss
+eine Capture-Vollversion auf einem separaten Computer laufen. Verbindet
+man diesen per Netzwerk mit dem Titan-Pult, so wird das Gerätepatch
+sowie die aktuelle Geräteauswahl zwischen Pult und Capture
+synchronisiert.
+
+Befinden sich Pult und Capture-PC im gleiche Netzwerk, so wird das Pult
+zur Auswahl unten im Reiter **Universes** in Capture angezeigt.
+Normalerweise erfolgt dies bereits vollautomatisch, aber befinden sich
+mehrere Titan-Pulte im Netzwerk, so ist eine manuelle Auswahl nötig.
+
+Für die Universen, die in Capture angezeigt werden sollen, muss Art-Net oder 
+sACN aktiviert sein, siehe [Einrichten der DMX-Ausgänge](../system-settings/dmx-output-mapping.md#configuring-dmx-outputs).
+
+> Damit die Verbindung und das Synchronisieren funktioniert, muss Capture 
+  mindestens in der Version Nexum, 2018 oder 2020 vorliegen. Mit älteren 
+  Versionen funktioniert das nicht oder nicht richtig.
+
+Solange die Netzwerkverbindung besteht, überträgt das Pult Daten zur
+Synchronisierung an Capture. Wird ein neues Gerät in Capture gepatcht,
+so wird dies auch im Pult hinzugefügt. Wird dagegen ein neues Gerät auf
+dem Pult gepatcht, so wird dies erst im Pult und dann in Capture
+hinzugefügt. Wählt man ein Gerät aus -- im Pult oder in Capture -- so
+wird diese Auswahl auch im jeweils anderen Teil angezeigt. Will man dies
+nicht, so kann man in Capture **Console Link** deaktivieren. Der in Titan 
+integrierte Capture Visualiser funktioniert davon unabhängig weiter.
+
+## Den Patch vom Pult nach Capture übertragen
+
+Wird das Pult neu mit Capture verbunden oder [eine Show geladen](../titan-basics/loading-and-saving-shows.md#laden-einer-show) oder ein
+[Gerät gepatcht](../patching/patching-new-fixtures-or-dimmers.md), so 
+wird in Capture automatisch der Patch-Dialog geöffnet. Dieser zeigt 
+eine Liste der Geräte, die auf dem Pult gepatcht sind und in Capture 
+zugewiesen werden müssen.
+
+Zum Zuweisen müssen die Geräte einfach von dieser Liste in eins der
+Capture-Fenster gezogen werden; dabei wird automatisch die in Titan
+angegebene DMX-Adresse verwendet. Es lassen sich auch mehrere Geräte
+gleichzeitig auswählen und in Capture zuweisen.
+
+![Capture Console Patch Window](/docs/images/Capture-Console-Patch-Window.png)
+
+Wurden Geräte bereits im internen Capture positioniert, so werden auch
+die Positionsdaten an das externe Capture übertragen. Änderungen in der
+Positionierung, Ausrichtung, Legende und Usernumber werden laufend
+synchronisiert.
+
+> Die Legende in Titan wird in Capture in der Spalte **Unit** angezeigt. 
+Die Usernumber von Titan wird in Capture als **Channel** angezeigt.
+
+## Den Patch von Capture ins Pult übertragen
+
+Wurden in Capture bereits Geräte gepatcht, bevor das Pult verbunden war,
+so können diese später im Pult mit Hilfe der Active Fixture-Funktion
+gepatcht werden:
+
+1. Drücken Sie <Keys.HardKey>Patch</Keys.HardKey>, <Keys.SoftKey>Active Fixtures</Keys.SoftKey>
+2. Wählen Sie <Keys.SoftKey>CITP Visualisers</Keys.SoftKey>.
+3. Der Capture-Computer wird nun als eine Option auf den Menütasten
+angezeigt. Klicken Sie die entsprechende Taste an.
+4. Wählen Sie eine freie Geräte-Schaltfläche, um die Geräte ab da zu
+patchen, oder wählen Sie die Option <Keys.SoftKey>Patch Capture @...</Keys.SoftKey>, um
+automatisch auf den nächsten freien Platz zu patchen.
+
+> Konnten einzelne Geräte nicht gepatcht werden (Gerätetyp nicht
+unterstützt, oder Nummer doppelt vergeben), so bleibt die entsprechende
+Geräteschaltfläche frei, und am Schluss wird eine entsprechende
+Fehlermeldung ausgegeben. Bestätigt man diese, so werden die gefundenen
+Probleme aufgelistet.
+
+Zum Beheben doppelt vergebener Gerätenummern ändern Sie in Capture den
+Wert im Feld **"Channel"**. Um dagegen bisher nicht unterstützte Geräte in
+Capture zu verwenden, [aktualisieren Sie zunächst die Gerätebibliothek](../fixture-personalities.md#aktualisieren-des-personality-speichers-des-pultes) 
+in Titan. Hilft das nicht, so [fordern Sie eine neue Personality](../fixture-personalities.md#anfordern-einer-neuen-gerätedatei) auf
+der [Avolites Personality-Website](https://personalities.avolites.com/?mainPage=Request%20Queue.asp&) an. Wählen
+Sie dabei als Desk Type "Capture Visualiser (.c2o)".
+
+## Legenden aus Capture-Screenshots erzeugen
+
+Screenshots von Capture können per CITP als Legende ans Pult übertragen werden. Damit hat man
+einen Eindruck davon, welche Bühnensituation auf dem Playback oder der Palette gespeichert ist.
+
+Öffnen Sie dazu wie gewohnt das 'Set Legend' Menü, als ob Sie etwas zeichnen würden. Öffnen Sie 
+den Tab 'Network'. Hier wird ein Screenshot der aktuellen Capture-Alpha-Ansicht angezeigt, und Sie 
+können das Bild als Legende verwenden.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/capture-visualiser/setting-up-the-rig.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/capture-visualiser/setting-up-the-rig.md
@@ -1,0 +1,191 @@
+---
+id: setting-up-the-rig
+title: Das Rig einrichten
+sidebar_label: Das Rig einrichten
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Raum und Bühne
+
+Für einen realistischen Eindruck und eine bessere Orientierung lassen
+sich verschiedene feste Elemente hinzufügen.
+
+Öffnen Sie das Fenster <Keys.SoftKey>Capture Visualiser Settings</Keys.SoftKey> per Doppelklick auf
+[<Keys.HardKey>Open/View</Keys.HardKey>](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster) und wählen Capture 
+Visualiser Settings, oder durch einen Klick auf den Kontext-Button <Keys.ContextKey>Open Settings</Keys.ContextKey> 
+im Capture Visualiser-Fenster). Klicken Sie nun oben auf den Reiter **Stage**.
+
+![Capture Visualiser Settings Window](/docs/images/Capture-Visualiser-Settings-Window.png)
+
+
+Die Elemente **"Floor"** (Boden) und **"Back Wall"** (Rückwand) sind bereits
+eingerichtet. Klickt man links unten auf das <Keys.ContextKey>+</Keys.ContextKey> (Pluszeichen), so
+können weitere Objekte hinzugefügt werden.
+
+Klicken Sie links auf eines der vorhandenen Objekte, so können seine
+Eigenschaften mit den Fadern und Input-Boxen rechts bearbeitet werden:
+so können Sie die Objekte positionieren und in der Größe verändern.
+Ebenso können Sie rechts oben Farbe und Bezeichnung der Objekte
+verändern.
+
+## Geräte/Fixtures hinzufügen und einrichten
+Ist die Funktion "Auto Update" aktiviert (zu finden auf dem Reiter
+&nbsp;**Show** im Fenster **Capture Settings**), 
+so werden Geräte beim Patchen in der Titan-Software automatisch zur 
+Capture-Bühne hinzugefügt.
+
+Wird eine Show aus einer früheren Titan-Version [geladen](../titan-basics/loading-and-saving-shows.md#laden-einer-show), so werden die
+Geräte/Fixtures **nicht** automatisch zu Capture hinzugefügt. Dazu ist
+zunächst ein [Updaten der Personalities](../patching/changing-the-patch.md#bereits-gepatchte-personalities-aktualisieren) 
+erforderlich: <Keys.HardKey>Patch</Keys.HardKey> <Keys.SoftKey>Edit Fixtures</Keys.SoftKey> <Keys.SoftKey>Update Personality</Keys.SoftKey> <Keys.SoftKey>Update All</Keys.SoftKey>. 
+Auch ein Gerätetausch ([Exchange Fixtures](../patching/changing-the-patch.md#geräte-austauschen)) kann helfen.
+
+Geräte werden, sobald sie in Capture vorhanden sind, mit den Rädern
+(Encodern) positioniert. Wählen Sie dazu [ein oder mehrere Geräte oder
+ein Gerätegruppe](../controlling-fixtures.md#dimmer-und-geräte-zum-steuern-auswählen) aus und drücken Sie [<Keys.HardKey>Locate</Keys.HardKey>](../controlling-fixtures.md#geräte-auf-startposition-setzen-locate). Mit dem Kontext-Button <Keys.ContextKey>Position - Orientation</Keys.ContextKey> wird die Steuerung für Position und 
+Orientierung der jeweils ausgewählten Geräte auf die Wheels gelegt. *Das
+Gleiche passiert, wenn man den Rad-Modus mit der Menütaste G auf „Räder
+= Visualiser" schaltet.*
+
+Wählen Sie mit den Attribut-Tasten <Keys.HardKey>Position</Keys.HardKey>, so können Sie nun die
+X/Y/Z-Position der gewählten Fixtures einstellen. Sind mehrere Geräte
+gewählt, so lassen sich mit der <Keys.HardKey>Fan</Keys.HardKey>-Taste oder der Option <Keys.ContextKey>Scale-Fan</Keys.ContextKey> die Geräte gleichmäßig verteilen/auffächern. Auch die Optionen Split, Curve, Group der [Fan-Funktion](../controlling-fixtures/changing-fixture-attributes.md#fan-modus) funktionieren wie gewohnt.
+
+Klicken Sie auf das Display oberhalb der Encoder, so können Sie
+ebenfalls die betreffenden Werte schrittweise verändern. Für die
+Rotation erfolgt das in 45°-Schritten.
+
+Wenn man von vorn auf die Bühne schaut, so ist die Orientierung von XYZ
+wie folgt:
+
+Achse | Beschreibung
+---|---
+**X** | bewegt nach rechts/links
+**Y** | bewegt nach oben/unten
+**Z** | bewegt nach vorn/hinten
+
+Klickt man nochmals auf <Keys.HardKey>Position</Keys.HardKey>, so schalten die Encoder auf
+Orientation. Damit können die Geräte um die X/Y/Z-Achse
+gedreht/geschwenkt werden. Auch hierbei kann der [Fan-Modus](../controlling-fixtures/changing-fixture-attributes.md#fan-modus) verwendet
+werden.
+
+Die XYZ-Rotation kann man sich am besten vorstellen, wenn man von einer
+kardanischen Aufhängung, einem sog. Gimbal, ausgeht: drei Ringe sind
+ineinander drehbar gelagert (siehe linkes Bild unten). Dabei kann es
+dazu kommen, dass zwei Achsen scheinbar das Gleich machen, womit
+bestimmte Orientierungen nicht mehr erreicht werden können. Dieser
+Zustand ist bekannt als sog. Gimbal Lock und entsteht dann, wenn zwei
+Achsen (durch Drehung der dritten um 90°) zusammenfallen (Bild unten
+rechts). Verändern Sie in diesem Falle die dritte Achse um 90°, damit
+wieder alle Freiheitsgrade zur Verfügung stehen und alle Orientierungen
+erreicht werden können.
+
+![gimbal](/docs/images/Gimbal.jpeg)
+
+*Illustration by MathsPoetry*
+
+Betätigen Sie <Keys.HardKey>Position</Keys.HardKey> ein drittes Mal, 
+so können Sie die Rotation verändern. Rotation funktioniert nur, wenn mehrere Geräte ausgewählt sind: 
+die Gruppe rotiert als Ganzes um ihren Mittelpunkt.
+
+- Um einzelne Geräte zu drehen, müssen Sie den Punkt **Orientation** verwenden. **Rotation** funktioniert nur bei mehreren ausgewählten Geräten, nicht bei einzelnen.
+
+>Es empfiehlt sich, zunächst die Geräte im Tilt etwas aus der Mitte zu fahren, 
+so dass man beim Ändern der Orientierung sieht, wohin man gerade dreht. 
+Außerdem empfiehlt es sich, zumindest ein richtiges Gerät zum Vergleich 
+anzuschließen, um zu überprüfen, dass alle Richtungen und Positionierungen
+im richtigen Sinn erfolgen. 
+
+### Geräte-Optionen im Visualiser
+
+es lassen sich verschiedene Optionen einstellen, wie genau die einzelnen Geräte im Visualiser angezeigt werden. je nach Gerätetyp können das unterschiedliche Optionen sein.
+
+Um diese Optionen einzustellen, drücken Sie im Hauptmenü die unterste Menütaste so oft, bis dort <Keys.SoftKey>Wheels=Visualiser</Keys.SoftKey> steht, oder Sie klicken auf den Kontextbutton <Keys.ContextKey>Position-Orientation</Keys.ContextKey>. Wählen Sie dann die zu editierenden Geräte aus und stellen Sie die Optionen wie folgt mit den Encodern ein:
+
+**Dimmer (einfach Leuchten)**
+
+Attributbank | Encoder | Funktion
+----------|-------|---------
+Colour | A/B/C | RGB-Lichtfarbe. Damit lassen sich Leuchten einfärben, also auffiltern.
+Beam | A | Zoom - Einstellen des Abstrahlwinkels von 5 bis 90°.
+" | B | Focus - Fokussierung
+" | C | Throws Light (siehe unten)
+Effect | A | Horizontal Frost - horizontaler Streufilter
+" | B | Vertical Frost - vertikaler Streufilter
+
+**Andere Geräte**
+
+Attributbank | Encoder | Funktion
+----------|-------|---------
+Beam | A | Throws Light
+" | B | Invert Pan
+" | C | Invert Tilt
+
+- Die Option *Throws Light* kann verwendet werden, um das Rendern des Lichtstrahls von unwichtigen Leuchten im Visualiser zu deaktivieren, um Ressourcen zu sparen. Dann wird zwar die Leuchte angezeigt, nicht aber der Lichtstrahl.
+- Mit den Optionen *Invert Pan / Tilt* kann Pan bzw. Tilt im Visualiser invertiert werden, um entsprechende Einstellungen der wirklichen Geräte nachzubilden.
+
+## Kameras einrichten (Ansichten)
+
+Es stehen vier Kameras - unabhängige Ansichten - zur Verfügung, wobei
+weitere hinzugefügt werden können.
+
+Die entsprechenden Optionen stehen über das Kontext-Menü zur
+Verfügung.
+
+![Capture Visualiser Workspace Window Context Menu](/docs/images/Capture-Visualiser-Workspace-Window-Context-Menu.png)
+
+Die Steuerung der Kameras erfolgt im Fenster [Capture Visualiser Settings](#setting-up-the-stage-and-rigging): zum Öffnen drücken Sie zweimal auf 
+<Keys.HardKey>View / Open</Keys.HardKey> und wählen <Keys.SoftKey>Capture Settings</Keys.SoftKey> von den Buttons,
+oder Sie verwenden den Kontext-Button <Keys.ContextKey>Open Settings</Keys.ContextKey> des Capture-Fensters.
+
+Die Steuerung der Kameras erfolgt ebenfalls im Fenster **Capture Visualiser Settings** auf dem Reiter 'Cameras'.
+
+Mit den vier Schaltflächen oben lassen sich die verschiedenen Kameras
+umschalten *(siehe unten)*; klickt man rechts auf das <Keys.ContextKey>+</Keys.ContextKey>, kann man weitere Kameras
+hinzufügen.
+
+![Camera movements in Capture Visualiser Workspace Window](/docs/images/Camera-movements-in-Capture-Visualiser-Workspace-Window.png)
+
+Der obere Button der linken Spalte schaltet zwischen der Ansicht mit
+einer oder mit vier Kameras um. Ist die Vierer-Ansicht aktiv, so
+schalten die vier Buttons darunter zwischen den einzelnen Teilansichten
+um.
+
+Mit der linken Fläche kann man die Kamera **rechts/links** sowie nach
+&nbsp;**vorn/hinten** positionieren.
+
+Mit der mittleren Fläche verschiebt man die Kamera nach **oben/unten**.
+
+Rechts kann man die Kamera drehen und schwenken; der jeweilige Modus wir
+mit den Buttons darunter gewählt:
+
+-   **Rotate:** dreht die Kamera nach links/rechts/oben/unten
+
+-   **Orbit:** schwenkt die Kamera im Kreis um die Bühne, wobei sie stets
+    auf den gleichen Punkt ausgerichtet bleibt.
+
+Klickt man auf den Kontext-Button <Keys.ContextKey>Move Camera</Keys.ContextKey>, so kann man die
+Kamera mit den Rädern bewegen sowie im Menü **Set Coordinates** 
+die Position/Rotation numerisch eingeben.
+
+Klickt man auf den Kontext-Button <Keys.ContextKey>Rotate Camera</Keys.ContextKey> oder \&#123;Orbit
+Camera\&#125;, so kann man die Kamera mit den Rädern drehen/schwenken, sowie
+die Rotation numerisch eingeben.
+
+## Capture Darstellungs-Optionen
+
+Der Reiter Appearance (Darstellung) im Fenster **Capture Visualiser Settings** bietet folgende Einstellmöglichkeiten:
+
+- **Ambient lighting** (Umgebungslicht)
+- **Smoke density** (Nebel/Haze; *bei Capture heißt das "Atmosphere"*)
+- **Smoke variation** (*"Atmosphere contrast"* - Mix zwischen statischem 
+Dunst und sich bewegendem Nebel - 0%=Haze, 100%=Nebel)
+- **Smoke speed** (*"Atmosphere speed"* - Nebel/Haze Geschwindigkeit)
+- **Exposure adjustment** (Belichtung, die Empfindlichkeit der Kamera)
+- **Bloom amount** (eine Rendereinstellung, die die Darstellung heller
+    Lichtquellen beeinflusst)
+- **Rendering settings detail** (Render Details Stufe): Qualität der
+    Darstellung. Eine höhere Stufe erzeugt eine bessere Darstellung,
+    niedrige Stufen nehmen weniger Rechenleistung in Anspruch.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/capture-visualiser/visualising-using-capture.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/capture-visualiser/visualising-using-capture.md
@@ -1,0 +1,32 @@
+---
+id: visualising-using-capture
+title: Mit Capture visualisieren
+sidebar_label: Mit Capture visualisieren
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Es sind keine besonderen Einstellungen erforderlich, um Capture zu
+verwenden. Bedienen Sie einfach da Pult wie gewohnt, und Capture zeigt
+eine Simulation dessen, was mit Ihren Fixtures passiert.
+
+>Verwenden Sie den Visualiser häufig, so empfiehlt sich die Verwendung eines externen Monitors. Ansonsten muss man ständig zwischen Capture und den anderen Fenstern hin- und herschalten.
+
+## Geräte anwählen
+
+Sobald auf dem Pult [Geräte angewählt](../controlling-fixtures.md#dimmer-und-geräte-zum-steuern-auswählen) sind, werden diese in Capture
+markiert, so dass man weiß, mit welchen Geräten man gerade arbeitet.
+
+![Fixtures elected on internal Capture Visualiser Window](/docs/images/Fixtures-elected-on-internal-Capture-Visualiser-Window.png)
+
+## Kameras/Ansichten
+
+Mit Capture kann man sich Bühne und Beleuchtung aus verschiedenen
+Blickwinkeln anschauen. So kann man sich auch bei großen Installationen
+einen Eindruck von verschiedenen Plätzen verschaffen, ohne durch das
+ganze Venue laufen zu müssen.
+
+Richten Sie sich wie [im vorigen Abschnitt beschrieben](setting-up-the-rig.md#kameras-einrichten-ansichten) mehrere
+Kameras/Ansichten ein, so können Sie schnell zwischen diesen wechseln
+und haben alles im Überblick.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases.md
@@ -1,0 +1,17 @@
+---
+id: chases
+title: Chaser
+sidebar_label: Chaser
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Ebenso wie [einzelne Cues](cues.md) können auch ganze Serien von Cues, 
+sog. Chaser, auf Fadern sowie Schaltflächen im Playbacks-Fenster gespeichert werden. 
+
+Chaser können einmalig durchlaufen oder dauernd wiederholt werden. Es lassen 
+sich [individuelle Zeiten pro Cue](chases/chase-timing.md#individuelle-zeiten-pro-schritt) einstellen sowie [die Abfolge der Cues trennen](chases/chase-options.md#linking), so dass das Pult darauf wartet, dass die <Keys.HardKey>Go</Keys.HardKey>-Taste betätigt wird.
+
+> Geht es eher darum, mit vielen Fixtures wiederkehrende Abläufe zu
+programmieren, ist vielleicht ein [Keyframe-Shape](effects/key-frame-shapes.md) sinnvoller, da man damit die Details besser anpassen kann.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases/chase-options.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases/chase-options.md
@@ -1,0 +1,95 @@
+---
+id: chase-options
+title: Chaser-Optionen
+sidebar_label: Chaser-Optionen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Um weitere Optionen eines Chasers zu ändern, drücken Sie im Hauptmenü
+<Keys.SoftKey>Options</Keys.SoftKey>, gefolgt von der entsprechenden **Swop**-Taste. Zum
+Einstellen der Optionen in einem Fenster drücken Sie <Keys.HardKey>Open/View</Keys.HardKey>, dann die
+entsprechende **Swop**-Taste, und klicken links in der Playback-Ansicht
+auf <Keys.SoftKey>Options</Keys.SoftKey>.
+
+![Playback Options (playback tab) for a chase](/docs/images/Playback-Options-Chase-Playback-Tab.png)
+
+Die meisten Optionen sind die gleichen wie für statische Cues (siehe
+[Playback Optionen](../cues/playback-options.md)), sowie ein paar 
+zusätzliche für Chaser, die hier beschrieben werden.
+
+## Tab "Handle"
+
+Alle Optionen dieser Rubrik funktionieren genauso wie im [Kapitel Cues](../cues/playback-options.md#playback-options----tab-handle) beschrieben.
+
+## Tab "Playback"
+
+[Blind](../cues/playback-options.md#blind), [Cross Fade HTP](../cues/playback-options.md#cross-fade-htp), [Priority](../cues/playback-options.md#priority) funktionieren genauso wie im Kapitel Cues beschrieben.
+
+### Cue Links Disabled
+Ist dies aktiviert, so läuft der Chaser nicht
+automatisch durch, sondern man muss nach jedem Schritt wieder <Keys.HardKey>Go</Keys.HardKey>
+drücken.
+
+### Linking
+bestimmt das Verhalten aufeinanderfolgender Schritte:
+
+&nbsp;<Keys.SoftKey>Link according to individual steps</Keys.SoftKey> - (Schrittfolge nach Vorgabe):
+jeder Schritt verhält sich gemäß der spezifischen Vorgaben, die im [Playback View Fenster ](editing-a-chase.md#opening-a-chase-for-editing) 
+oder per [Unfold-Funktion](editing-a-chase.md#editing-a-chase-using-unfold) ) eingestellt wurden.
+
+
+&nbsp;<Keys.SoftKey>Always Link Steps</Keys.SoftKey> - (Schritte stets folgen lassen): der Chaser
+läuft automatisch mit den vorgegebenen Zeiten ab.
+
+
+&nbsp;<Keys.SoftKey>Never Link Steps</Keys.SoftKey> - (Schritte nie folgen lassen): der Chaser stoppt
+nach jeder Verzögerungs-/Überblendzeit und wartet auf das Betätigen der <Keys.HardKey>Go</Keys.HardKey>-Taste.
+
+> Ist ein Chaser 'unlinked', d.h. wartet immer auf das manuelle ‚Go', so startet auch der erste Schritt nicht 
+  automatisch, wenn der Fader hochgezogen wird. Um dies zu umgehen, linken Sie den ersten Schritt zum vorherigen, 
+  sofern der Chaser nicht auf ‚Loop' (Wiederholung) steht. Steht er hingegen auf ‚Loop', so fügen Sie am Ende 
+  einen ‚Blindschritt' ein mit 0 Sek. Fade- und 0 Sek. Delayzeit, und linken den ersten Schritt mit diesem.
+
+### Loop Action
+bestimmt, was passiert, wenn der Chaser durchgelaufen ist:
+
+&nbsp;<Keys.SoftKey>Stop on Final Cue</Keys.SoftKey> - Der Chaser stoppt, läuft also nur einmal.<br/>
+&nbsp;<Keys.SoftKey>Loop</Keys.SoftKey> - Der Chaser läuft immer wieder von Anfang an durch -- eine
+Schleife.
+
+### Play Order
+stellt die Richtung des Chasers ein (forwards = vorwärts, backwards 
+= rückwärts, bounce = hin und zurück, random = zufällige Folge).
+
+## Tab "Times"
+
+Flash Fade In, Flash Fade Out sowie Speed verhalten sich wie bei
+einzelnen Cues. Der Speed (Geschwindigkeit) kann auch mit dem linken Rad
+eingestellt werden, wenn der Chaser connected ist. Siehe [Geschwindigkeit und Überblendung einstellen](chase-playback.md#geschwindigkeit-und-überblendung-einstellen) für weitere Details.
+
+### Speed Multiplier
+zum Einstellen eines Faktors für das Tempo.
+
+### XFade
+Eine weitere Möglichkeit, das Überblenden des Chasers
+einzustellen.
+
+## Tab "Effects
+
+Alle Optionen dieser Rubrik funktionieren genauso wie im [Kapitel Cues](../cues/playback-options.md#playback-options----tab-effects) beschrieben.
+
+## Tab "Release"
+
+[Release Mask](../cues/playback-options.md#release-mask) und 
+[Release Time](../cues/playback-options.md#release-time) funktionieren genauso wie im
+[Kapitel Cues](../cues/playback-options.md#playback-options----tab-release) beschrieben.
+
+### Cue Release
+Cue Release: erlaubt es, Chaser zu erstellen, bei denen zwischen den
+einzelnen Schritten ein Release erfolgt. 
+
+*So lässt sich damit z.B. ein Chaser erstellen, der die Geräte einzeln 
+auf weiß einblendet und dann wieder released, also auf die vorher 
+verwendete Farbe zurücksetzt. Diesen kann man dann vor jedem anderen - durch andere Cues/Paletten eingestellten - Hintergrund laufen lassen.*

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases/chase-playback.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases/chase-playback.md
@@ -1,0 +1,158 @@
+---
+id: chase-playback
+title: Abrufen
+sidebar_label: Abrufen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Abrufen eines Chasers
+
+Zum Starten eines Chasers bewegen Sie den entsprechenden Regler nach
+oben *(oder Sie verwenden die **Swop** / **Flash**-Tasten)*. Der Chaser
+beginnt daraufhin zu laufen. Am unteren Rand des Bildschirms oberhalb
+des jeweiligen Reglers wird die Nummer des aktuellen Schritts sowie die
+Geschwindigkeit angezeigt.
+
+![Chase playing on a playback](/docs/images/Chase-playing-on-a-playback.png)
+
+
+>   Die HTP-Kanäle (Helligkeit) werden durch den Fader gesteuert; sind
+    [Einblendzeiten](chase-timing.md) programmiert, so endet das Einblenden 
+	mit Erreichen des mit dem Fader eingestellten Werts. Die anderen (LTP-) Kanäle
+    beginnen mit ihrem Einblenden (abhängig von den gewählten Zeiten),
+    sobald der Regler über 0 bewegt wird.
+
+Bei einem aktiven Chaser werden im Display oberhalb der Räder
+Details der einzelnen Schritte angezeigt.:
+
+![Connected chase with speed and crossfade controls](/docs/images/Connected-chase-with-speed-and-crossfade-controls.png)
+
+Der Chaser lässt sich mit der <Keys.HardKey>Stop</Keys.HardKey>-Taste rechts neben den Rädern
+vorübergehend anhalten. Drücken Sie <Keys.HardKey>Go</Keys.HardKey>, um den Chaser fortzusetzen.
+
+Mit einer [Vielzahl von Optionen](chase-options.md) lässt sich das Verhalten 
+von Chasern beeinflussen; diese werden im Rest dieses Kapitels erklärt.
+
+## Verbinden eines Playbacks mit der Steuerung
+
+Wird ein Chaser oder eine Cueliste aufgerufen, so ist dessen Steuerung automatisch den
+Rädern (Geschwindigkeit, Überblendung) und <Keys.HardKey>Stop</Keys.HardKey>/<Keys.HardKey>Go</Keys.HardKey>-Tasten
+zugeordnet: dies nennt sich **Connect** (Verbinden) des Playbacks. Ist mehr
+als ein Playback aktiv, so lässt sich mit der <Keys.HardKey>Connect / Cue</Keys.HardKey>-Taste wählen,
+welches davon mit den Rädern/Tasten beeinflusst werden soll.
+
+-   Zum Verbinden eines anderen Chasers drücken Sie die Taste <Keys.HardKey>Connect / Cue</Keys.HardKey>, 
+    und dann die Auswahltaste des gewünschten Chasers.
+
+-   Zum Lösen der Zuordnung drücken Sie die <Keys.HardKey>Connect / Cue</Keys.HardKey>-Taste zweimal.
+
+-   Das automatische Verbinden lässt sich mit der Option **"Auto Connect"**
+    im Tab [Wheels](../system-settings/user-settings#wheels) der Benutzereinstellungen
+    abschalten, wenn dieses Verhalten nicht erwünscht ist. In diesem
+    Fall muss immer mit der <Keys.HardKey>Connect / Cue</Keys.HardKey>-Taste die Steuerung zugeordnet
+    werden.
+
+-   Es gibt außerdem die Benutzereinstellung "Auto View On Connect" im Tab 
+    [Wheels](../system-settings/user-settings#wheels) der Benutzereinstellungen. Ist
+    dies aktiviert, so wird beim Connecten mit einem Playback direkt die
+    [Detailansicht (Playback View)](editing-a-chase.md#einen-chaser-zum-editieren-öffnen) 
+	für das Playback geöffnet. *Dies ist besonders sinnvoll, wenn man 
+	zwischen mehreren Chasern hin- und herwechselt*.
+
+>   Normalerweise werden Änderungen von Geschwindigkeit und Überblendung durch Betätigung 
+    der Wheels sofort gespeichert. Dies lässt sich ändern, so dass solche Änderungen nur
+    vorübergehend wirksam sind und beim erneuten Laden einer Show die
+    [User Settings](../system-settings/user-settings.md) auf (<Keys.HardKey>AVO</Keys.HardKey>-Taste + <Keys.SoftKey>User Settings</Keys.SoftKey>) und stellen auf dem Reiter **[Times](../system-settings/user-settings.md#times-zeiten)** die Option 'Connected View Sets' auf **Temporary Speed**. Dessen ungeachtet lässt sich eine geänderte Geschwindigkeit 
+    vorherigen Einstellungen wieder aktiviert werden. Dazu rufen Sie die
+	explizit speichern: drücken sie dazu im Menü <Keys.SoftKey>Set Times</Keys.SoftKey> die Taste <Keys.SoftKey>Save Temporary Speed</Keys.SoftKey>.
+
+
+## Geschwindigkeit und Überblendung einstellen
+
+Das linke Rad beeinflusst die Geschwindigkeit des verbundenen Chasers.
+Die Geschwindigkeit wird im Display in 'Beats Per Minute' (BPM)
+angezeigt. Ebenso lässt sich die Geschwindigkeit über die Zifferntasten
+eingeben (s.u.). Die zuletzt gewählte Geschwindigkeit wird automatisch
+gespeichert.
+
+**Crossfade** ist die Überblendung zwischen den einzelnen Schritten. Bei
+Crossfade = 0 werden die Geräte zwischen den einzelnen Schritten hart
+umgeschaltet, bei Crossfade = 100 erfolgt ein allmähliches Überblenden
+über die Gesamtdauer des Schrittes, und bei Crossfade = 50 bleiben die
+Geräte die Hälfte der Zeit auf den eingestellten Werten, und blenden die
+andere Hälfte auf die neuen Werte über.
+
+![Chases crossfade diagram](/docs/images/Chases-crossfade-diagram.png)
+
+Überblendung und Geschwindigkeit werden wie folgt eingestellt:
+
+1. Wählen Sie <Keys.SoftKey>Edit Times</Keys.SoftKey> aus dem Hauptmenü, und drücken dann die
+&nbsp;**Swop**-Taste des Chasers.
+2. Zum Einstellen der **Überblendung** drücken Sie <Keys.SoftKey>Xfade</Keys.SoftKey> und geben mit
+den Zifferntasten einen Wert von **0 ... 100** ein *(0 = hartes
+Umschalten, 100 = komplettes Überblenden etc., s.o.)*.
+3. Zum Eingeben der **Geschwindigkeit** drücken Sie <Keys.SoftKey>Speed</Keys.SoftKey>, geben die
+gewünschte Geschwindigkeit ein, und drücken <Keys.HardKey>Enter</Keys.HardKey>. *Abhängig von der
+Benutzereinstellung [Tempo Units](../system-settings/user-settings.md#times-zeiten) kann die Geschwindigkeit in 'Beats Per Minute'
+(BPM) oder Sekunden eingegeben werden*.
+
+In diesem Menü lassen sich noch weitere Optionen einstellen, etwa das
+[Geräte-Überlappen](../cues/cue-timing.md#einstellen-von-überblendzeiten-und-geräteversatz). Details dazu finden sich im Abschnitt [Zeiten bei Chasern](chase-timing.md).
+
+Für jeden Schritt lassen sich getrennte Zeiten vergeben, ebenso lässt
+sich die Schrittfolge unterbrechen, so dass der nächste Schritt auf das
+Betätigen der <Keys.HardKey>Go</Keys.HardKey>-Taste wartet. Beides erfolgt entweder in der
+Ansicht [Playback View](editing-a-chase.md#einen-chaser-zum-editieren-öffnen)
+oder mittels <Keys.HardKey>Unfold</Keys.HardKey>, siehe [Unfold-Funktion](editing-a-chase.md#ändern-eines-chasers-mit-der-unfold-funktion).
+
+Die Anzeige der Geschwindigkeit lässt sich zwischen Sekunden und Beats
+Per Minute (BPM) umschalten. Dazu drücken 
+Sie <Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>User Settings</Keys.HardKey>, und wählen dann mit der 
+Option <Keys.SoftKey>Tempo Units</Keys.SoftKey> zwischen <Keys.SoftKey>Tempo Units Seconds</Keys.SoftKey>
+(Sekunden) und <Keys.SoftKey>Tempo Units Beats Per Minute (BPM)</Keys.SoftKey>.
+
+Ferner lässt sich der Chaser einem [Speed Master](../running-the-show/playback-controls.md#speed--und-size-master) zuordnen; 
+dies erlaubt es, direkt während der Show die Geschwindigkeit zu steuern. 
+Siehe auch [Speed and Size Masters](../running-the-show/playback-controls.md#speed--und-size-master).
+
+## Manuelle Steuerung der Schritte
+
+Ein verbundener Chaser lässt sich mit der <Keys.HardKey>Stop</Keys.HardKey>-Taste (neben den
+Rädern) anhalten, und mit der <Keys.HardKey>Go</Keys.HardKey>-Taste fortsetzen.
+
+Ist ein Chaser angehalten, so lässt sich mit den Pfeiltasten (<Keys.HardKey>←</Keys.HardKey> und <Keys.HardKey>→</Keys.HardKey> bzw. <Keys.HardKey>Prev. Step</Keys.HardKey>/<Keys.HardKey>Next Step</Keys.HardKey>) bei der <Keys.HardKey>Connect / Cue</Keys.HardKey>-Taste der
+nächste/vorherige Schritt wählen. Dabei erfolgt das Überblenden jeweils
+in der eingestellten Zeit, es sei denn die Benutzereinstellung **Chase Snap** (Tab [**General (Allgemein)**](../system-settings/user-settings.md#general-allgemein)) wird aktiviert oder man verwendet die Taste <Keys.HardKey>Snap</Keys.HardKey> (sofern
+vorhanden).
+
+Ebenso lassen sich die blaue und die graue Taste des Handles mit den
+Funktionen 'Stop' und 'Go' belegen; dazu dient die Funktion [Key
+Profiles (Tastenbelegungen)](../system-settings/key-profiles.md).
+
+1. Halten Sie <Keys.HardKey>AVO</Keys.HardKey> gedrückt und drücken Sie <Keys.SoftKey>Edit Current Key Profile</Keys.SoftKey>.
+2. Verwenden Sie momentan eines der nicht editierbaren Vorgabeprofile,
+so werden Sie zum Anlegen eines neuen aufgefordert.
+3. Drücken Sie <Keys.SoftKey>Chases</Keys.SoftKey>, und wählen dann entweder die blaue oder die
+graue Taste.
+4. Wählen Sie aus dem Funktionen-Menü entweder <Keys.SoftKey>Go</Keys.SoftKey> oder <Keys.SoftKey>Stop</Keys.SoftKey>.
+Danach drücken Sie <Keys.HardKey>Exit</Keys.HardKey> und ändern ggf. noch die Funktion der
+anderen Taste.
+5. Drücken Sie <Keys.HardKey>Exit</Keys.HardKey>, um zum normalen Programmiermenü
+zurückzukehren.
+
+## Ändern der Richtung eines Chasers
+
+Die Tasten <Keys.HardKey>Prev Step</Keys.HardKey>/<Keys.HardKey>Next Step</Keys.HardKey> (← und → auf manchen Pulten) 
+rechts neben der <Keys.HardKey>Connect / Cue</Keys.HardKey>-Taste bestimmen die Richtung des 
+verbundenen Chasers. Der Doppelpfeil <Keys.HardKey>↔</Keys.HardKey> (wenn vorhanden) steht dabei für
+&nbsp;**Hin und Her**: der Chaser läuft in einer Richtung bis zum Ende, dann
+wieder zurück zum Anfang, und so fort. Die Taste <Keys.HardKey>Review</Keys.HardKey> sorgt für
+einen **zufälligen** Ablauf. 
+
+## Direktanwahl eines Schrittes
+Man kann direkt zu einem bestimmten Schritt in einem Chaser springen:
+drücken Sie dazu <Keys.HardKey>Connect / Cue</Keys.HardKey>, geben die gewünschte Schrittnummer ein,
+und drücken <Keys.HardKey>Enter</Keys.HardKey> oder Funktionstaste A. Alternativ geben Sie im
+Hauptmenü die Schrittnummer ein und drücken <Keys.HardKey>Connect / Cue</Keys.HardKey>.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases/chase-timing.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases/chase-timing.md
@@ -1,0 +1,143 @@
+---
+id: chase-timing
+title: Zeiten bei Chasern
+sidebar_label: Zeiten bei Chasern
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Globale Zeiten für Chaser
+
+Wird ein Chaser erstmals programmiert, gelten für sämtliche Schritte die
+gleichen Zeiten. Dies sind die globalen Zeiten. Wenn gewünscht, lassen
+sich anschließend für jeden Schritt gesonderte Zeiten in der Ansicht
+[Playback View](editing-a-chase.md#einen-chaser-zum-editieren-öffnen) bzw. mit 
+der [Unfold](editing-a-chase.md#ändern-eines-chasers-mit-der-unfold-funktion)-Funktion 
+vergeben; das ist [im nächsten Abschnitt](#individuelle-zeiten-pro-schritt)
+ genauer beschrieben.
+
+1. Drücken Sie im Hauptmenü <Keys.SoftKey>Edit Times</Keys.SoftKey>, und anschließend die **Swop**-Taste des gewünschten Chasers.
+2. Stellen Sie wie unten beschrieben **Geschwindigkeit**, **Überblendung**,
+&nbsp;**Geräteversatz** und **Attributversatz** ein.
+3. Drücken Sie <Keys.HardKey>Exit</Keys.HardKey>, um den Vorgang abzuschließen.
+
+-   Zum Einstellen der **Geschwindigkeit** drücken Sie <Keys.SoftKey>Speed</Keys.SoftKey>, geben die
+    gewünschte Geschwindigkeit mit den Zifferntasten ein und schließen
+    die Eingabe mit <Keys.HardKey>Enter</Keys.HardKey> ab. Abhängig von den Benutzereinstellungen
+    kann man die Geschwindigkeit in ‚Beats Per Minute' (BPM) oder in
+    Sekunden eingeben.
+
+-   Zum Einstellen der **Überblendung** drücken Sie <Keys.SoftKey>Xfade</Keys.SoftKey>, geben den
+    gewünschten Wert mit den Zifferntasten ein und schließen die Eingabe
+    mit <Keys.HardKey>Enter</Keys.HardKey> ab 
+	
+	*(0 = keine Überblendung, hartes Umschalten; 100 = maximale Überblendung, ständiges Umblenden von einem Schritt zum nächsten)*.
+
+-   Es gibt ein vorbereitetes Macro ‚Tap Tempo'. Kopieren Sie dieses auf
+    eine freie Taste, so wirkt diese als Tap-Taste, sobald ein Chaser
+    verbunden ist: drücken Sie diese mehrfach im gewünschten Rhythmus.
+    Ebenso lässt sich mittels [Tastenprofil (Key Profiles)](../system-settings/key-profiles.md) die blaue oder graue Taste
+    als **Tap Tempo**-Taste belegen
+
+### Fixture Overlap - Geräte-Überlappung
+
+Mit Fixture Overlap - Geräte-Überlappung - werden Änderungen von einem 
+Cue zum nächsten auf die einzelnen Fixtures nacheinander statt gleichzeitig 
+angewendet. Genauer ist dies in [Einstellen von Überblendzeiten und Geräteversatz](../cues/cue-timing.md#einstellen-von-überblendzeiten-und-geräteversatz) erläutert.
+
+## Individuelle Zeiten pro Schritt
+
+Jeder Schritt eines Chasers lässt sich mit gesonderten Zeitvorgaben
+versehen. Dazu können Sie entweder das ‚Playback View'-Fenster oder die
+‚Unfold'-Funktion verwenden.
+
+> Werden sehr komplexe Zeiten benötigt, so bietet sich die Verwendung einer Cueliste an, siehe [Cuelisten](../cue-lists.md).
+
+### Unter Verwendung des 'Playback View'-Fensters:
+
+1. Berühren Sie das Display oberhalb des betreffenden Reglers, oder drücken Sie <Keys.HardKey>Open/View</Keys.HardKey> und die **Swop**-Taste des Speicherplatzes. Darauf öffnet sich das ‚Playback View'-Fenster.<br/>
+   ![Playback View for chase](/docs/images/Playback-View-for-chase.png)
+2. Im Fenster können Sie durch Anklicken die zu ändernden Zeiten auswählen.
+3. Zum Ändern der Zeiten und Einstellungen nutzen Sie die entsprechenden Funktionstasten.
+4. Wiederholen Sie ab Schritt 2, um weitere Änderungen vorzunehmen.
+
+> Zum gleichzeitigen Ändern mehrerer Schritte lassen sich durch
+    'Wischen' über das Display mehrere Cues auf einmal auswählen, oder
+    man benutzt den **Encoder B** zur Mehrfachauswahl.
+
+### Unter Verwendung der 'Unfold'-Funktion
+
+1. Drücken Sie die <Keys.HardKey>Unfold</Keys.HardKey>-Taste und dann die **Swop**-Taste des zu
+editierenden Chasers.
+2. Drücken Sie <Keys.SoftKey>Edit Times</Keys.SoftKey> und dann die **Swop**-Taste des
+gewünschten Schrittes.
+3. Stellen Sie die Zeiten auf die gewünschten Werte ein. Die möglichen
+Optionen sind unten beschrieben.
+4. Drücken Sie <Keys.HardKey>Unfold</Keys.HardKey>, um den Modus zu verlassen.
+
+### Zeit-Optionen
+
+Im Ausgangszustand sind sämtliche Zeitvorgaben auf die globalen Werte
+voreingestellt. Vorgenommene individuelle Einstellungen lassen sich
+rückgängig machen, indem man die Funktionstaste der entsprechenden
+Zeiteinstellung betätigt und den Wert mit <Keys.HardKey>Back</Keys.HardKey> (oder der Backspace-Taste einer angeschlossenen Tastatur) löscht.
+
+The timing options for the cue are:
+
+-   Delay (Verzögerung)
+
+-   Fade In (Einblenden, Überblenden)
+
+-   Fade Out (Ausblenden)
+
+-   Fixture Overlap (Geräteversatz)
+
+-   Link with previous step (mit dem vorigen Schritt verbinden)
+
+-   Attribute times (Attribut-Zeiten, siehe [nächster Abschnitt](#vergeben-von-attribut-zeiten-für-einzelne-schritte))
+
+'Linking' (Verbinden) kann entweder auf <Keys.SoftKey>Link After Previous</Keys.SoftKey>(der
+Schritt folgt unmittelbar auf den vorigen, und der Chaser läuft
+automatisch durch) oder auf <Keys.SoftKey>Link Wait For Go</Keys.SoftKey> (der Schritt wartet auf
+das Betätigen der <Keys.HardKey>Go</Keys.HardKey>-Taste) gestellt werden.
+
+## Vergeben von Attribut-Zeiten für einzelne Schritte
+
+Für jeden Schritt eines Chasers lassen sich ebenso verschiedene
+Überblendzeiten für die einzelnen Attribute, etwa die Position,
+vergeben. Das Vergeben solcher individueller Zeiten überschreibt die
+vorgegebenen normalen Zeiten. Zum Ändern dieser Einstellungen lässt sich
+entweder das ‚Cue View'-Fenster oder die ‚Unfold'-Funktion nutzen.
+
+Zum Vergeben einer Überblendzeit für eine Attributgruppe:
+
+1. Drücken Sie <Keys.HardKey>Open/View</Keys.HardKey> oder die <Keys.HardKey>Unfold</Keys.HardKey>-Taste, und
+danach die **Swop**-Taste des gewünschten Chasers.
+2. Drücken Sie <Keys.SoftKey>Edit Times</Keys.SoftKey>, und wählen danach den zu ändernden
+Schritt im 'Playback View'-Fenster, oder - bei Verwendung der
+'Unfold'-Funktion - mit der entsprechenden **Swop**-Taste aus.
+3. Drücken Sie die **Attribut-Auswahltaste** (rechts) des Attributs, das
+Sie bearbeiten möchten.
+4. Drücken Sie <Keys.SoftKey>Delay</Keys.SoftKey>, um die Verzögerung einzustellen, oder <Keys.SoftKey>Set
+fade</Keys.SoftKey> zum Einstellen der Überblendzeit.
+5. Geben Sie die gewünschte Zeit mit den Zifferntasten, gefolgt von
+<Keys.HardKey>Enter</Keys.HardKey>, ein, oder drücken sie <Keys.HardKey>Back</Keys.HardKey>, um die individuellen
+Einstellungen zu löschen und die globalen Zeiten zu verwenden.
+6. Drücken Sie <Keys.HardKey>Enter</Keys.HardKey> zum Übernehmen der Werte.
+
+## Rate- und BPM-Master
+
+Chaser können einem Rate- oder einem BPM-Master zugewiesen werden -
+dadurch wird dann das Tempo durch einen anderen Masterregler gesteuert.
+Die Zuordnung erfolgt in den [Optionen](../cues/playback-options.md) des Chasers unter <Keys.SoftKey>Effects</Keys.SoftKey>, dann <Keys.SoftKey>Speed Source</Keys.SoftKey>. Siehe Abschnitt [Speed and Size Masters](../running-the-show/playback-controls.md#speed--und-size-master).
+
+## Speed-Faktoren
+
+Mittels Speed-Faktoren kann das Geschwindigkeitsverhältnis zwischen
+mehreren Chasern und Effekten festgelegt werden (etwa x4 oder /2).
+
+Wählen Sie <Keys.SoftKey>Speed Multiplier</Keys.SoftKey> im ‚Edit Times'-Menü des Chasers oder in
+[<Keys.SoftKey>Options</Keys.SoftKey> Tab <Keys.SoftKey>Playback</Keys.SoftKey>](../cues/playback-options.md#speed-multiplier), und 
+stellen Sie den gewünschten Wert mit den Menütasten ein. 
+<Keys.SoftKey>Multiply or Divide</Keys.SoftKey> bestimmt, ob es ein Faktor oder ein Teiler ist.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases/copying-moving-linking-and-deleting.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases/copying-moving-linking-and-deleting.md
@@ -1,0 +1,43 @@
+---
+id: copying-moving-linking-and-deleting
+title: Kopieren, verschieben, verlinken, löschen
+sidebar_label: Kopieren, verschieben, verlinken, löschen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Einen Chaser verschieben oder kopieren
+
+Mit den Tasten <Keys.HardKey>Copy</Keys.HardKey> und <Keys.HardKey>Move</Keys.HardKey> können Chaser 
+kopiert oder auf einen anderen Speicherplatz verschoben
+werden, oder Sie können eine Verknüpfung auf einen bestehenden Chaser
+erstellen. Verschieben ist sinnvoll zum Erhalt einer aufgeräumten
+Arbeitsoberfläche. Verknüpfungen bieten sich an, wenn aus Gründen des
+Showablaufs der gleiche Chaser auf mehreren Playback-Seiten abrufbar
+sein soll; dabei enthält der verknüpfte Chaser generell die gleichen
+Informationen wie das Original, kann aber andere Zeiten und Optionen
+zugewiesen bekommen.
+
+Das Vorgehen ist das gleiche wie beim Kopieren/Verschieben/Verknüpfen
+von Cues, und ist in Abschnitt 
+[Kopieren, verschieben, verlinken, löschen von Cues](../cues/copying-moving-linking-and-deleting.md) genau beschrieben.
+
+## Löschen eines Chasers
+
+Zum Löschen eines kompletten Chasers drücken Sie <Keys.HardKey>Delete</Keys.HardKey>, dann die **Auswahltaste** des Chasers. Drücken Sie diese zur Bestätigung nochmals.
+
+## Löschen eines Schrittes aus einem Chaser
+
+Um einen einzelnen Schritt zu löschen:
+
+1. Drücken Sie die <Keys.HardKey>Delete</Keys.HardKey>-Taste.
+2. Drücken Sie die **Auswahltaste** des Chasers.
+3. Auf dem Display werden nun die Schritte des Chasers angezeigt.
+Wählen Sie mit dem **linken Encoder** den zu löschenden Schritt, oder geben Sie
+dessen Nummer mit den Zifferntasten ein.
+4. Drücken Sie <Keys.SoftKey>Delete Cue x</Keys.SoftKey>, um den Schritt zu löschen.
+5. Bestätigen Sie den Löschvorgang mit <Keys.SoftKey>Confirm</Keys.SoftKey>.
+
+> Alternativ lassen sich auch einzelne Schritte mit der
+[<Keys.HardKey>Unfold</Keys.HardKey>-Funktion](editing-a-chase.md#ändern-eines-chasers-mit-der-unfold-funktion) löschen.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases/creating-a-chase.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases/creating-a-chase.md
@@ -1,0 +1,88 @@
+---
+id: creating-a-chase
+title: Erstellen eines Chasers
+sidebar_label: Erstellen eines Chasers
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Einen Chaser programmieren
+
+<Video videoId="M0h5zV4S_OI" title="Recording a Chase" />
+
+Zum Programmieren eines Chasers stellen Sie für jeden Schritt das
+gewünschte Bild ein und speichern es.
+
+Dazu können Sie alle Geräte und Dimmer einzeln einstellen, Sie können
+per [Quick Build](#einen-chaser-mit-quick-build-erstellen) einen Chaser aus 
+[Paletten](../palettes.md) und [Cues](../cues.md) zusammenstellen,
+oder Sie benutzen <Keys.HardKey>Include</Keys.HardKey>, siehe [Include-Funktion](../cues/editing-cues.md#cues-wiederverwenden---die-include-funktion), um bereits programmierte Cues zu verwenden.
+
+1. Drücken Sie die Taste <Keys.HardKey>Record</Keys.HardKey>, dann <Keys.SoftKey>Chase</Keys.SoftKey> (oder 2x <Keys.HardKey>Record</Keys.HardKey>). 
+*(Ältere Pulte haben dafür die Taste <Keys.HardKey>Record Chase</Keys.HardKey>).*
+2. Drücken Sie die **Swop**-Taste des Playbacks, auf das Sie den Chaser
+speichern möchten *(ebenso lassen sich Chaser auf die Schaltflächen im
+'Playbacks'-Fenster speichern)*.
+3. Stellen Sie das gewünschte Bild für den ersten Schritt ein, entweder
+manuell, oder unter Verwendung bestehender Cues per <Keys.HardKey>Include</Keys.HardKey>.
+4. Die Nummer des aktuellen Schrittes lässt sich mit <Keys.SoftKey>Step Number</Keys.SoftKey>
+ändern.
+5. Betätigen Sie die **Swop**-Taste des Playbacks, um den Inhalt des
+Programmierspeichers als Schritt eines Chasers zu speichern. Alternativ
+können Sie <Keys.SoftKey>Append Step</Keys.SoftKey> (Schritt anfügen) aus dem Menü verwenden.
+6. Drücken Sie <Keys.HardKey>Clear</Keys.HardKey> *(außer wenn Sie den Inhalt des
+Programmierspeichers teilweise weiterverwenden wollen)*, und wiederholen
+den Vorgang ab Schritt 3 zum Erstellen des nächsten Chase-Schrittes.
+7. Drücken Sie <Keys.HardKey>Exit</Keys.HardKey> zum Beenden, wenn Sie alle gewünschten Schritte
+gespeichert haben.
+
+-   Mit <Keys.SoftKey>Record Mode</Keys.SoftKey> wählt man zwischen:
+
+    - <Keys.SoftKey>Record By Fixture</Keys.SoftKey> (Speichern pro Gerät) - alle Attribute 
+	aller angewählten oder veränderten Geräte werden gespeichert
+
+    - <Keys.SoftKey>Record By Channel</Keys.SoftKey> (Speichern pro Kanal) - nur die geänderten 
+	Attribute werden gespeichert
+
+    - <Keys.SoftKey>Record Stage</Keys.SoftKey> (Bühne speichern) - alle Geräte mit
+    Helligkeit > 0 werden gespeichert
+
+    - <Keys.SoftKey>Quick Build</Keys.SoftKey> - [siehe nächster Abschnitt](#einen-chaser-mit-quick-build-erstellen)
+
+-   Die aktuelle Schrittnummer sowie die Gesamtzahl der Schritte wird in
+    der oberen Zeile des Displays angezeigt.
+
+-   Drücken Sie <Keys.HardKey>Clear</Keys.HardKey>, wenn Sie mit dem Programmieren fertig sind;
+    anderenfalls überlagert der Programmierspeicher den aufgerufenen
+    Chaser, so dass nicht das gewünschte Ergebnis zu sehen ist.
+
+-   In Chasern lassen sich auch [Shapes](../effects.md) verwenden. 
+	Wird derselbe Shape in mehreren aufeinanderfolgenden Schritten 
+	verwendet, so läuft er nahtlos durch; anderenfalls endet er mit 
+	dem jeweiligen Schritt. *(‚Derselbe' Shape wird dann angenommen, 
+	wenn nach dem vorherigen Schritt nicht <Keys.HardKey>Clear</Keys.HardKey> gedrückt wurde 
+	und Größe, Geschwindigkeit und Phase des Shapes nicht verändert 
+	wurden, oder wenn der Shape per <Keys.HardKey>Include</Keys.HardKey> 
+	aus dem vorherigen Schritt übernommen und nicht modifiziert wurde.)*
+
+-   Dem Chaser kann eine Bezeichnung zugeordnet werden: drücken Sie dazu <Keys.SoftKey>Set Legend</Keys.SoftKey>, und dann die **Swop**-Taste des Chasers, um dann,
+    wie auch bei Cues, die Bezeichnung einzugeben.
+
+-   Chaser können aus einer unbegrenzten Anzahl von Schritten bestehen.
+
+## Einen Chaser mit Quick Build erstellen
+
+Mit Quick Build kann man, wie der Name schon vermuten lässt, sehr rasch
+einen Chaser aus bestehenden Cues und Paletten erstellen.
+
+Beginnen Sie wie oben beschrieben, einen Chaser zu programmieren, und
+setzen Sie den <Keys.SoftKey>Record Mode</Keys.SoftKey> auf ‚Quick Build'.
+
+Wählen Sie nun einen Cue oder eine [Palette](../palettes.md) aus, um einen Schritt zu
+erstellen. Werden mehrere Cues/Paletten ausgewählt, so wird jeweils ein
+neuer Schritt angefügt.
+
+Um nur ausgewählte Geräte aus einer Palette oder einem Playback zu
+verwenden, wählen Sie zunächst die Geräte aus, und klicken dann auf die
+Palette/das Playback.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases/editing-a-chase.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/chases/editing-a-chase.md
@@ -1,0 +1,81 @@
+---
+id: editing-a-chase
+title: Editieren eines Chasers
+sidebar_label: Editieren eines Chasers
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Einen Chaser zum Editieren öffnen
+
+Neue Schritte lassen sich wie gewohnt mit <Keys.HardKey>Record</Keys.HardKey> und der
+**Swop**-Taste des Playbacks am Ende des Chasers anfügen.
+
+Zur Anzeige einer Übersicht der vorhandenen Schritte dient die 'Playback
+View'-Ansicht (berühren Sie das Display oberhalb des Reglers, oder
+drücken Sie <Keys.HardKey>Open/View</Keys.HardKey> und die entsprechende
+&nbsp;**Swop**-Taste). Um eine bestimmte Zeitvorgabe zu ändern, klicken Sie
+auf den entsprechenden Wert (oder auf einen ganzen Bereich) auf dem Touchscreen.
+und benutzen die Funktionstasten für die gewünschte Änderung.
+
+![Playback View of a chase](/docs/images/Playback-View-for-chase.png)
+
+## Ändern eines Chasers mit der Unfold-Funktion
+
+Eine weitere Möglichkeit zum Editieren eines Chasers bietet die
+Unfold-Funktion. Die Taste <Keys.HardKey>Unfold</Keys.HardKey> (‚Aufklappen') legt jeden
+einzelnen Schritt eines Chasers auf einen der Regler, so dass sich jeder
+Schritt einzeln aufrufen und editieren lässt, als wäre er ein separater
+Cue. Ebenso lassen sich damit einzelne Zeitvorgaben für jeden Schritt
+machen.
+
+1. Drücken Sie die <Keys.HardKey>Unfold</Keys.HardKey>-Taste, und dann die **Swop**-Taste 
+des zu bearbeitenden Chasers.
+2. Die ersten zehn oder 15 Chaserschritte (ja nachdem wie viel Playbackfader das Pult hat)
+werden daraufhin auf die Regler abgebildet.
+3. Aktivieren Sie einen Regler, um den jeweiligen Schritt zu sehen
+*(dabei werden die Überblendzeiten wie programmiert abgerufen)*.
+4. Die verschiedenen Optionen des 'Unfold'-Menüs werden weiter unten
+beschrieben.
+5. Drücken Sie nochmals <Keys.HardKey>Unfold</Keys.HardKey>, um den Modus wieder zu beenden.
+
+-   Um einen Schritt zu **ändern**, drücken Sie <Keys.HardKey>Clear</Keys.HardKey>, um den
+    Programmierspeicher zu löschen, aktivieren den Schritt mit dem
+    entsprechenden Regler, machen die gewünschten Änderungen, drücken <Keys.SoftKey>Record Step</Keys.SoftKey>, und anschließend die **Swop**-Taste des
+    entsprechenden Schrittes.
+
+-   Zum **Einfügen** eines Schrittes zwischen zwei vorhandene Schritte
+    stellen Sie zunächst das gewünschte Bild ein, drücken dann <Keys.SoftKey>Insert Step</Keys.SoftKey> und geben mit den Ziffern die gewünschte Schrittnummer ein
+    (etwa 1.5, wenn der Schritt zwischen den Schritten 1 und 2 eingefügt
+    werden soll). Sollte ein Schritt mit dieser Nummer bereits vorhanden
+    sein, so wird dieser mit den neuen Einstellungen gemischt;
+    anderenfalls wird ein neuer Schritt eingefügt.
+
+-   Zum **Anhängen** eines neuen Schritts am Ende des Chasers stellen Sie
+    das gewünschte Bild ein, drücken <Keys.SoftKey>Insert Step</Keys.SoftKey>, und anschließend
+    die **Swop**-Taste des nächsten freien Schrittes.
+
+-   Um die aktuellen Werte im Programmierspeicher in den aktuellen
+    Schritt zu integrieren (**mergen**), klicken Sie zweimal auf <Keys.SoftKey>Record Step</Keys.SoftKey>.
+
+-   Zum **Ändern** einzelner Zeiteinstellungen drücken Sie <Keys.SoftKey>Edit Times</Keys.SoftKey>,
+    dann die entsprechende **Swop**-Taste (oder tippen die Schrittnummer
+    ein), und stellen die gewünschten Zeiten ein. Details dazu finden
+    sich im Abschnitt [Zeiten bei Chasern](chase-timing.md).
+
+-   Enthält der Chaser mehr Schritte als es Fader gibt, so lässt sich
+    mit den Funktionstasten <Keys.SoftKey>Previous Page</Keys.SoftKey> (zurück) und <Keys.SoftKey>Next Page</Keys.SoftKey>
+    (vor) zwischen den Seiten umschalten.
+
+## Laden eines Chase-Schritts mit Include
+
+Einzelne Chaser-Schritte lassen sich ebenfalls per Include-Funktion in
+den Programmer laden. Dazu drücken Sie <Keys.HardKey>Include</Keys.HardKey>, wählen den Chaser,
+tippen die gewünschte Schritt-Nummer ein und drücken <Keys.SoftKey>Include Cue</Keys.SoftKey>.
+
+Damit kann man z.B. einen Chase-Schritt in einem anderen Chaser
+wiederverwenden oder als Einzelcue speichern. Ebenso sinnvoll ist das,
+wenn man z.B. Shapes oder Effekte in diesem Schritt editieren will und
+das nicht in der Playback-Ansicht macht. Siehe 
+[Playback View window](#einen-chaser-zum-editieren-öffnen).

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures.md
@@ -1,0 +1,479 @@
+---
+id: controlling-fixtures
+title: Anwählen von Geräten und Dimmern
+sidebar_label: Anwählen von Geräten und Dimmern
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Um eine Show zu programmieren - und mitunter auch während der Show - müssen Fixtures und Dimmer ausgewählt 
+werden, um deren Attribute - Dimmer, Position, Farbe etc. - einzustellen. 
+
+## Dimmer und Geräte zum Steuern auswählen
+
+Um die zu steuernden Geräte und Dimmer auszuwählen, betätigen Sie die
+entsprechenden Geräte-Buttons im Fenster **Fixtures**, womit die Geräte in den Editor geladen
+werden. Geräte können auch in einer Layout-Anzeige ausgewählt werden, siehe [Layouts](./controlling-fixtures/layouts.md). Es lassen sich einzelne oder mehrere verschiedene Geräte auf
+einmal anwählen. Ebenso lassen sich Gruppen verwenden, um mehrere Geräte
+auf einmal anzuwählen, siehe [Gruppen](./controlling-fixtures/fixture-groups.md).
+
+Ist das Gerät/der Dimmer auf einen Fader gepatcht, so drücken Sie die zugehörige blaue Taste, um die Auswahl vorzunehmen.
+
+![Fixtures Window](/docs/images/Fixtures-Window.png)
+
+1. Betätigen Sie die Buttons/Tasten der gewünschten Geräte. Die
+Schaltflächen erscheinen daraufhin hellblau, bei auf Tasten gepatchten
+Geräten leuchten die LEDs hell auf.
+2. Um eine größere Zahl von Geräten auszuwählen, ziehen Sie mit dem
+Finger einen entsprechenden Auswahlrahmen. Bei Tasten halten Sie die
+erste gedrückt und betätigen dazu die letzte.
+
+Ein paar weitere wissenswerte Dinge:
+
+-   Die Taste <Keys.HardKey>Locate</Keys.HardKey> aktiviert die angewählten Geräte weiß (ohne
+    Farbe) und in Grundstellung (Pan und Tilt jeweils 50%). Weitere
+    Optionen dazu sind im [nächsten Abschnitt](./controlling-fixtures.md#geräte-auf-startposition-setzen-locate) erläutert.
+
+-   Um ein Gerät aus der Auswahl zu entfernen, einfach die betreffende
+    Auswahltaste erneut betätigen.
+
+-   Oben am Touchscreen, direkt oberhalb der oberen Fenster, werden die
+    momentan angewählten Geräte angezeigt.
+
+-   Drücken Sie <Keys.HardKey>Clear</Keys.HardKey> (rechts vom Zifferntastenblock), um sämtliche
+    Geräte aus der Auswahl zu entfernen und sämtliche Änderungen aus dem
+    Programmierspeicher zu löschen. Weitere Optionen dazu sind im
+    [nächsten Abschnitt](./controlling-fixtures.md#clear----löschen-des-programmers-und-der-geräteauswahl) erläutert. 
+
+-   Sobald ein Attribut verändert und wieder eine Auswahltaste betätigt
+    wurde, werden sämtliche Geräte aus der Auswahl entfernt, und der
+    Auswahlprozess startet von neuem. Alle vormals angewählten Geräte
+    (seit der letzten Betätigung von <Keys.HardKey>Clear</Keys.HardKey>) verbleiben im
+    Programmierspeicher. Sobald ein Gerät editiert wurde, erscheint die
+    betreffende Schaltfläche in Dunkelblau. Im obigen Bild sind die
+    ersten beiden Geräte angewählt, die folgenden drei im
+    Programmierspeicher, und alle anderen nicht angewählt oder editiert.
+
+-   Zur Auswahl von Geräten auf weiteren Seiten der Geräte-Auswahlliste
+    kann man entweder mit den 'Page' (Seiten)-Tasten links der
+    Gerätetasten die Seiten umschalten, oder (sofern die 'Page'-Tasten
+    per Kontext-Taste ausgeblendet sind) mit dem Schiebe-Reiter durch
+    die Liste navigieren. Für Fader/Tasten gibt es getrennte tasten für
+    die Seitenumschaltung: beim Pearl expert sind dies die vier Tasten
+    oberhalb des Ziffernblocks, bei den anderen Pulten die Tasten oder
+    Buttons Page+/Page- bei den Fadern.
+
+-   Mit den [Tastenprofilen](./system-settings/key-profiles.md) lässt sich
+    die Geräte-Auswahltaste in den Einrast-Modus ('latch mode')
+    umschalten, so dass damit der Dimmerkanal des betreffenden Gerätes
+    geschaltet wird (gleiches Ergebnis wie Setzen des Faders auf 100%).
+
+## Geräte auf Startposition setzen (Locate)
+
+Die Taste <Keys.HardKey>Locate</Keys.HardKey> (unten rechts auf dem Pult) versetzt die
+angewählten Geräte in eine definierte Ausgangsposition mit 'Licht an',
+um den Start des Programmierens zu vereinfachen.
+
+Ein einfaches Betätigen der Taste bewegt alle Geräte auf 'Mitte' (50%
+Pan/Tilt) und setzt sämtliche Attribute zurück, resultierend in einfach
+weißem Licht. Dennoch ist es zuweilen wünschenswert, etwa die Geräte
+dabei nicht zu bewegen oder andere Attribute unverändert zu lassen. 
+
+-  Per **Locate** werden keine Werte im Programmer gesetzt. Entsprechend wird im 
+Speichermodus **Record by Channel** nichts gespeichert, wenn nicht Attribute manuell verändert wurden. 
+(Siehe [Speichermodus/Record Mode](./cue-lists/creating-a-cue-list.md#speichermodusrecord-mode)).
+
+Hält man die <Keys.HardKey>Locate</Keys.HardKey>-Taste gedrückt, so erscheinen im Menü weitere  Funktionen:
+
+-   Sie können einige der 'Locate'-Funktionen maskieren (z.B. nur 'das
+    Licht einschalten', ohne Position oder Farbe zu verändern), indem
+    bei gedrückter <Keys.HardKey>Locate</Keys.HardKey>-Taste die Funktion <Keys.SoftKey>Set Mask to Exclude All</Keys.SoftKey> gewählt wird. Darauf - bei noch gedrückt gehaltener <Keys.HardKey>Locate</Keys.HardKey>-Taste - 
+    schalten Sie die einzelnen Attribute, die Sie
+    auf Startposition haben wollen, mittels der Attribut-Tasten ein. Nur
+    die so angewählten Attribute werden nun bei 'Locate' zurückgesetzt.
+    Ein Druck auf <Keys.HardKey>Attribute Options</Keys.HardKey> löscht wiederum die Maskierung.
+
+-   Die Option <Keys.SoftKey>Auto Reset Mask</Keys.SoftKey> löscht die Maskierung automatisch, so
+    dass bei jedem 'Locate'-Vorgang wieder sämtliche Attribute
+    beeinflusst werden. Alternativ bestimmt die Option <Keys.SoftKey>Remember Mask</Keys.SoftKey>, dass die Maskierung erhalten bleibt.
+
+-   Die Option <Keys.SoftKey>Don't Clear/Clear Located Attributes</Keys.SoftKey> hilft dabei zu verhindern, 
+	versehentlich Locate-Werte zu speichern, wenn ein Cue im Modus **Record by Channel** gespeichert werden soll. 
+	Steht die Option auf **Don't clear** (Vorgabewert), so werden beim Betätigen von <Keys.HardKey>Locate</Keys.HardKey> 
+	bereits im Programmer vorhandene Werte auf Locate-Werte geändert und später mit in den Cue gespeichert.
+	Steht die Option dagegen auf **Clear**, so werden bereits im Programmer befindliche Werte beim Betätigen 
+	von <Keys.HardKey>Locate</Keys.HardKey> gelöscht und nicht mit in den Cue gespeichert.
+	
+> Um schnell zu 'Locaten', **ohne Pan/Tilt zu verändern**, drücken und halten Sie <Keys.HardKey>Locate</Keys.HardKey>, drücken dazu <Keys.HardKey>Pan/Tilt</Keys.HardKey> und lassen nun <Keys.HardKey>Locate</Keys.HardKey> los.<br/> 
+Um **nur Pan/Tilt zu locaten**, drücken und halten Sie <Keys.HardKey>Locate</Keys.HardKey>, drücken 
+dazu <Keys.HardKey>Options</Keys.HardKey> (bzw. <Keys.HardKey>Attribute Options</Keys.HardKey> auf älteren Pulten), drücken dann <Keys.HardKey>Pan/Tilt</Keys.HardKey>, und lassen nun <Keys.HardKey>Locate</Keys.HardKey> los.
+
+
+### Ändern des Locate-Wertes
+
+Ebenso können Sie den Locate-Wert des Gerätes für die betreffende Show
+ändern, und zwar entweder für das eine angewählte Gerät, oder für alle
+Geräte dieses Typs. Stellen Sie dazu den gewünschten Wert für das
+entsprechende Gerät ein, drücken Sie <Keys.HardKey>Record</Keys.HardKey>, dann <Keys.HardKey>Locate</Keys.HardKey>.
+Wählen Sie nun <Keys.SoftKey>Shared</Keys.SoftKey> (gemeinsam = alle Lampen dieses Typs) 
+oder <Keys.SoftKey>Individual</Keys.SoftKey> (nur einzelne Geräte). Drücken Sie schließlich 
+nochmals <Keys.HardKey>Record</Keys.HardKey> oder <Keys.HardKey>Locate</Keys.HardKey>.
+
+## Clear -- Löschen des Programmers und der Geräteauswahl
+
+Die Taste <Keys.HardKey>Clear</Keys.HardKey> (rechts vom Zifferntastenblock) löscht sämtliche
+Änderungen aus dem Programmierspeicher sowie die aktuelle Geräteauswahl.
+
+Normalerweise löscht ein **einfacher** Druck auf die Taste sowohl den Programmer als auch die Geräteauswahl. 
+Dies lässt sich ändern, so dass entweder **zuerst** der Programmer und erst **mit einem zweiten Tastendruck** 
+die Geräteselektion gelöscht wird oder umgekehrt. Siehe [Action Precedence](controlling-fixtures.md#clear-optionen).
+
+### Das Clear-Menü
+
+Hält man die Taste <Keys.HardKey>Clear</Keys.HardKey> gedrückt, erscheinen weitere Optionen. Diese werden 
+jeweils ausgeführt, sobald die <Keys.HardKey>Clear</Keys.HardKey>-Taste losgelassen wird.
+
+Mit **Set Mask** lassen sich einzelne Attribute zum Löschen maskieren (etwa: die
+Position im Programmierspeicher belassen, aber alles andere
+löschen); dazu bei gedrückter <Keys.HardKey>Clear</Keys.HardKey>-Taste die 
+Option <Keys.HardKey>Set Mask to Clear Nothing</Keys.HardKey> wählen. Darauf (noch 
+immer <Keys.HardKey>Clear</Keys.HardKey> gedrückt halten) lassen sich mit den Attribut-Tasten die zu löschenden
+Attribute einzeln wählen, oder Sie wählen <Keys.SoftKey>Set Mask</Keys.SoftKey> und benutzen
+die Kontext-Tasten. Nun werden nur die angezeigten Attribute gelöscht. 
+
+Ein Druck auf die Taste <Keys.SoftKey>Attribute Options</Keys.SoftKey> bzw. <Keys.SoftKey>Options</Keys.SoftKey>
+wiederum löscht die Maskierung. 
+
+Mit der Option **Time** kann man einstellen, ob die Fade-/Delayzeiten im Programmierspeicher für alle
+Attribute ebenfalls gelöscht oder aber beibehalten werden sollen(werden einzelne Attribute gelöscht, 
+so werden auch die Zeiten für die jeweiligen Attribute gelöscht; setzt man also die Maske auf P,
+so werden die Zeiten für Pan/Tilt gelöscht).
+
+Lässt man die Taste <Keys.HardKey>Clear</Keys.HardKey> los, so werden alle in der Maske ausgewählten 
+Attribute aus dem Programmer gelöscht, und die Clear-Maske wird auf **Clear All** zurückgesetzt. Das automatische
+Zurücksetzen lässt sich wie unten beschrieben deaktivieren, so dass die Clear-Maske beibehalten wird.
+
+-   Hält man <Keys.HardKey>Clear</Keys.HardKey> gedrückt und betätigt dazu <Keys.HardKey>All</Keys.HardKey>, so werden
+    alle Geräte deselektiert, aber die Werte verbleiben im Programmierspeicher.
+
+-   <Keys.SoftKey>Clear Options</Keys.SoftKey> öffnet ein Untermenü mit weiteren, im nächsten Abschnitt 
+    beschriebenen Optionen.
+
+-   Mit <Keys.SoftKey>Clear All Fixtures/Selected Fixtures</Keys.SoftKey> bestimmen Sie, ob
+    sämtliche, oder nur die aktuell ausgewählten, Geräte aus dem
+    Programmierspeicher gelöscht werden sollen.
+
+-   <Keys.SoftKey>Individual Attributes</Keys.SoftKey> erlaubt das Löschen einzelner Attribute
+    aus dem Programmierspeicher. Beim Betätigen dieser Taste erhalten
+    Sie eine Liste der aktuell im Programmierspeicher vorhandenen
+    Attribute, die sich mit der jeweiligen Taste einzeln löschen lassen.
+
+-   <Keys.SoftKey>Clear All Programmers</Keys.SoftKey> löscht alle zurzeit verwendeten
+    Programmierspeicher. Dies betrifft insbesondere Werte, die mit der
+    Remote, von einem anderen Pult/User in einer Multiuser-Session sowie
+    beim Erstellen von Keyframe-Shapes gesetzt wurden.
+
+### Clear-Optionen
+
+Es gibt folgende weitere "Clear-Optionen". Diese gelten pro Benutzer und können auch im Tab Clear 
+der [Benutzereinstellungen](./system-settings/user-settings.md#clear) geändert werden.
+
+-   <Keys.SoftKey>Auto Reset Mask</Keys.SoftKey> setzt die Maskierung bei jedem Betätigen der
+    'Clear'-Taste automatisch zurück. Alternativ bestimmt <Keys.SoftKey>Remember Mask</Keys.SoftKey>, 
+    dass die Maskierung erhalten bleibt.
+
+-   &nbsp;<Keys.SoftKey>Leave/Zero Preset Fader Levels</Keys.SoftKey> bestimmt, ob Faderwerte von
+    Geräten mit <Keys.HardKey>Clear</Keys.HardKey> auf 0 gesetzt werden sollen oder nicht. (Das
+    Tastenprofil der Geräteauswahl lässt sich auf 'Einrasten' (Latch)
+    stellen, womit der Dimmerkanal des Gerätes eingeschaltet wird,
+    sobald das Gerät angewählt wird, siehe [Key Profiles](./system-settings/key-profiles.md)).
+
+-   Mit <Keys.SoftKey>Freeze current values</Keys.SoftKey> lässt sich festlegen, was mit
+    LTP-Kanälen (nicht Helligkeit) geschieht, deren Wert modifiziert
+    wurde. Steht diese Option auf <Keys.SoftKey>Freeze Current Values</Keys.SoftKey>, so behalten
+    diese Kanäle die gewählten Werte. Steht die Option auf <Keys.SoftKey>Release To Playback Values</Keys.SoftKey>, 
+    so werden die Kanäle auf die Werte der aktuell laufenden Cues zurückgesetzt. Beispiel: 
+    wird ein Cue aufgerufen, in dem einige Geräte grün abgespeichert sind, und nun manuell deren
+    Farbe auf Rot geändert, so werden diese bei 'Clear' und der Option <Keys.SoftKey>Freeze</Keys.SoftKey> rot 
+    bleiben; ist hingegen die Option <Keys.SoftKey>Release</Keys.SoftKey> angewählt, so werden die Geräte zum
+    gespeicherten Grün zurückgesetzt.
+
+-   <Keys.SoftKey>Clear/Maintain Cue Times</Keys.SoftKey> bestimmt, ob Cue-Zeiten im
+    Programmierspeicher gelöscht oder aber beibehalten werden (dies ist
+    unabhängig von Attributzeiten im Speicher).
+
+-   <Keys.SoftKey>Clear/Maintain Rate Settings</Keys.SoftKey> bestimmt, ob Rate-Einstellungen (also die Speed 
+    Source, z.B. Master) gecleart werden sollen oder nicht.
+
+-   <Keys.SoftKey>Clear Direction</Keys.SoftKey> Löschen der Direction (Richtung) aus dem Programmer oder nicht.
+
+-   <Keys.SoftKey>Action Precedence</Keys.SoftKey> Einstellungen zum zweistufigen <Keys.HardKey>Clear</Keys.HardKey>:
+
+    - Selection With Programmer: **(default)** Betätigen der Clear-Taste löscht sowohl Programmer als auch Geräteauswahl
+
+    - Selection Then Programmer: sind Geräte angewählt, so wird mit Clear die Geräteauswahl gelöscht. Sind keine Geräte vorhanden, so wird der Programmer gelöscht.
+
+    - Programmer Then Selection: Befinden sich Werte im Programmer, so werden mit Clear diese gelöscht. Wenn der Programmer leer ist, wird die Geräteauswahl gelöscht.
+
+> Geben Sie mit den Zifferntasten eine Zahl ein und drücken dann <Keys.HardKey>Clear</Keys.HardKey>, so faden im Programmer befindliche HTP-Werte in dieser Zeit (in Sekunden) aus. Gibt man etwa 5 ein und drückt <Keys.HardKey>Clear</Keys.HardKey>, so wird in 5 Sekunden ausgefadet. Damit kann man unauffällig mit dem Programmer arbeiten.
+
+### Direktes Clearen einzelner Attribute
+
+Mit dem Fenster [Channel Grid](./controlling-fixtures/viewing-and-editing-fixture-values.md#übersicht-über-die-kanäle-das-channel-grid-fenster) können einzelne Attribute einzelner
+Geräte selektiv gelöscht werden.
+
+## Geräte mit mehreren Zellen/Subfixtures
+
+Verfügt ein Gerät über mehrere einzeln steuerbare Bereiche (z.B.
+LED-Bars) und ist die Personality entsprechend angepasst, so kann man
+wahlweise das gesamte Gerät oder einzelne Zellen steuern. Dies empfiehlt
+sich besonders bei Verwendung von Shapes sowie dem Pixelmapper.
+
+Wird das Gerät mit der Schaltfläche angewählt, auf die es gepatcht
+wurde, so werden alle Zellen synchron gesteuert.
+
+Um auf die einzelnen Zellen zuzugreifen, können Sie die entsprechenden
+Reiter oben im Attribut-Editor verwenden, wobei der ganz linke Reiter
+das Gesamtgerät steuert und daneben Reiter für die einzelnen Zellen sind
+(zum Öffnen des Attribut-Editors verwenden Sie z.B. den vorgegebenen
+Workspace oder drücken zweimal auf <Keys.HardKey>Open/View</Keys.HardKey> 
+und wählen den Attribut-Editor).
+
+![Cell Selection](/docs/images/Cell-Selection.png)
+
+Ebenso können Sie dazu die Unfold-Funktion verwenden: drücken Sie <Keys.HardKey>Unfold</Keys.HardKey> 
+und dann die entsprechende Geräteschaltfläche. Daraufhin
+werden im Gerätefenster Schaltflächen für die einzelnen Zellen
+angezeigt. Verwenden Sie dies auf Geräten auf Fadern/Tasten, so werden
+die Zellen ab Fader 1 eingeblendet.
+
+Es gibt zwei Möglichkeiten für Unfold:
+
+-   Drücken Sie <Keys.HardKey>Unfold</Keys.HardKey> und wählen Sie mehrere Geräte aus. Die
+    entsprechenden Schaltflächen für die Zellen erscheinen sofort im
+    Gerätefenster.
+
+-   Wählen Sie die Geräte aus und drücken Sie <Keys.HardKey>Unfold</Keys.HardKey>. Wählen Sie 
+    nun <Keys.SoftKey>Selected Fixtures</Keys.SoftKey>. Dies bietet sich insbesondere für mehrere
+    nicht unmittelbar aufeinander folgende Geräte an.
+
+Um in die normale Anzeige zu wechseln, wählen Sie <Keys.HardKey>Unfold</Keys.HardKey>, 
+dann <Keys.SoftKey>Exit Unfold</Keys.SoftKey>.
+
+Einzelne Zellen lassen sich auch über eine spezielle Syntax mit den
+Zifferntasten auswählen (<Keys.HardKey>THRO</Keys.HardKey> ist auf manchen Pulten 'Through'):
+
+| Tasten                                         | Auswahl                                                 |
+|------------------------------------------------|---------------------------------------------------------|
+| <Keys.HardKey>.</Keys.HardKey>  	                                     | Alle Zellen der gewählten Geräte                        |
+| **n** <Keys.HardKey>.</Keys.HardKey>                                    | Alle Zellen von Gerät **n**                             |
+| <Keys.HardKey>.</Keys.HardKey> <Keys.HardKey>THRO</Keys.HardKey> <Keys.HardKey>.</Keys.HardKey> **j**                     | Zellen 1 bis **j** aller gewählten Geräte               |     
+| **n** <Keys.HardKey>.</Keys.HardKey> <Keys.HardKey>THRO</Keys.HardKey>                           | Alle Zellen der Geräte ab Nr. **n** des jeweiligen Typs |
+| **n** <Keys.HardKey>THRO</Keys.HardKey> <Keys.HardKey>.</Keys.HardKey> **j**                     | Kurzform, s.o.                                          |
+| **n** <Keys.HardKey>.</Keys.HardKey> <Keys.HardKey>THRO</Keys.HardKey> **i**                     | Zellen 1 bis **i** von Gerät **n**                      |
+| <Keys.HardKey>.</Keys.HardKey> **m**          		                     | Zelle **m** aller ausgewählten Geräte                   |
+| **n** <Keys.HardKey>.</Keys.HardKey> <Keys.HardKey>THRO</Keys.HardKey> **i** <Keys.HardKey>.</Keys.HardKey> **j**         | Zellen 1 bis **j** der Geräte **n** bis **i**           |
+| <Keys.HardKey>.</Keys.HardKey> **m** <Keys.HardKey>THRO</Keys.HardKey>                           | Zellen ab **m** der gewählten Geräte                    |
+| **n** <Keys.HardKey>.</Keys.HardKey> **m**                              | Zelle **m** von Gerät **n**                             |
+| <Keys.HardKey>.</Keys.HardKey> **m** <Keys.HardKey>THRO</Keys.HardKey> <Keys.HardKey>.</Keys.HardKey> **j**               | Zellen **m** bis **j** aller gewählten Geräte           |    
+| **n** <Keys.HardKey>.</Keys.HardKey> **m** <Keys.HardKey>THRO</Keys.HardKey>                     | Zellen ab **m** des Gerätes **n**                       |
+| <Keys.HardKey>.</Keys.HardKey> **m** <Keys.HardKey>THRO</Keys.HardKey> **j**                     | Kurzform, s.o.                                          |
+| **n** <Keys.HardKey>.</Keys.HardKey> **m** <Keys.HardKey>THRO</Keys.HardKey> **i**               | Zellen **m** bis **i** von Gerät **n**                  |
+| **n** <Keys.HardKey>THRO</Keys.HardKey> **i** <Keys.HardKey>.</Keys.HardKey>                     | alle Zellen der Geräte **n** bis **i**                  |
+| **n** <Keys.HardKey>.</Keys.HardKey> **m** <Keys.HardKey>THRO</Keys.HardKey> **i** <Keys.HardKey>.</Keys.HardKey>         | Zellen ab **m** der Geräte **n** - **i**                |
+| **n** <Keys.HardKey>THRO</Keys.HardKey> **i** <Keys.HardKey>.</Keys.HardKey> **j**               | Zelle **j** der Geräte **n** - **i**                    |
+| **n** <Keys.HardKey>.</Keys.HardKey> **m** <Keys.HardKey>THRO</Keys.HardKey> **i** <Keys.HardKey>.</Keys.HardKey> **j**   | Zellen **m** - **j** der Geräte **n** - **i**           |
+| **n** <Keys.HardKey>THRO</Keys.HardKey> <Keys.HardKey>.</Keys.HardKey> **j**                     | Zellen 1 - **j** von Gerät **n**                        |
+| **n** <Keys.HardKey>.</Keys.HardKey> **m** <Keys.HardKey>THRO</Keys.HardKey> <Keys.HardKey>.</Keys.HardKey> **j**         | Zellen **m** - **j** von Gerät **n**                    |
+
+-   Die Auswahl von Zellen kann als separate Gruppe gespeichert werden.
+    Damit können später verschiedene Zusammenstellungen von Zellen
+    aufgerufen werden, ohne jedes Mal den Attribut Editor oder Unfold
+    zu verwenden.
+
+## Anwählen von Dimmern/Geräten nach (Kanal-)Nummer
+
+In bestimmten Situationen, etwa beim Programmieren einer Vielzahl von
+Dimmern, kann es einfacher sein, die zu ändernden Kanäle anhand ihrer
+Nummer auszuwählen. Über das 'Channel'-Menü geht das für Dimmer und
+Bewegungsscheinwerfer. Zum Aufruf des 'Channel'-Menüs drücken Sie die
+Taste <Keys.HardKey>Fixture</Keys.HardKey> links oberhalb des Zifferntastenblocks.
+
+Ebenso können Sie einfach die entsprechenden Ziffern eingeben; enthält
+Ihre Eingabe 'Through', 'And' oder '@', so wird automatisch das
+'Channel'-Menü aufgerufen.
+
+Through, And und @ stehen je nach Pult sowohl als Menü-Taste im
+Fixtures-Menü als auch über die Pfeiltasten direkt beim Ziffernblock zur
+Verfügung.
+
+Die Geräte lassen sich anhand der Gerätenummer (User Number), der Nummer
+des Gerätebuttons (Handle Number) oder der DMX-Adresse anwählen, je nach
+Einstellung der Menütaste A.
+
+Bei der Benutzung des 'Channel'-Menüs empfiehlt es sich, dieses zu
+fixieren (Taste <Keys.HardKey>Menu Latch</Keys.HardKey>).
+
+-   Zum Anwählen eines Gerätes die Nummer eingeben und <Keys.HardKey>Enter</Keys.HardKey>
+    drücken.
+
+-   Um mehr als ein Gerät anzuwählen, drücken Sie die Funktionstaste <Keys.SoftKey>And</Keys.SoftKey> 
+    zwischen den einzelnen Nummern. 
+    
+    Beispiel: 1 <Keys.SoftKey>And</Keys.SoftKey> 
+    2 <Keys.SoftKey>And</Keys.SoftKey> 5 <Keys.HardKey>Enter</Keys.HardKey> wählt die Geräte 1, 2, 5.
+
+-   Um eine Folge von Geräten anzuwählen, drücken Sie <Keys.SoftKey>Thro</Keys.SoftKey>.
+    
+    Beispiel: 1 <Keys.SoftKey>Thro</Keys.SoftKey> 8 <Keys.HardKey>Enter</Keys.HardKey> wählt 1-8. 
+    
+    Lässt man die zweite Zahl weg, so werden alle noch folgenden Geräte des gleichen Typs angewählt.
+
+-   Um einzelne Geräte in einer Folge auszulassen, drücken Sie <Keys.SoftKey>Not</Keys.SoftKey>.
+
+    Beispiel: 1 <Keys.SoftKey>Through</Keys.SoftKey> 4 <Keys.SoftKey>Not</Keys.SoftKey> 3 <Keys.HardKey>Enter</Keys.HardKey> wählt 1, 2, 4.
+
+-   Die Taste <Keys.SoftKey>@</Keys.SoftKey> stellt den Dimmer-Wert der ausgewähl­ten Geräte ein,
+    etwa: 1 <Keys.SoftKey>Through</Keys.SoftKey> 8 <Keys.SoftKey>@</Keys.SoftKey> 
+    5 <Keys.HardKey>Enter</Keys.HardKey> setzt Gerät 1-8 auf 50% (in den
+    Benutzereinstellungen lässt sich einstellen, ob 50% durch "5" oder
+    "50" eingegeben wird, siehe [Benutzereinstellungen](./system-settings/user-settings.md)). Beim Betätigen
+    der Taste <Keys.SoftKey>@</Keys.SoftKey> erscheinen außerdem Optionen auf den Funktionstasten
+    für 'Full' (100%), 'Off' (0) und +/- (schrittweise
+    erhöhen/vermindern).
+
+-   Zur numerischen Anwahl von Gruppen verwenden Sie die Taste 'Group';
+
+    Beispiel: <Keys.HardKey>Group</Keys.HardKey> 1 <Keys.SoftKey>And</Keys.SoftKey> <Keys.HardKey>Group</Keys.HardKey> 2 <Keys.SoftKey>Not</Keys.SoftKey> 5 <Keys.HardKey>Enter</Keys.HardKey> selektiert
+    Gruppe 1 und 2 außer Gerät 5.
+
+-   Die <Keys.HardKey>Locate</Keys.HardKey>-Taste macht das Betätigen der <Keys.HardKey>Enter</Keys.HardKey>-Taste
+    überflüssig, wenn die Geräte angewählt und dann auf die
+    Startposition gebracht werden sollen: 1 <Keys.SoftKey>Through</Keys.SoftKey> 4 <Keys.HardKey>Locate</Keys.HardKey>
+    wählt Gerät 1 bis 4 aus und initialisiert diese.
+
+![Syntax Selection](/docs/images/Syntax-Selection.png)
+
+-   Beim Eingeben eines Kommandos wird dieses im Infobereich des
+    Displays angezeigt. Mittels der grauen ←<Keys.HardKey>Back</Keys.HardKey>Taste kann man
+    schrittweise zurückgehen; mit der grauen →<Keys.HardKey>@</Keys.HardKey>Taste lässt sich die
+    Eingabe abbrechen.
+
+-   Die Funktionen AND, THRO sowie @ stehen auch auf den Pfeiltasten zur
+    Verfügung (siehe deren Beschriftung).
+
+## Geräteauswahl nach Muster
+
+Beim Programmieren einer Show ist es oftmals wünschenswert, verschiedene
+Muster von Geräten auszuwählen. Anstatt nun die Geräte einzeln aus- und
+abzuwählen, gestattet es das Pult, Geräte aus einer Gesamtauswahl nach
+einem bestimmten Muster zu selektieren.
+
+1. Selektieren Sie einige Geräte.
+2. Drücken Sie die weiße Taste <Keys.HardKey>All</Keys.HardKey> (bzw. <Keys.HardKey>All/Even/Odd</Keys.HardKey>).
+3. Wählen Sie ein Muster von den Menütasten. Die gewählte Auswahl wird
+geändert, so dass z.B. nur die ungeraden (odd) Geräte ausgewählt werden.<br/>
+   ![Pattern Select](/docs/images/Pattern-Select.png)
+4. Drücken Sie die Taste <Keys.HardKey>Fix+1</Keys.HardKey> oder <Keys.HardKey>Fix-1</Keys.HardKey>, um den nächsten
+Schritt im gewählten Muster anzuwählen (auf manchen Pulten <Keys.HardKey>Next</Keys.HardKey> und <Keys.HardKey>Prev</Keys.HardKey>).
+5. Um die Musterauswahl zu beenden, drücken Sie zweimal <Keys.HardKey>All</Keys.HardKey>.
+
+-   Mittels <Keys.SoftKey>Direction</Keys.SoftKey> (Richtung) kann eingestellt werden, dass die
+    Geräte-Reihenfolge einer bestimmten Richtung folgt; dabei wird das
+    Layout der Geräte herangezogen. Damit lassen sich z.B. sehr einfach
+    symmetrische Paare von Geräten wählen. Auch beim Verwenden von 
+	[Fixture Overlap](./cues/cue-timing.md#einstellen-von-überblendzeiten-und-geräteversatz) 
+	ist die Richtung von Bedeutung.
+
+-   Drückt man <Keys.HardKey>Clear</Keys.HardKey>, so wird die Richtung (Direction) wieder auf
+    'None' zurückgesetzt. Dies lässt sich mit <Keys.SoftKey>Clear Options</Keys.SoftKey> <Keys.SoftKey>Clear / Maintain Direction</Keys.SoftKey> umstellen (halten Sie <Keys.HardKey>Clear</Keys.HardKey> gedrückt zum
+    Einstellen der Clear-Optionen).
+
+-   Wenn Sie etwa einen Chaser mit 16 Geräten programmieren, und dazu jedes 4. synchron einstellen wollen, 
+    wählen Sie zunächst alle 16 Geräte aus, drücken dann <Keys.HardKey>All</Keys.HardKey>, 
+    dann <Keys.SoftKey>1 in x</Keys.SoftKey>, und danach <Keys.SoftKey>1 in 4</Keys.SoftKey>. Nun sind die 
+    Geräte 1, 5, 9 und 13 aus der vorherigen Auswahl zum Bearbeiten angewählt. Drücken 
+    Sie <Keys.HardKey>Fix+1</Keys.HardKey> bzw. <Keys.HardKey>Next</Keys.HardKey>, so werden die Geräte 
+    2, 6, 10 und 14 angewählt. Nach der Anwahl des 4. Schrittes erscheint wieder der erste Schritt des Musters, 
+    bis zweimal <Keys.HardKey>All</Keys.HardKey> betätigt wird.
+
+-   Sie können sehr einfach eigene Muster programmieren: geben Sie dazu z.B. mit den Ziffern- und 
+    Funktionstasten "2" A <Keys.SoftKey>In</Keys.SoftKey> "6" <Keys.HardKey>Enter</Keys.HardKey> ein.
+
+-   Diese Funktionen stehen ebenfalls auf den Menütasten zur Verfügung,
+    wenn man einen Gruppen-Button gedrückt hält.
+
+-   Bei der Verwendung der Geräteauswahl nach Muster kann man um eine komplette 'Musterbreite' (also einen kompletten Block) springen, indem man die <Keys.HardKey>Avo</Keys.HardKey>-Taste gedrückt hält und dazu <Keys.HardKey>Fix +1</Keys.HardKey> oder <Keys.HardKey>Fix -1</Keys.HardKey> drückt.
+
+## Auswahl von Geräten in einem Cue
+
+Zur Auswahl der Geräte, die in einem bestimmten Cue enthalten sind,
+dient die **Select If**-Funktion.
+
+Drücken Sie dazu <Keys.HardKey>Select If</Keys.HardKey> gefolgt von dem Speicherplatz. (Auf
+älteren Pulten gibt es keine gesonderte <Keys.HardKey>Select If</Keys.HardKey>-Taste; in diesem
+Fall drücken Sie <Keys.HardKey>Fixture</Keys.HardKey> und dann <Keys.SoftKey>Select If</Keys.SoftKey>).
+
+Ebenso lässt sich 'Select If' mit den Tasten <Keys.HardKey>@</Keys.HardKey> und <Keys.HardKey>Thro</Keys.HardKey>
+verwenden, um alle Geräte mit einer bestimmten Helligkeit anzuwählen.
+
+&nbsp;<Keys.HardKey>Select If</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> 5: Geräte mit 50% Dimmer
+
+&nbsp;<Keys.HardKey>Select If</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>Through</Keys.HardKey> 5: Geräte mit der Helligkeit 0 - 50%
+
+&nbsp;<Keys.HardKey>Select If</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> 5 <Keys.HardKey>Through</Keys.HardKey>: Geräte mit der Helligkeit 50% - 100%
+
+&nbsp;<Keys.HardKey>Select If</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> 5 <Keys.HardKey>Through</Keys.HardKey> 7: : Geräte mit der Helligkeit zwischen 50% und 70%
+
+&nbsp;<Keys.HardKey>Select If</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey>: Geräte mit der Helligkeit \> 0.
+
+Pegelangaben können entweder in der Schreibweise 0-9 oder 00-99 gemacht
+werden, abhängig von der [Benutzereinstellung](./system-settings/user-settings.md) <Keys.SoftKey>Channel Levels Set In</Keys.SoftKey>.
+
+## Einzeln durch die Geräte einer Auswahl durchschalten
+
+Sind mehrere Geräte oder eine Gruppe von Geräten ausgewählt, so bietet
+das Pult die Möglichkeit, einzeln durch die angewählten Geräte
+durchzuschalten. Dies vereinfacht das Programmieren, da man so nicht
+jedes Gerät einzeln selektieren muss.
+
+Für diese Funktion werden die Tasten <Keys.HardKey>Fix-1</Keys.HardKey> (zurück), <Keys.HardKey>Fix+1</Keys.HardKey>
+(weiter), <Keys.HardKey>All</Keys.HardKey> (alle) und <Keys.HardKey>HiLight</Keys.HardKey> (hervorheben) genutzt.
+
+1. Wählen Sie mehrere Geräte oder eine Gruppe von Geräten.
+2. Mit den Tasten <Keys.HardKey>Fix-1</Keys.HardKey> und <Keys.HardKey>Fix+1</Keys.HardKey> wird jeweils ein Gerät
+   ausgewählt bzw. weitergeschaltet (in der Reihenfolge der Auswahl). 
+   Auf manchen Pulten dienen dazu die Tasten <Keys.HardKey>Prev</Keys.HardKey> und <Keys.HardKey>Next</Keys.HardKey> .
+3. Die Taste <Keys.HardKey>All</Keys.HardKey> wählt alle Geräte aus, die sich im
+   Programmierspeicher befinden (alle Geräte, die seit der letzten
+   Betätigung von <Keys.HardKey>Clear</Keys.HardKey> angewählt wurden).
+
+-   Die 'HiLight'-Funktion ermöglicht es, das aktuelle Gerät
+    hervorzuheben, siehe nächster Abschnitt.
+
+## Das ausgewählte Gerät bei Fix+1/Fix-1 hervorheben
+
+Beim Durchschalten durch eine Geräteauswahl mit den \<Fix+1/\
+Fix-1/All\>-Tasten lässt sich das jeweils angewählte Gerät hervor­heben.
+Dies vereinfacht es zu sehen, welches Gerät man gerade steuert. Die
+anderen Geräte in der Auswahl werden gleichzeitig heruntergedimmt
+('Lowlight').
+
+-   Betätigen Sie die <Keys.HardKey>HiLight</Keys.HardKey>-Taste, um diese Funktion zu
+    aktivieren. Ein weiteres Betätigen der Taste schaltet die Funktion
+    wieder aus. Ist der Highlight-Modus aktiv, so werden die davon
+    betroffenen Attribute (z.B. der Dimmer) überschrieben und können
+    nicht editiert oder gespeichert werden.
+
+-   Die für Highlight/Lowlight verwendeten Werte lassen sich ändern:
+    stellen Sie den gewünschten Wert ein, drücken Sie <Keys.HardKey>Record</Keys.HardKey>, 
+    dann <Keys.HardKey>HiLight</Keys.HardKey>, und wählen dann <Keys.SoftKey>Store Highlight State</Keys.SoftKey> 
+    oder <Keys.SoftKey>Store Lowlight State</Keys.SoftKey>.
+
+## Nicht ausgewählte Geräte ausblenden (Remainder Dim)
+
+Mit "Remainder Dim" (<Keys.HardKey>Rem Dim</Keys.HardKey> oder <Keys.HardKey>Avo</Keys.HardKey>+<Keys.HardKey>All</Keys.HardKey>) werden die nicht
+angewählten Geräte ausgeblendet; dabei wird der Wert Intensity=0 in den
+Programmierspeicher geschrieben und entsprechend beim Speichern
+übernommen.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/advanced-options.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/advanced-options.md
@@ -1,0 +1,49 @@
+---
+id: advanced-options
+title: Weitere Optionen
+sidebar_label: Weitere Optionen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Geräte ein- und ausschalten
+
+Viele Geräte haben einen gesonderten Steuerkanal, mit dem man Funktionen
+wie 'Brenner an', 'Brenner aus', ‚Reset' etc. aufrufen kann.
+
+Auf dem Pult lassen sich diese Funktionen als Geräte-Makros (nicht zu
+verwechseln mit den Pult-Makros) aufrufen.
+
+1.  Drücken Sie so oft <Keys.HardKey>Exit</Keys.HardKey>, bis das Pult im 
+    Hauptmenü ist (mit <Keys.HardKey>Avo</Keys.HardKey><Keys.HardKey>Exit</Keys.HardKey> 
+    kommt man ebenfalls direkt ins Hauptmenü).
+2.  Wählen Sie die zu steuernden Geräte aus. Manche Makros funktionieren
+    nicht auf Geräten unterschiedlicher Hersteller gleichzeitig, deshalb
+    bietet es sich an, jeden Gerätetyp einzeln zu steuern.
+3.  Drücken Sie <Keys.HardKey>Macro</Keys.HardKey> und wählen 
+    Sie <Keys.SoftKey>Fixture Macros</Keys.SoftKey> (auf Pulten mit einer 
+    Taste <Keys.HardKey>ML Menu</Keys.HardKey> findet man 
+    die <Keys.SoftKey>Fixture Macros</Keys.SoftKey> auch über diese Taste).
+4.  Im Display wird eine Liste der für diese Geräte verfügbaren Makros
+    angezeigt. Wählen Sie das gewünschte aus.
+
+-   Einige Makros beinhalten bestimmte zeitliche Abläufe und können bis zu
+    30 Sekunden zum Ausführen benötigen.
+
+## Die ML-Menü-Taste
+
+Einige Pulte haben eine Taste <Keys.HardKey>ML Menu</Keys.HardKey>. Wenn sich 
+das Pult im Hauptmenü befindet, kann man mit dieser Taste das 'Moving Light 
+Actions'-Menü (mit Funktionen für intelligente Scheinwerfer) aufrufen, 
+welches spezielle Funktionen für diese Geräte bietet, wie etwa 'Locate' 
+(gleiche Funktion wie mit der <Keys.HardKey>Locate</Keys.HardKey>-Taste
+aufrufbar, s.o.), Abruf von Macros zum Zurücksetzen oder Ein-/Ausschalten 
+der Geräte etc. Die vorstehend beschriebenen Funktionen 'Align' (Abgleich) 
+und 'Flip' sind ebenfalls in diesem Menü zu finden.
+
+Auf dem Tiger Touch I und dem Pearl Expert fixiert diese Taste das
+aktuelle Menü, wenn sich das Pult nicht im Hauptmenü befindet. Drücken
+Sie <Keys.HardKey>Exit</Keys.HardKey>, um zum Hauptmenü zurückzukehren, damit Sie das 'Moving
+Light Menu' aufrufen können. Auf neueren Pulten gibt es eigens eine
+Taste <Keys.HardKey>Menu Latch</Keys.HardKey>.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/changing-fixture-attributes.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/changing-fixture-attributes.md
@@ -1,0 +1,639 @@
+---
+id: changing-fixture-attributes
+title: Attributwerte ändern
+sidebar_label: Attributwerte ändern
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Sobald ein oder mehrere Geräte zum Steuern ausgewählt sind, gibt es verschiedene 
+Möglichkeiten, diese zu steuern.
+
+## Einstellen von Attributen mit den Encodern
+
+"Attribute" sind die einzelnen Funktionen des Gerätes, wie Pan
+(Schwenken), Tilt (Neigen), Farbe, Dimmer etc. Wählen Sie die zu
+bearbeitenden Attribute mit den IPCGBESFX Attribut-Tasten, und stellen Sie den
+gewünschten Wert mit den Rädern ein. Die verfügbaren Attribute sind
+abhängig vom Gerätetyp. Dimmerkanäle besitzen nur das Attribut \'Dimmer\'.
+
+Im Display direkt über den Encodern werden die aktuelle Attributbank (hellgrau) 
+und die momentanen Werte bei den Encodern angezeigt. Ein hellblauer Kreis markiert 
+Attribute im Programmer. Die genaue Anzeige der Werte ist davon abhängig, ob 
+das Attribut kontinuierlich gesteuert werden kann (Prozent-Anzeige) oder ob 
+zwischen verschiedenen Werten umgeschaltet wird (z.B. feste Farben oder Gobos).
+
+![Wheels](/docs/images/Wheels.png)
+
+Die Attribute können auch im [Attribute Editor Fenster](./changing-fixture-attributes.md#das-fenster-attribut-editor) eingestellt werden.
+
+> Auf dem Pearl Expert dienen je nach Benutzereinstellung die Encoder des Touchwings zum Einstellen der Attribute.
+
+Jede einzelne Attribut-Taste kann mehrere Attribute steuern, von denen
+jedes einem Rad zugeordnet ist. Beim Diamond 9 und beim Sapphire Touch werden 
+mit dem Trackball Pan und Tilt gesteuert; der äußere Ring steuert normalerweise 
+den Dimmer, wobei sich dies mit der Taste <Keys.HardKey>Assign</Keys.HardKey> 
+direkt daneben ändern lässt.
+
+1. Nach der Anwahl der betreffenden Geräte betätigen Sie die Taste des
+einzustellenden Attributs.
+2. Benutzen Sie die Encoder, um den Wert des Attributs einzustellen.
+Das Display oberhalb der Räder zeigt, welche Attribute momentan
+gesteuert werden, und die verfügbaren Einstellungen lassen sich mit den
+Encoder durchschalten. Ebenso können die einzelnen Werte im 'Walzen'-Fenster 
+des Touchscreens durchgeschaltet werden. Für stufenlos steuerbare Funktionen (etwa ein
+Dimmer) schaltet die Walze auf 100% bzw. 0.
+3. Wiederholen Sie Schritt 1 und 2, um weitere Attribute der gewählten
+Geräte einzustellen.
+
+Weitere wissenswerte Dinge zu Attributen:
+
+![Toggle Attributes](/docs/images/Toggle-Attributes.png)
+
+-   Wird im Display rechts neben den Attributen ein kleiner Pfeil angezeigt,
+	so bedeutet das, dass auf dieser Bank mehr als drei Attribute zu steuern sind. 
+	In diesem Fall kann man durch mehrfaches Anwählen der Attributbank durch 
+	die Attribute durchschalten. Angenommen ein Scheinwerfer habe die Attribute 
+	Red, Green, Blue, Amber und White, so wird beim ersten Klicken auf <Keys.HardKey>Colour</Keys.HardKey> 
+	Red, Green und Blue gesteuert und beim nächsten Klick Amber und White.
+
+-   Befindet sich ein Attribut im Programmierspeicher, so wird es hellblau
+    angezeigt (siehe 'Green' in obigem Bild). Dies ermöglicht einen
+    schnellen Überblick darüber, was momentan im Program­mierspeicher
+    ist.
+
+-   Wird das angewählte Attribut nicht im Display oberhalb der Räder
+    angezeigt, so ist es für die angewählten Geräte nicht verfügbar.
+
+-   Die Räder arbeiten in einem 'Beschleunigungsmodus'. Wird ein Rad
+    schnell bewegt, so folgt das Gerät schnell und in groben
+    Abstufungen. Wird es dagegen langsam bewegt, folgt das Gerät in
+    kleinstmöglichen Schritten.
+
+-   Wird beim Drehen des Rades die <Keys.HardKey>AVO</Keys.HardKey>-Taste gedrückt, so arbeitet
+    das Rad im 'Schnell'-Modus: eine Radumdrehung durchläuft den
+    gesamten Bereich des Attributes. Wird etwa bei gedrückter
+    <Keys.HardKey>AVO</Keys.HardKey>-Taste das Rad für Pan bewegt, so macht das Gerät bei einer
+    Radumdrehung einen kompletten Schwenk von einem Anschlag zum
+    anderen.
+
+-   Für einige LED-Geräte mit Farbmischung gibt es eine 'virtuelle
+    Dimmerfunktion', wenn das Gerät selbst über keinen Dimmer verfügt:
+    dazu wirkt das Intensity-Rad als Hauptregler für die einzelnen
+    Farben.
+
+## Der Trackball (Diamond 9 und Sapphire Touch)
+
+Der Trackball steuert normalerweise Pan und Tilt der Geräte, und der äußere Ring den Dimmer. 
+Man kann den Trackball aber auch anderen Attributen zuweisen:
+
+1. Wählen Sie ein paar Geräte aus, die das zu steuernde Attribut haben (nur damit 
+ dieses zur Auswahl steht).
+2. Wählen Sie die entsprechende Attributbank, so dass das gewünschte Attribut mit einem 
+Encoder gesteuert werden kann.
+3. Drücken Sie die Taste <Keys.HardKey>Assign</Keys.HardKey>.
+4. Wählen Sie im Menü die gewünschte Funktion <Keys.SoftKey>Track Ball X</Keys.SoftKey>, <Keys.SoftKey>Track Ball Y</Keys.SoftKey> oder <Keys.SoftKey>Wheel Z</Keys.SoftKey>.
+5. Drücken Sie die <Keys.HardKey>@</Keys.HardKey>-Taste des Rades, mit dem gerade das betreffende Attribut gesteuert wird.
+
+Damit ist das Attribut entsprechend zugewiesen, und das Menü wird geschlossen. 
+Um die Zuweisung zu überprüfen, drücken Sie wieder auf <Keys.HardKey>Assign</Keys.HardKey>. Daraufhin wird im Menü die aktuelle Zuweisung angezeigt.
+
+- Mit dem Trackball kann auch der Mauszeiger gesteuert werden, siehe [Trackball (Maus-Steuerung)](../titan-basics/workspace-windows.md#trackball-diamond-9-and-sapphire-touch-only).
+
+
+## Dimmer-Handrad (Nur beim Diamond 9 und Diamond 7)
+
+Auf dem D9 und D7 gibt es ein gesondertes Handrad zur Steuerung des Dimmers der 
+ausgewählten Geräte. Oberhalb dessen wird der aktuelle Wert in einem separaten 
+Display angezeigt. Dieses Handrad steuert immer den Dimmerwert und wird nicht 
+mit den Attributbänken umgeschaltet. (Es kann aber wie nachstehend beschrieben 
+anderen Attributen zugewiesen werden).
+
+Unterhalb des Handrades befindet sich eine <Keys.HardKey>Level @</Keys.HardKey> Taste, mit 
+der das Menü zum Einstellen des Dimmerwertes aufgerufen werden kann (siehe [Einstellen von Attributwerten per @-Taste](../controlling-fixtures/changing-fixture-attributes.md#adjusting-attributes-with-the--buttons)). 
+
+- Das Handrad kann zur Steuerung eines anderen Attributs zugewiesen werden. Gehen 
+Sie dazu wie beim Ändern der Zuordnung des Trackballs vor (s.o.), wählen aber bei Schritt 
+4 die Funktion <Keys.SoftKey>Level Wheel</Keys.SoftKey>. 
+Das Display oberhalb des Handrades zeigt nun den Wert des neu zugewiesenen Attributs an.
+
+## Das Fenster 'Attribut-Editor'
+
+Für Attribute mit festen Werten wie Gobos oder Farbräder ist das Fenster
+'Attribut-Editor' ggf. besser geeignet als die Encoder. Es bietet darüber
+hinaus einen Farbwähler für Geräte mit RGB- oder CMY-Farbmischung.
+
+Das Diamond 9 und das Diamond 7 hat einen separaten Touchscreen nur für den Attribut-Editor. 
+Auf allen anderen Pulten gibt es diesen als normales Arbeitsfenster. 
+Drücken Sie zweimal auf [<Keys.HardKey>Open/View</Keys.HardKey>](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster) und wählen <Keys.SoftKey>Attribute Editor</Keys.SoftKey>, um den
+Attribut-Editor einzublenden. Oder klicken Sie auf den Attribut-Namen
+direkt unterhalb der IPCGBES-Schaltflächen auf dem Display.
+
+Die Schaltflächen links im Fenster 'Attribut Control' wählen das zu
+ändernde Attribut.
+
+![Attribute Editor](/docs/images/Attribute-Editor.png)
+
+Der übrige Bereich des Fensters enthält Schaltflächen und
+Steuerelemente, um den Attributwert einzustellen. Bei Attributen mit
+festen Werten (Gobos, Farben etc.) gibt es für jeden einzelnen Festwert
+eine Schaltfläche; dies ermöglicht eine deutlich schnellere Auswahl als
+mit den Rädern.
+
+Beim Aufruf eines Wertes wird dessen Schaltfläche blau, um zu
+signalisieren, dass dieser Wert im Programmierspeicher ist. Ein erneutes
+Betätigen der Schaltfläche löscht diesen Wert aus dem
+Programmierspeicher.
+
+Beim Anwählen des Titels einzelner Attribute (z.B. "Gobo 2") werden
+sämtliche Einstellmöglichkeiten dieses Attributs im gesamten Fenster
+angezeigt. Siehe nächstes Bild. Bilder der Gobos werden angezeigt,
+sofern die Personality die entsprechenden Informationen enthält.
+
+![Gobo Selection](/docs/images/Gobo-Selection.png)
+
+Für stufenlos einstellbare Attribute (z.B. Dimmer) erscheint ein Regler
+im Display, sobald die Schaltfläche gedrückt gehalten wird. Der Regler
+lässt sich einfach durch Bewegen des Fingers verstellen.
+
+![Range slider](/docs/images/Range-slider.png)
+
+Verfügt das gewählte Gerät über Teilgeräte (Subfixtures), so erscheinen
+oben im Attribut-Editor Schaltflächen zur Auswahl der einzelnen Zellen
+bzw. des Gesamtgerätes (links). Die Buttons der einzelnen Zellen werden
+in der Anordnung der wirklichen Zellen angezeigt.
+
+![Cells](/docs/images/Cell-Selection.png)
+
+Einzelne Attribute haben je nach Funktion gesonderte Anzeigen:
+
+### Dimmer/Shutter
+
+![Intensity Shutter](/docs/images/Intensity-Shutter.png)
+
+Speziell unterteilter Fader und Buttons für 0%, 100%, +5%, -5% sowie
+Locate (nur Dimmer).
+
+### Position
+
+![Position](/docs/images/Position.png)
+
+Pan/Tilt-Steuerung per X/Y-Raster. Dabei werden die angewählten Geräte
+durch Kreis angezeigt, was die Steuerung vereinfacht. Weitere
+Steuerungsmöglichkeiten:
+
+-   Mit <Keys.SoftKey>Locate</Keys.SoftKey> wird die Position auf 50% Pan/50% Tilt 
+    gesetzt, ohne andere Attribute zu verändern.
+
+-   Mit <Keys.SoftKey>Align</Keys.SoftKey> wird Pan/Tilt auf die Werte des zuletzt angewählten
+    Gerätes gesetzt. Möchte man z.B. alle angewählten Geräte auf den
+    Wert des ersten Gerätes bringen, so wählt man die Geräte in der
+    Reihenfolge 2-3-4-1 aus und klickt <Keys.SoftKey>Align</Keys.SoftKey>.
+
+-   Mit Pan/Tilt Lock lässt sich die Bearbeitung mehrerer Geräte auf
+    einmal vereinfachen, indem entweder Pan oder Tilt kurzzeitig von der
+    Bearbeitung ausgenommen wird. Hat man z.B. die gerät in Pan
+    aufgefächert und will nur Tilt etwas nachziehen, so verhindert Pan
+    Lock, dass der bereits eingestellte Fächer verlorengeht.
+
+-   Mit dem Button <Keys.SoftKey>Fine</Keys.SoftKey> lässt sich die Auflösung 
+    verringern, so dass man die gewünschte Position sehr genau ansteuern kann.
+
+### Farbmischung: Channel
+
+Für Geräte mit Farbmischung gibt es mehrere Möglichkeiten, die Farbe
+einzustellen; diese sind in verschiedenen Reitern oben im
+Attribut-Editor zusammengefasst. (Wird das Fenster zu einer Hochkant-Anzeige 
+verändert, so werden die Fader horizontal und nicht vertikal wie im Bild gezeigt dargestellt).
+
+![Attribute Editor - Colour Channels](/docs/images/Attribute-Editor-Channels.png)
+
+Auf dem Reiter **Channel** gibt es einen Regler pro tatsächlich im Gerät
+vorhandenen Farb-Attribut; entsprechend hängt die Anzahl und Art der
+Fader vom gewählten Gerät ab (z.B. sieben Fader beim ETC Lustr). Dies
+bietet sich z.B. bei der gezielten Bearbeitung einzelner Farbtöne an,
+oder etwa dann, wenn man nur einzelne Kanäle (z.B. Weiß oder UV)
+speichern möchte.
+
+### Farbmischung: HSI/RGB/CMY
+
+![Attribute Editor - Colour Mix](/docs/images/Attribute-Editor-HSI-RGB-CMY.png)
+
+HIS/RGB/CMY bietet sowohl den klassischen Colourpicker als auch Fader
+für die unterschiedlichen Farbmischsysteme, die sich sämtlich
+gegenseitig beeinflussen, abhängig davon, welchen Wert man gerade
+verändert. Klickt man in den Colourpicker, so werden alle Fader auf den
+für diese Farbe erforderlichen wert gesetzt. So lässt sich z.B. mittels
+Saturation eine Pastellfarbe erreichen, ohne den Farbton (Hue) zu
+verändern.
+
+Für Geräte mit Farbmischung funktionieren stets alle drei Fadersysteme
+parallel, unabhängig davon, nach welchem System genau das Gerät
+arbeitet.
+
+### Farbmischung: Picker
+
+![Attribute Editor - Colour Picker](/docs/images/Attribute-Editor-Picker.png)
+
+Dies ist der aus früheren Versionen gewohnte Colourpicker: in dem großen
+Feld lässt sich die gewünschte Farbe wählen (Hue und Saturation),
+während der Fader rechts daneben die Helligkeit (Intensity, I) regelt.
+
+### Farbmischung: Filters
+
+![Attribute Editor - Colour Filters](/docs/images/Attribute-Editor-Filters.png)
+
+Auswahl der Farbe nach Farbfilter-Nummer; dabei sind verschiedene gebräuchliche 
+Systeme implementiert. Mit der Suchleiste oben im
+Fenster kann nach einer bestimmten Nummer gesucht werden. Per
+Kontext-Button kann zwischen <Keys.SoftKey>Order Filters by Number</Keys.SoftKey> (nach Nummer
+sortieren) und <Keys.SoftKey>Order Filters by Hue</Keys.SoftKey> (nach Farbton sortieren)
+umgeschaltet werden.
+
+- Mit den Zifferntasten kann man Farben direkt nach Nummer anwählen. Die Syntax dafür ist <Keys.HardKey>@</Keys.HardKey> *Marke* <Keys.HardKey>/</Keys.HardKey> *Farbnummer*. Um z.B. L 106 auszuwählen, tippt man <Keys.HardKey>@</Keys.HardKey> *1* <Keys.HardKey>/</Keys.HardKey> *106*. Man kann auch direkt Fixtures anwählen und diese mit einer Farbe versehen, z.B. 10 <Keys.HardKey>@</Keys.HardKey> 1 <Keys.HardKey>/</Keys.HardKey> 106 (stellt das Fixture 10 auf L 106). Die Marken sind 1=L, 2=R, 3=G. Verfügt das Pult nicht über eine <Keys.HardKey>/</Keys.HardKey>-Taste, so muss eine externe Tastatur angeschlossen oder die Bildschirmtastatur verwendet werden.
+
+
+> Für Geräte mit RGBW, RGBA oder WW/CW-Steuerung steuert der Colourpicker auch die Kanäle für Weiß und Amber. Dies ist seit Titan Version 9 implementiert; in älteren Versionen müssen diese Attribute manuell eingestellt werden.
+
+### Medienserver/Active Fixtures
+
+Aktive Geräte (z.B. Medienserver) zeigen ein Vorschaubild des
+Video­clips auf der jeweiligen Schaltfläche. Dabei muss der Medienserver
+das Protokoll CITP unterstützen sowie als Aktives Gerät gepatcht sein,
+damit diese Vorschauen angezeigt werden können.
+
+Für Ai-Server und Synergy sei auf [Synergy](../synergy.md) verwiesen, wo
+Einrichtung und Verwendung ausführlich beschrieben sind. 
+
+![Clip Selection](/docs/images/Clip-Selection.png)
+
+### Shutterblenden/Keystone
+
+Geräte, bei denen man eine Kissenentzerrung (Keystoning) oder
+Blendenschieber per DMX steuern kann, lassen sich ebenfalls komfortabel
+per Attribut Editor steuern: ziehen Sie die Ecken bzw. Kanten auf dem
+Bildschirm einfach auf die gewünschte Position. Die genaue Darstellung
+und Funktionsweise hängt dabei vom jeweiligen Gerät ab.
+
+![Attribute Editor - Blades](/docs/images/Attribute-Editor-Blades.png)
+
+> Ggf. sind aktualisierte Personalities erforderlich, um die 
+Keystone/Blendenschieber-Funktionalität zu nutzen. Laden Sie dazu 
+die neueste [Personality-Library](../fixture-personalities.md#herunterladen-der-personalities-bei-avolites) 
+herunter, installieren diese und [aktualisieren die bereits gepatchten Geräte](../patching/changing-the-patch.md#bereits-gepatchte-personalities-aktualisieren).
+
+## Direkte Eingabe für Attributwerte
+
+Für aktuell den Rädern zugeordnete
+Attribute lassen sich direkt numerische Werte eingeben. Dazu müssen Sie
+sich im Hauptmenü befinden (drücken Sie <Keys.HardKey>Exit</Keys.HardKey>, bis die senkrechte
+Menüleiste 'Program Menu' anzeigt).
+
+Geben Sie mit den Zifferntasten eine Zahl ein und betätigen dann eine
+der Multifunktionstasten, um den Wert einem Attribut zuzuordnen. Die
+Beschriftung der Taste zeigt, wie der Wert vom Gerät dargestellt wird
+(z.B. <Keys.SoftKey>Gobo 5</Keys.SoftKey> oder <Keys.SoftKey>Deep Blue</Keys.SoftKey>).
+
+![Attribute Softkey](/docs/images/Attribute-Softkey.png)
+
+Für Attribute, deren Wert in Prozent dargestellt wird, wie etwa Dimmer
+oder Farbmischung, geben Sie einen Wert zwischen 0 und 100 ein, um den
+entsprechenden Prozentwert einzustellen (kann für den Dimmer auch auf 
+einstellige Eingabe geändert werden, siehe [Benutzereinstellungen](../system-settings/user-settings.md#formatting-formate)). Für Attribute mit mehreren
+Festwerten, wie z.B. feste Farbräder, geben Sie den Index des
+gewünschten Wertes ein; um etwa die dritte Farbe des Farbrades
+anzuwählen (wie in der Liste über dem Rad angegeben), geben Sie eine 3
+ein.
+
+Mit der <Keys.HardKey>@</Keys.HardKey>-Taste bei den Zifferntasten können Dimmerpegel 
+wie am Theater gewohnt eingegeben werden, so stellt z.B. <Keys.HardKey>@</Keys.HardKey>
+50 <Keys.HardKey>Enter</Keys.HardKey> die aktuell angewählten Geräte auf 50% Helligkeit.
+
+
+## Eingeben von Attributwerten mit den @-Tasten
+
+Drückt man die <Keys.HardKey>@</Keys.HardKey>-Taste bei einem der Räder, so öffnet sich das Menü zum
+numerischen Eingeben der Attributwerte.
+
+Dieses Menü lässt sich auch öffnen, indem man auf den mittleren Bereich
+der Anzeige der Attributwerte (oberhalb der Räder) anklickt, oder durch
+Anklicken eines Attributs im Channel Grid (Kanalübersicht).
+
+(Beim Tiger Touch dienen die drei Tasten zwischen den Rädern als
+<Keys.HardKey>@</Keys.HardKey>-Tasten, beim Pearl Expert gibt es 
+diese Tasten nicht, und man muss eine der anderen Varianten nutzen).
+
+Folgende Funktionen stehen auf den Menütasten zur Verfügung:
+
+-   Select Function (Funktion wählen): damit werden die verschiedenen
+    Festwerte auf die Multifunktionstasten zur Auswahl gelegt (für
+    Dimmerkanäle gibt es eine Reihe von Abstufungen)
+
+-   Touch/Clear: lädt das Attribut in den Programmierspeicher oder
+    entfernt es daraus
+
+-   Locate: setzt das Attribut auf Locate-Werte (wird nicht in den
+    Programmierspeicher übernommen)
+
+-   Release: gibt das Attribut frei
+
+-   Off: setzt das Attribut auf Off. Damit wird es vorübergehend
+    deaktiviert, der Wert bleibt aber im Programmierspeicher und kann
+    mit On wieder aktiviert werden.
+
+-   On: aktiviert das Attribut wieder zu On (wird On in einen Cue oder
+    eine Palette verschmolzen, so wird ein vorher mittels Off
+    deaktivierter Wert wieder aktiv)
+
+-   Freeze/Unfreeze: Fixieren des Attributes bzw. Fixierung aufheben
+
+## Attributgruppen -- IPCGBES-FX
+
+Zur Vereinfachung sind die Attribute nach ihrer grundlegenden Funktion
+gruppiert und mit den Buchstaben IPCGBESFX versehen:
+
+I-Intensity/Helligkeit (Dimmer, Stroboskop, Shutter)
+
+P-Position (Pan, Tilt)
+
+C-Colour/Farbe (feste Farbräder, Farbmischung)
+
+G-Gobo (Goboräder, Rotation, Index)
+
+B-Beam (Iris, Fokussierung, Zoom, Beam Shaper)
+
+E-Effects/Effekte (Prisma)
+
+S-Special (Geschwindigkeit)
+
+FX-Shapes, Pixelmapper
+
+Diese Gruppen werden vielfach verwendet, um die einzelnen Attribute zum
+Bearbeiten auszuwählen, insbesondere beim Maskieren der Attribute, um
+sie vom Speichern auszuschließen.
+
+![Attribute Groups](/docs/images/Attribute-Groups.png)
+
+Über der Attribut-Walze im Touchscreen wird die aktuell ausgewählte
+Gruppe mit einer grauen Box angezeigt. Weiter wird die Attributgruppe
+blau hinterlegt, wenn sich Attribute dieser Gruppe im
+Programmierspeicher befinden. So ist im obigen Bild die Farbe zum
+Bearbeiten angewählt, während Intensity und Special bereits verändert
+(und damit im Programmierspeicher) sind.
+
+## Geräte miteinander abgleichen
+
+<Video videoId="xZrVhnY1hnA" title="Align Fixtures" />
+
+Die Werte einzelner Attribute lassen sich mit der 'Align'-Funktion von
+einem auf andere Geräte kopieren. So kann man etwa Geräte angleichen,
+die man beim Programmieren eines Cues versehentlich nicht mit angewählt
+hatte.
+
+Es lassen sich mehrere Geräte auf einmal abgleichen, sowohl durch
+Verwenden von Gruppen als auch durch Auswahl einzelner Geräte. Stimmt
+die Anzahl der anzugleichenden Geräte nicht mit der der ‚Ziel'-Geräte
+überein, so gibt es mehrere Optionen, die bestimmen, wie damit verfahren
+wird.
+
+1. Wählen Sie die anzugleichenden Geräte, entweder einzeln, oder unter
+Verwendung von Gruppen.
+2. Im Hauptmenü drücken Sie <Keys.HardKey>ML Menu</Keys.HardKey>, dann <Keys.SoftKey>Align Fixtures</Keys.SoftKey> (auf dem D9 oder D7 drücken Sie <Keys.HardKey>Align</Keys.HardKey>).
+3. Wählen (maskieren) Sie die zu kopierenden Attribute (mittels der
+Attribut-Tasten rechts, oder mit den Funktionstasten, um alle Attribute
+ein- oder auszuschließen)
+4. Betätigen Sie die Auswahltaste des Gerätes bzw. der Gruppe, von dem
+die Attribute übernommen werden sollen.
+5. Drücken Sie <Keys.SoftKey>Align</Keys.SoftKey>
+
+Die Reihenfolge der Geräteauswahl bestimmt, wie die angeglichenen Werte
+übertragen werden:
+
+-   Ist die Option <Keys.SoftKey>Auto Reset Mask</Keys.SoftKey> aktiviert, so wird die
+    Attributmaske stets auf 'Alle' zurückgesetzt, sobald man das
+    Align-Menü aufruft. Mit <Keys.SoftKey>Remember Mask</Keys.SoftKey> dagegen wird die
+    eingestellte Maske beibehalten.
+
+-   Mit <Keys.SoftKey>Spread Attributes</Keys.SoftKey> werden Attributwerte gleichmäßig
+    aufgeteilt, wenn die Anzahl der anzugleichenden Geräte nicht mit der
+    Anzahl der 'Ziel'-Geräte übereinstimmt. Mit <Keys.SoftKey>Repeat Attributes</Keys.SoftKey>
+    dagegen werden die exakten Werte mehrfach wiederholt.
+
+-   Mit der Einstellung <Keys.SoftKey>Add To Programmer, Matching Source</Keys.SoftKey> werden nur Attribute
+    angeglichen, die bereits im Programmer sind. Mit <Keys.SoftKey>Align All
+    Attributes To Programmer</Keys.SoftKey> dagegen werden sämtliche Attribute der Geräte
+    angeglichen, sofern sie in der Maske angewählt sind. Hat man z.B.
+    Tilt wie gewünscht eingestellt und im Programmer, so würden mit <Keys.SoftKey>Add To Programmer, Matching Source</Keys.SoftKey> alle anderen Geräte nur den
+    Tilt-Wert übernehmen, mit <Keys.SoftKey>Align All Attributes To Programmer</Keys.SoftKey> aber auch den
+    Pan-Wert.
+
+-   Wählt man <Keys.SoftKey>Palette References Maintained</Keys.SoftKey>, so werden 
+    Paletten auch auf den Ziel-Geräten als Referenz auf die Palette gespeichert. 
+    Mit <Keys.SoftKey>Palette References Lost</Keys.SoftKey> dagegen werden die 
+    Referenzen gelöscht und nur feste Attributwerte gespeichert.
+
+-   Überschneiden sich die Geräte der Quell- und Zielauswahl, so ist es
+    schwierig, den Überblick zu wahren, da alle Geräteschaltflächen
+    aktiviert sind. Da hilft es, dass die ausgewählten Geräte in der
+    Leiste oben am Bildschirm aufgelistet sind.
+
+## Flip
+
+Kopfbewegte Scheinwerfer können den gleichen Punkt der Bühne mit zwei
+verschiedenen Kopfstellungen erreichen. Daher ist es zuweilen
+erforderlich, bei einem Gerät diese Kopfstellung zu wechseln, damit das
+Gerät synchron mit anderen läuft. Die Flip-Funktion ermöglicht das
+schnell und einfach.
+
+1. Wählen Sie das zu bearbeitende Gerät.
+2. Im Hauptmenü drücken Sie <Keys.HardKey>Fixture</Keys.HardKey>, 
+danach <Keys.SoftKey>Flip Pan and Tilt</Keys.SoftKey>.
+
+Auf der Positions-Seite des Attribut-Editors steht ebenfalls die
+Flip-Funktion zur Verfügung.
+
+- Auf Pulten mit der Taste <Keys.HardKey>ML Menu</Keys.HardKey> kann man 
+auch darüber die Funktion 'Flip' auswählen.
+
+> Die Einstellungen für Flip sind in der Personality vorgegeben. 
+Sollte Flip nicht wie erwartet funktionieren, muss evtl. die 
+Personality-Bibliothek aktualisiert werden.
+
+## Fan-Modus
+
+Der Fan-Modus spreizt automatisch Attributwerte über mehrere angewählte
+Geräte. Wird er etwa für Pan und Tilt benutzt, so ergibt sich eine
+strahlenförmige Verteilung: das erste und letzte Gerät werden dabei am
+meisten beeinflusst, das mittlere Gerät am wenigsten. Das Maß der
+Spreizung lässt sich mit den Rädern ändern.
+
+Wie bei Abläufen, so ist auch beim Fan-Modus die Reihenfolge der Geräte
+bei der Auswahl wesentlich. Die als erstes und als letztes ausgewählten
+Geräte werden am meisten von der Spreizung beeinflusst. Wird dazu eine
+gespeicherte Gerätegruppe verwendet, so bezieht sich das auf die
+Reihenfolge der Geräteauswahl beim Erstellen der Gruppe.
+
+Der Fan-Modus ist nicht auf Pan und Tilt beschränkt, sondern kann auf
+jedes Attribut angewendet werden.
+
+1. Wählen Sie die zu bearbeitenden Geräte.
+2. Drücken Sie die <Keys.HardKey>Fan</Keys.HardKey>-Taste.
+3. Wählen Sie das Attribut, auf das der Effekt angewendet werden soll,
+mit den Attribut-Tasten.
+4. Stellen Sie das gewünschte Maß von Spreizung mit den Rädern ein.
+5. Verlassen Sie den Fan-Modus wieder durch Betätigen der
+<Keys.HardKey>Fan</Keys.HardKey>-Taste. Werden andere Geräte angewählt, 
+wird 'Fan' automatisch beendet.
+
+Haben Sie Geräte aus verschiedenen Gruppen ausgewählt, so können Sie
+wählen, ob die Gruppenaufteilung beim Fan beachtet werden soll oder
+nicht. Haben Sie etwa 12 Geräte auf der Bühne, die in 3 Gruppen à 4
+Stück aufgeteilt sind, so können Sie entweder eine gleichmäßige
+Verteilung auf alle 12 Geräte, oder ein Aufspreizen innerhalb jeder
+Gruppe erreichen.
+
+Während die <Keys.HardKey>Fan</Keys.HardKey>-Taste gedrückt gehalten wird, lassen sich im Menü
+verschiedene Einstellungen vornehmen:
+
+-   <Keys.SoftKey>Ignore Groups</Keys.SoftKey>: Sämtliche ausgewählten Geräte werden als eine
+    große Gruppe behandelt.
+-   <Keys.SoftKey>Fan Group as Fixture</Keys.SoftKey>: alle Geräte innerhalb 
+    einer Gruppe werden identisch behandelt.
+-   <Keys.SoftKey>Fan Within Groups</Keys.SoftKey>: Die Fan-Aufspreizung erfolgt 
+    innerhalb jeder einzelnen Gruppe.
+
+Ferner lässt sich bei gedrückter <Keys.HardKey>Fan</Keys.HardKey>-Taste 
+die gewünschte Kurve auswählen. Mit unterschiedlichen Kurven lassen sich 
+unterschiedliche Effekte erzielen.
+
+Für gute Ergebnisse sind mindestens 4 Geräte erforderlich. Bei einer
+ungeraden Anzahl von Geräten wird das mittlere Gerät im Fan-Modus nicht
+beeinflusst.
+
+Betätigen Sie die <Keys.HardKey>Fan</Keys.HardKey>-Taste, um den Fan-Modus zu verlassen.
+Sämtliche Einstellungen verbleiben dabei im Programmierspeicher.
+
+> Es kann rasch passieren, dass der Fan-Modus versehentlich aktiviert bleibt, was zu der irrigen Annahme führen kann, dass die Räder nicht ordnungsgemäß funktionieren. Stellen Sie daher sicher, den Fan-Modus zu verlassen, wenn Sie mit den Einstellungen fertig sind. Um dies zu vermeiden, gibt es die [Benutzereinstellung](../system-settings/user-settings.md) <Keys.SoftKey>Press and hold Fan</Keys.SoftKey>. Ist diese aktiviert, muss die <Keys.HardKey>Fan</Keys.HardKey>-Taste gedrückt gehalten werden, um den Fan anzuwenden.
+
+### Fan-Kurven
+
+Es lassen sich verschiedene Kurven definieren, die die Fan-Funktion
+beeinflussen. Halten Sie dazu <Keys.HardKey>Fan</Keys.HardKey> gedrückt und wählen <Keys.SoftKey>Curve</Keys.SoftKey>. Es
+stehen folgende Auswahlmöglichkeiten zur Verfügung:
+
+-   Line: der gewohnte Fan, das erste und letzte Gerät werden am
+    meisten, aber gegensinnig beeinflusst, das mittlere Gerät bleibt
+    unverändert. Insbesondere sinnvoll bei Pan.
+
+    ![Fan Line](/docs/images/Fan-Line.png)
+
+-   Mirror- die Gesamtauswahl wird in zwei Hälften geteilt, die in
+    entgegengesetztem Sinn gesteuert werden.
+
+    ![Fan Mirror](/docs/images/Fan-Mirror.png)
+
+-   Wings -- die Gesamtauswahl wird in drei Teile geteilt, deren beide
+    äußere in entgegengesetztem Sinn gesteuert werden, während der
+    Mittelteil unverändert bleibt.
+
+    ![Fan Wings](/docs/images/Fan-Wings.png)
+
+-   Arrow -- die ersten und letzten Geräte werden ebenso beeinflusst wie
+    die mittleren, aber in entgegengesetzter Richtung. Ebenfalls
+    geeignet für Farbmischung, Tilt und Dimmer.
+
+    ![Fan Arrow](/docs/images/Fan-Arrow.png)
+
+-   Pull Middle -- Das erste und das letzte Gerät bleiben auf dem
+    ursprünglichen Wert, das mittlere Gerät wird am meisten beeinflusst.
+    Besonders geeignet für Farbmischung, Tilt und Dimmer.
+
+    ![Fan Pull Middle](/docs/images/Fan-Pull-Middle.png)
+
+-   Pull Ends -- Wie vor, aber das mittlere Gerät bleibt unverändert,
+    die äußeren Geräte werden am meisten (aber gleichsinnig)
+    beeinflusst. Besonders geeignet für Farbmischung, Tilt und Dimmer.
+
+    ![Fan Pull Ends](/docs/images/Fan-Pull-Ends.png)
+
+-   Pull End -- Wie vor, aber das erste Gerät bleibt unverändert, das
+    letzte Gerät wird am meisten beeinflusst.
+
+    ![FanPull End](/docs/images/FanPull-End.png)
+
+### Fan-Teile
+
+Die Fan-Funktion, d.h. das Auffächern der Veränderung, lässt sich auch
+gruppieren. Wählen Sie dazu die gewünschten Geräte aus, halten <Keys.HardKey>Fan</Keys.HardKey>
+gedrückt, und geben die Anzahl der gewünschten Gruppen mit den
+Zifferntasten ein:
+
+Normal (1):
+
+![Fan 1 Part](/docs/images/Fan-1-Part.png)
+
+2:
+
+![Fan 2 Parts](/docs/images/Fan-2-Parts.png)
+
+3:
+
+![Fan 3 Parts](/docs/images/Fan-3-Parts.png)
+
+## Speichern von Zeiten für Attribute und Geräte
+
+Fade- und Delayzeiten können direkt für einzelne Geräte oder einzelne
+Attribute gesetzt werden. Werden diese dann in einen Cue gespeichert, so
+sind auch die Zeiten Bestandteil des Cues.
+
+Zeiten lassen sich auf mehrere Arten einstellen:
+
+-   Mit der Funktionstaste <Keys.SoftKey>Wheels=</Keys.SoftKey> im Hauptmenü lassen sich die
+    Räder in die entsprechende Betriebsart schalten, und man kann Zeiten
+    mit den Rädern einstellen.
+
+-   Individuelle Zeiten lassen sich auch mit den @-Tasten und der Taste <Keys.HardKey>TIME</Keys.HardKey> vorgeben.
+
+-   Ebenso kann man auch die Geräte auswählen und mit der <Keys.HardKey>TIME</Keys.HardKey>-Taste
+    in den jeweiligen Untermenüs individuelle Zeiten einstellen.
+
+-   Schließlich gibt es auch eine Syntax, um Zeiten per Tastatur
+    einzustellen. So setzt z.B. die Tastenfolge
+    <Keys.HardKey>TIME</Keys.HardKey> <Keys.HardKey>FIXTURE</Keys.HardKey> <Keys.HardKey>Position</Keys.HardKey> 5 <Keys.HardKey>@</Keys.HardKey> 3 
+    5s Fadezeit, 3s Delayzeit für die Positionsattribute der gerade
+    ausgewählten Geräte. Die @-Tasten lassen sich auch in der
+    Tastatursyntax verwenden, und mittels <Keys.HardKey>THRO</Keys.HardKey> ergeben sich auch
+    Optionen zum Auffächern.
+
+Wird für ein Attribut eine Zeit vergeben, so wird dieses Attribut
+als 'im Programmierspeicher' angezeigt.
+
+In der Kanalübersicht (Channel Grid) gibt es eine
+Kontext-Schaltfläche <Keys.SoftKey>Times</Keys.SoftKey>, damit lassen sich alle momentan im
+Programmierspeicher befindlichen Zeiten anzeigen und editieren. Mit
+Off können die Zeiten temporär deaktiviert und mit On wieder
+aktiviert werden.
+
+Zeiten können auch getestet werden: dazu dient die Kombination <Keys.HardKey>Avo</Keys.HardKey>+<Keys.HardKey>TIME</Keys.HardKey>, oder Sie drücken zweimal die Taste <Keys.HardKey>TIME</Keys.HardKey>.
+
+Auf früheren Konsolen liegt die Funktion der Taste <Keys.HardKey>TIME</Keys.HardKey> entweder
+auf der Taste <Keys.HardKey>SET</Keys.HardKey> (Titan Mobile/Sapphire Touch) oder auf der
+Taste <Keys.HardKey>NEXT TIME</Keys.HardKey> (Tiger Touch/Pearl Expert).
+
+## Attribute mit "Off" deaktivieren
+
+Wurde ein Attribut editiert, so ist der aktuelle Wert im Programmer, und
+kann entsprechend in Cues und Paletten gespeichert werden. Wurde ein
+Wert versehentlich editiert (und in den Programmer gebracht) und soll
+aber nicht gespeichert werden, so kann er mittels Off deaktiviert
+werden.
+
+1. Drücken Sie die Taste <Keys.HardKey>Off</Keys.HardKey>, um das Off-Menü zu öffnen.
+2. Wählen Sie die Attribut-Bänke, um die entsprechenden Attribute zu deaktivieren, und drücken Sie auf <Keys.SoftKey>Attributes Off</Keys.SoftKey>.
+3. Mit den Menütasten lassen sich auch einzelne Attribute Off schalten,
+z.B. mit <Keys.SoftKey>Dimmer Off</Keys.SoftKey>.
+
+-   Um komplette Geräte im Programmer zu deaktivieren, wählen Sie diese
+    an, drücken <Keys.HardKey>Off</Keys.HardKey> und dann <Keys.SoftKey>Selected Fixtures Off</Keys.SoftKey>.
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/changing-fixture-attributes.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/changing-fixture-attributes.md
@@ -637,3 +637,22 @@ z.B. mit <Keys.SoftKey>Dimmer Off</Keys.SoftKey>.
 -   Um komplette Geräte im Programmer zu deaktivieren, wählen Sie diese
     an, drücken <Keys.HardKey>Off</Keys.HardKey> und dann <Keys.SoftKey>Selected Fixtures Off</Keys.SoftKey>.
 
+## Verwenden von DMX/sACN-Eingang
+
+In den DMX-Einstellungen lässt sich eine [DMX-Linie als Input einem sACN-Universum hinzufügen](/system-settings/dmx-output-mapping.md#dmx-sacn-input), um die auf dieser Linie gepatchten Geräte direkt durch ein externes Pult steuern zu können. Die Fixtures auf dieser Linie können mit dem externen Signal kontrolliert werden, und das Ergebnis kann in Titan mit abgespeichert werden.
+
+Es können sowohl ganze Fixtures als auch nur einzelne Attribute extern gesteuert werden.
+
+Es gibt drei Wege, ein Gerät oder Attribut extern zu steuern:
+
+- Wählen Sie ein oder mehrere Geräte aus, drücken Sie <Keys.HardKey>Include</Keys.HardKey>, dann <Keys.SoftKey>Live DMX Input</Keys.SoftKey>. Drücken Sie <Keys.HardKey>Enter</Keys.HardKey> oder <Keys.SoftKey>Include Live Input</Keys.SoftKey>, um die externe Steuerung der Geräte zu ermöglichen (per Attributmaske lässt sich bestimmen, welche Attribute extern gesteuert werden können).
+
+- Wählen Sie ein oder mehrere Geräte aus und drücken Sie die @-Taste des zu steuernden Attributs, um das Menü **Adjust Attribute Value** zu öffnen. Drücken Sie nun die Menütaste <Keys.SoftKey>Live DMX Input</Keys.SoftKey>, um die externe Steuerung dieses Attributs zu aktivieren.
+
+- Wählen Sie im Channel Grid (Kanalübersicht) die extern zu steuernden Kanäle und drücken Sie auf die Menütaste <Keys.SoftKey>Live DMX Input</Keys.SoftKey>.
+
+Werden Geräte bzw. Attribute extern gesteuert, so wird dies mit dem Wasserzeichen "DMX Input" angezeigt. Im Channel Grid und im Intensity View wird ein "Input"-Icon dargestellt.
+
+Das extern anliegende Signal kann nun in Playbacks und Paletten gespeichert werden.
+
+Wird im Pult selbst ein anderer Wert eingestellt, z.B. mit den Encodern oder durch Aufrufen eine Palette, so wird für das betreffende Attribut der DMX-Eingang deaktiviert. Betätigen von <Keys.HardKey>Clear</Keys.HardKey> deaktiviert den DMX-Eingang für sämtliche Geräte.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/fixture-groups.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/fixture-groups.md
@@ -1,0 +1,211 @@
+---
+id: fixture-groups
+title: Geräte-Gruppen
+sidebar_label: Geräte-Gruppen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Verwenden von Geräte-Gruppen
+
+Sie können Geräte zu Gruppen zusammenfassen, um mit einem einzigen Klick
+(im Fenster ‚Groups') die so zusammengefassten Geräte auszuwählen oder
+die Gruppen numerisch anzuwählen. Beispiele wären etwa, alle Geräte
+gleichen Typs zu einer Gruppe zusammenzufassen, Gruppen für Stage
+Left/Stage Right etc.
+
+Beim Arbeiten mit vielen Geräten sind Gruppen eine unschätzbare
+Arbeitserleichterung.
+
+![Groups Window](/docs/images/Groups-Window.png)
+
+Gruppen können in verschiedene Fenster (nicht nur das Gruppen-Fenster),
+auf Fader-Playbacks und auf Macro/Exekutor-Tasten gespeichert werden.
+
+Wird eine Gruppe auf einen Fader gespeichert, so fungiert dieser als
+Helligkeits-Masterregler für die Gruppe. Dazu lassen sich mittels [Tastenprofil](../system-settings/key-profiles.md) verschiedene Funktionen der Tasten
+wählen. 
+
+### Eine Gruppe speichern
+
+<Video videoId="E8QxOKT5TCA" title="Recording Groups" />
+
+Wird das Gruppen-Fenster nicht angezeigt so lässt es sich mit <Keys.HardKey>Open/View</Keys.HardKey>, <Keys.HardKey>Group</Keys.HardKey> (oberhalb der Zifferntasten) aufrufen.
+
+1. Wählen Sie die Geräte aus, die Sie zu einer Gruppe zusammen­fassen
+wollen (auch die Reihenfolge der Auswahl wird in der Gruppe
+gespeichert).
+2. Drücken Sie die graue Taste <Keys.HardKey>Group</Keys.HardKey> (rechts oberhalb des
+Ziffernblocks), dann <Keys.SoftKey>Record Group</Keys.SoftKey>. Ebenso können Sie <Keys.HardKey>Record</Keys.HardKey>,
+<Keys.HardKey>Group</Keys.HardKey> drücken.
+3. Benutzen Sie die Menütaste A, um die Gruppe mit einer Nummer zu
+versehen, oder B <Keys.SoftKey>Provide a legend</Keys.SoftKey>, um 
+eine Bezeichnung zu vergeben.
+4. Betätigen Sie eine freie Gruppen-Schaltfläche oder eine blaue
+Playback-Taste oder eine Macro/Executor-Taste, um die Gruppe zu
+speichern, oder drücken Sie <Keys.SoftKey>Store</Keys.SoftKey>, um die Gruppe als nummerierte
+Gruppe zu speichern.
+5. Drücken Sie <Keys.HardKey>Clear</Keys.HardKey>, und wiederholen Sie 
+die Schritte für weitere Gruppen.
+
+-   Ebenso kommt man mit <Keys.HardKey>AVO</Keys.HardKey>+<Keys.HardKey>Group</Keys.HardKey> direkt in das 'Record
+    Group'-Menü (um Gruppen zu speichern). Oder Sie klicken zweimal auf
+    eine freie Gruppen-Schaltfläche, um die Schnellspeicher­Funktion zu
+    nutzen: beim ersten Klick wird die Schaltfläche rot mit einem +,
+    beim zweiten Klick wird die Gruppe gespeichert.
+
+![Quick Record](/docs/images/Quick-Record.png)
+
+-   Um die Geräte einer Gruppe anzuwählen, klicken Sie einfach auf die
+    Schaltfläche der Gruppe.
+
+-   Die Reihenfolge der Auswahl der einzelnen Geräte beim Anlegen der
+    Gruppe wird ebenfalls gespeichert. Dies wirkt sich später aus bei
+    den Funktionen 'Last Fixture' -- 'Next Fixture' (siehe [nächster
+    Abschnitt](../controlling-fixtures/fixture-groups.md#gerätereihenfolge-und--anordnung-in-den-gruppen)), beim Programmieren von Abläufen, dem Fan-Modus sowie der
+    Überlappungsfunktion.
+	Die Reihenfolge lässt sich später auch
+    ändern, siehe [nächster Abschnitt](../controlling-fixtures/fixture-groups.md#gerätereihenfolge-und--anordnung-in-den-gruppen).
+    Die Reihenfolge innerhalb der Gruppe lässt sich beim Aufrufen
+    überschreiben: halten Sie dazu die jeweilige Gruppen-Taste/den
+    Button gedrückt, und wählen Sie die entsprechende Funktion mit den
+    Menütasten.
+
+-   Gruppen lassen sich auch anhand ihrer Nummer aufrufen:
+
+1. Drücken Sie die graue <Keys.HardKey>Group</Keys.HardKey>-Taste.
+2. Tippen Sie die Nummer der auszuwählenden Gruppe ein.
+3. Drücken Sie <Keys.SoftKey>Recall Group</Keys.SoftKey>.
+
+-   Beim Betätigen der <Keys.HardKey>Group</Keys.HardKey>-Taste ergeben sich auf den Menütasten
+    Optionen zum Ändern und Löschen von Gruppen.
+
+-   Mittels <Keys.HardKey>Select If</Keys.HardKey> lassen sich auch Gerätegruppen aus einer
+    Selektion wieder abwählen. Damit lässt sich z.B. eine Teilmenge von
+    Geräten aus einer größeren Gruppe wieder abwählen. Hat man z.B. eine
+    Gruppe von Geräten am Rand einer 5x5-Matrix sowie eine andere
+    Gruppe, die nur die ungeraden Geräte der Matrix enthält, so kann man
+    nun zuerst die Gruppe ‚Rand' auswählen, dann <Keys.HardKey>Select If</Keys.HardKey> drücken
+    und die Gruppe ‚Ungerade' wählen -- daraufhin werden die ungeraden
+    Geräte am Rand ausgewählt.
+
+### Geräte aus einer Gruppe entfernen
+
+Um Geräte aus einer Gruppe zu entfernen:
+
+1.  Drücken Sie die graue <Keys.HardKey>Group</Keys.HardKey>-Taste.
+2.  Klicken Sie die gewünschte Gruppe an. Darauf werden alle enthaltenen
+    Geräte angewählt.
+3.  Klicken Sie die Geräte an, die entfernt werden sollen, um sie
+    abzuwählen.
+4.  Verlassen Sie das Menü mit <Keys.HardKey>Exit</Keys.HardKey>.
+
+Die Gruppe enthält nun nur die Geräte, die am Schluss noch ausgewählt
+waren.
+
+### Auto-Gruppen
+
+Beim Patchen mehrerer Geräte werden diese automatisch zu Gruppen
+zusammengefasst. So werden Gruppen pro Gerätetyp erstellt, die alle
+Geräte dieses Typs enthalten (z.B. <Keys.SoftKey>All Robe Pointe</Keys.SoftKey>). Eine weitere
+Gruppe wird pro Patchvorgang erstellt, wenn mehrere Geräte gepatcht
+werden, z.B. <Keys.SoftKey>4 BB4</Keys.SoftKey>. Diese Funktion kann mit der 
+Benutzereinstellung <Keys.SoftKey>Auto Groups</Keys.SoftKey> deaktiviert werden.
+
+-	Automatisch erzeugte 'All'-Gruppen können nicht gelöscht werden;
+	stattdessen werden sie in die Show Library verschoben. Das passiert 
+	auch, wenn eine zu löschende Gruppe für den Pixelmapper verwendet 
+	wird. Dabei wird eine entsprechende Warnung angezeigt.
+
+## Gerätereihenfolge und -anordnung in den Gruppen
+
+Geräte werden innerhalb von Gruppen mit ihrer 2D-Position gespeichert, was direkt in Shapes und im Pixelmapper verwendet wird. Zunächst werden die Geräte dabei nebeneinander in einer Zeile angelegt in der Reihenfolge, in der sie beim Erstellen der Gruppe angewählt wurden. Dies lässt sich dann ändern, so dass die tatsächliche Position widergespiegelt wird. Die X-Position ist dabei gleichzeitig die Reihenfolge der Geräte, die bei Fan und Overlap verwendet wird.
+
+Die Position der Geräte kann man entweder per Gerätereihenfolge oder im Gruppenlayout-Editor ändern. Wichtig ist zu beachten, dass die X-Position immer gleichbedeutend mit der Reihenfolge ist: ändert man das eine, so wird automatisch auch das andere geändert.
+
+Die Gruppenanordnung (Gruppenlayout) kann auch zum Anlagen von Layout-Fenstern verwendet werden, siehe nächstes Kopitel.
+
+### Gerätereihenfolge
+
+<Video videoId="2TqYjvGoGXQ" title="Fixture Order" />
+
+Zum Ändern der numerischen Geräte-Reihenfolge:
+
+1.  Drücken Sie die Taste <Keys.HardKey>Group</Keys.HardKey>.
+2.  Wählen Sie die Gruppe aus, die Sie editieren möchten.
+3.  Drücken Sie <Keys.SoftKey>Fixture Order</Keys.SoftKey>.
+
+Im Geräte-Fenster werden nun Zahlen für die einzelnen Geräte
+eingeblendet.
+
+![Fixture Order](/docs/images/Fixture-Order.png)
+
+Um die Reihenfolge zu ändern, schalten Sie <Keys.SoftKey>Auto Increment</Keys.SoftKey> auf On,
+und klicken dann in der gewünschten Reihenfolge auf die Geräte. Wird
+doppelt auf ein Gerät geklickt, so wird mit einem X angezeigt, dass es
+nicht Teil der Reihenfolge ist.
+
+### Gruppenlayout
+
+<Video videoId="9S5nQmVpPNs" title="Fixture Layout" />
+
+Zum Ändern der 2D-Geräteanordnung in der Gruppe:
+
+1.  Drücken Sie die Taste <Keys.HardKey>Group</Keys.HardKey>.
+2.  Wählen Sie die Gruppe aus, die Sie editieren möchten.
+3.  Drücken Sie <Keys.SoftKey>Edit Layout</Keys.SoftKey>. Das Fenster 'Group Layout Editor' öffnet
+sich.
+
+Zunächst sind alle Geräte in einer Zeile nebeneinander angeordnet. Die
+Anordnung ändert man einfach, indem man ein Gerät auf seine neue
+Position zieht. Ebenso kann man einzelne Geräte durch Anklicken
+markieren und die Position mit den Rädern verändern. Zum Ändern der
+Gesamtgröße der Anordnung dient die rechte und untere Seite des Rasters
+(ebenfalls klicken und ziehen).
+
+Geräte mit mehreren Zellen werden mit allen Zellen dargestellt, können
+im Layout jedoch nur als ganzes verschoben und rotiert werden. Das
+Layout der Zellen wird in der jeweiligen Personality festgelegt.
+
+Mit <Keys.SoftKey>Arrange Fixtures</Keys.SoftKey> werden die Geräte automatisch in einem Rechteck
+entsprechend den Vorgaben für Rows (Zeilen, Höhe) und Columns (Spalten,
+Breite) angeordnet.
+
+![Group Layout Editor](/docs/images/Layout-Editor.png)
+
+-   Die X-Koordinate entspricht dabei der Geräte-Reihenfolge. Ändert man
+    diese, so ändert sich auch die erstere.
+
+-   Es empfiehlt sich, auch die Abstände zwischen den Geräten
+    maßstabsgerecht mit in das Layout zu übernehmen und die Gesamtgröße
+    entsprechend anzupassen.
+
+-   Wenn man versehentlich mehrere Geräte genau übereinander platziert
+    hat, zieht man entweder das im Vordergrund auf eine andere Position,
+    oder man wählt das verdeckte z.B. über die Zifferntasten oder mit
+    <Keys.HardKey>Fix+1</Keys.HardKey> aus und verschiebt es mithilfe der Räder.
+
+-   Mit der <Keys.HardKey>Fan</Keys.HardKey>-Funktion können Geräte 
+    gleichmäßig verteilt werden.
+
+-   Um Geräte zu verschieben oder zu rotieren, klicken und ziehen Sie
+    auf dem Display oder verwenden die Räder. Dazu kann man auch auf die
+    betreffenden Up/Down-Flächen der Räder im Display klicken, um die
+    Werte zu ändern (+/- 1 px oder +/- 45°). Mit der @-Taste des
+    jeweiligen Rades lässt sich auch der Wert numerisch eingeben.
+
+-   Klickt man im Kontextbereich auf <Keys.SoftKey>Position and Angle</Keys.SoftKey>, 
+    so wechselt die Funktion zu <Keys.SoftKey>Scale</Keys.SoftKey>, und 
+    die Zellen in den betroffenen Geräten lassen sich auffächern. Damit 
+    lassen sich z.B. die Zellgrößen bzw. Abstände unterschiedlicher Gerätetypen angleichen.
+
+![Position](/docs/images/Position-2.png)
+
+![Scale](/docs/images/Scale.png)
+
+-   Weitere Details und Beispiele zum Gruppenlayout-Editor gibt es im Abschnitt
+    zum [Pixel Mapper ](../effects/pixel-mapper.md). Es gibt außerdem
+    spezielle Funktionen zur Verwendung des Layouts mit [Ai/Synergy](../synergy/operating-synergy.md#verwendung-des-layout-editors-mit-ai).
+
+> Um die enthaltenen Geräte vorübergehend in zufälliger Reihenfolge auszuwählen, halten Sie den Gruppen-Button gedrückt und wählen mit den Menütasten <Keys.SoftKey>Random Order</Keys.SoftKey>.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/fixture-groups.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/fixture-groups.md
@@ -160,17 +160,13 @@ sich.
 Zunächst sind alle Geräte in einer Zeile nebeneinander angeordnet. Die
 Anordnung ändert man einfach, indem man ein Gerät auf seine neue
 Position zieht. Ebenso kann man einzelne Geräte durch Anklicken
-markieren und die Position mit den Rädern verändern. Zum Ändern der
+markieren und die Position mit den Encodern verändern (Verschieben mit **Position X** und **Position Y**, Rotieren mit **Angle**). Zum Ändern der
 Gesamtgröße der Anordnung dient die rechte und untere Seite des Rasters
 (ebenfalls klicken und ziehen).
 
 Geräte mit mehreren Zellen werden mit allen Zellen dargestellt, können
 im Layout jedoch nur als ganzes verschoben und rotiert werden. Das
 Layout der Zellen wird in der jeweiligen Personality festgelegt.
-
-Mit <Keys.SoftKey>Arrange Fixtures</Keys.SoftKey> werden die Geräte automatisch in einem Rechteck
-entsprechend den Vorgaben für Rows (Zeilen, Höhe) und Columns (Spalten,
-Breite) angeordnet.
 
 ![Group Layout Editor](/docs/images/Layout-Editor.png)
 
@@ -186,7 +182,10 @@ Breite) angeordnet.
     oder man wählt das verdeckte z.B. über die Zifferntasten oder mit
     <Keys.HardKey>Fix+1</Keys.HardKey> aus und verschiebt es mithilfe der Räder.
 
--   Mit der <Keys.HardKey>Fan</Keys.HardKey>-Funktion können Geräte 
+-   Mit <Keys.SoftKey>Arrange Fixtures</Keys.SoftKey> werden die Geräte automatisch in einem Rechteck
+    entsprechend den Vorgaben für Rows (Zeilen, Höhe) und Columns (Spalten, Breite) angeordnet.
+
+-   Mit der <Keys.HardKey>Fan</Keys.HardKey>-Funktion zusammen mit den X/Y-Encodern können Geräte 
     gleichmäßig verteilt werden.
 
 -   Um Geräte zu verschieben oder zu rotieren, klicken und ziehen Sie
@@ -194,6 +193,18 @@ Breite) angeordnet.
     betreffenden Up/Down-Flächen der Räder im Display klicken, um die
     Werte zu ändern (+/- 1 px oder +/- 45°). Mit der @-Taste des
     jeweiligen Rades lässt sich auch der Wert numerisch eingeben.
+
+-   Sind mehrere Geräte ausgewählt, so wird mit **Angle** (Encoder C) jedes einzeln um seine Achse gedreht.
+    Will man statt dessen die komplette Geräteauswahl um ihr Zentrum drehen, so wechselt man im 
+	Kontextmenü <Keys.SoftKey>Wheels Rotate Individual Fixtures</Keys.SoftKey> zu <Keys.SoftKey>Wheels Rotate Selection</Keys.SoftKey>.
+
+-   Normalerweise springen Positionen immer zu ganzen Pixeln (Kästchen), und der Winkel springt in 45°-Schritten. Um auch Zwischenwerte zu ermöglichen,
+    schaltet man im Kontextmenü <Keys.SoftKey>Wheels Move Full Pixel</Keys.SoftKey> zu <Keys.SoftKey>Wheels Move Sub Pixel</Keys.SoftKey> um.
+
+-   Wird eine Gruppe aus einzelnen Zellen von Geräten gebildet (siehe [Geräte mit mehreren Zellen/Subfixtures](../controlling-fixtures.md#fixtures-with-multiple-cellssub-fixtures)), so
+	kann man im Editor die Position der einzelnen Zellen einstellen. Damit lassen sich auch Geräte korrekt verwenden, bei denen in der Personality
+	das Layout nicht korrekt hinterlegt ist. Es empfiehlt sich aber, entweder die Personality zu korrigieren oder den Bug in der Personality 
+	zu melden und von Avolites beheben zu lassen.
 
 -   Klickt man im Kontextbereich auf <Keys.SoftKey>Position and Angle</Keys.SoftKey>, 
     so wechselt die Funktion zu <Keys.SoftKey>Scale</Keys.SoftKey>, und 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/layouts.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/layouts.md
@@ -1,0 +1,156 @@
+---
+id: layouts
+title: Layouts
+sidebar_label: Layouts
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Bei Anwählen von Fixtures ist es hilfreich, wenn diese wie in einem Plan dargestellt werden.
+Das Fenster Layouts erlaubt es, mehrere verschiedene solche Darstellungen anzulegen, in denen jeweils einzelne oder alle Geräte angezeigt werden. Man kann auch einen Plan als Grafik importieren, auf dem die Geräte angezeigt werden. Die Fixtures können selektiert werden, und die Helligkeit, das aktuelle Gobo und die Farbe werden angezeigt (soweit die Geräte über diese Attribute verfügen).
+
+Auch Playbacks, Macros und Gruppen könne in Layouts integriert werden, so dass man einen schnellen Zugriff hat ohne Fenster wechseln zu müssen.
+
+![Layout screen](/docs/images/Layouts-With-Gobos.png)
+
+## Anlegen eines Layouts
+
+Es können beliebig viele Layouts erzeugt und auf den Buttons im Fenster **Layouts** gespeichert werden.
+
+1. Wählen Sie die Geräte, die in dem Layout enthalten sein sollen (kann auch später erfolgen oder geändert werden).
+2. Drücken Sie 2x die Taste <Keys.HardKey>Open/View</Keys.HardKey> und wählen Sie <Keys.SoftKey>Layouts</Keys.SoftKey>.
+3. Klicken Sie auf einen leeren Button im Fenster Layouts.
+4. Geben Sie eine passende Legende ein (Bezeichnung, Skizze).
+5. Klicken Sie erneut auf den Button oder drücken Sie auf <Keys.SoftKey>Record Layout</Keys.SoftKey>.
+6. Das Layout wurde gespeichert. Klickt man auf den Button, so wird das Layout geöffnet.
+
+Wurden die Fixtures gleich als Gruppe angewählt, so wird das Gruppenlayout direkt in das neue Layout übernommen. Siehe [Fixtures aus Gruppenlayouts per Record hinzufügen](./layouts.md#fixtures-aus-gruppenlayouts-per-record-hinzufügen) im nächsten Abschnitt.
+
+> Haben Sie nur einen Bildschirm, so empfiehlt es sich, für den Layout-Editor einen Workspace anzulegen, so dass man beim Kopieren der Geräte einfach die Fenster wechseln kann.
+
+### Gerätedarstellung
+
+In dem Layout wird jedes Gerät durch ein quadratisches 'Element' dargestellt, wobei das eingestellte [Fixture-Halo](../titan-basics/workspace-windows.md#button-halo) angezeigt wird (farbiger Rand).
+
+![Layout fixture mimics](/docs/images/Layouts-Fixture-Mimics.png)
+
+- In der linken oberen Ecke steht die Gerätenummer, unten in der Mitte der aktuelle Pegel.
+- Mittig wird die Farbe und das aktuelle Gobo angezeigt (wenn dies in der Personality korrekt angelegt ist). Dies lässt sich mit der Einstellung *Show Fixture Mimics* im Tab 'Elements' der Layout View-Optionen de- oder aktivieren (klicken Sie dazu auf den Kontextbutton <Keys.ContextKey>Options</Keys.ContextKey>).
+- Geräte im Programmer werden mit einer Leiste in Cyan unten angezeigt.
+- Geräte mit laufenden Effekten werden mit einer Tilde ( ~ ) oben rechts angezeigt.
+- Läuft gerade ein Dimmereffekt, so wird der Pegel gelb angezeigt.
+- Die Vorderseite der Fixtures wird durch einen Pfeil angegeben.
+
+Einfache Dimmer werden normalerweise weiß angezeigt. Dies lässt sich ändern, um z.b. die Farbe des verwendeten Filters anzuzeigen: wählen Sie das Gerät aus und schalten Sie die Funktion der Encoder mit der unteren Menütaste auf <Keys.SoftKey>Wheels=Visualiser</Keys.SoftKey> um, wählen die Attributbank Colour, und stellen mit den Encodern die gewünschte Farbe ein.
+
+### Funktionen der Layout-Anzeige
+Der Layout-View (die Anzeige) kann durch Klicken auf das <Keys.ContextKey>Lock</Keys.ContextKey> rechts oben gesperrt werden.
+
+- Zum Positionieren der einzelnen Elemente muss das Layout **entsperrt** sein. Dann können die Elemente angeklickt und gezogen werden, oder man verwendet die Encoder. Geräte können so nicht zum Programmieren angewählt werden.
+- Um dagegen Fixtures zum Programmieren und Steuern anzuwählen, muss das Layout **gesperrt** sein. So können Geräte ausgewählt, aber nicht verschoben werden. Playbacks sowie Macros und Gruppen funktionieren ebenfalls nur im gesperrten Modus.
+
+Mit dem Schieberegler links kann man in das Layout hinein- bzw. daraus herauszoomen. Mit einem Klick auf <Keys.ContextKey>Zoom to Fit</Keys.ContextKey> wird das Layout formatfüllend dargestellt.
+
+Mit den Buttons <Keys.ContextKey>Select</Keys.ContextKey> und <Keys.ContextKey>Pan</Keys.ContextKey> kann man entweder per Auswahlbox mehrere Elemente anwählen oder per Hand-Werkzeug die komplette Ansicht verschieben ('pannen').
+
+## Elemente zum Layout hinzufügen
+
+Es gibt mehrere Wege, Elemente zu einem Layout hinzuzufügen. Zum Löschen wiederum drückt man die Taste <Keys.HardKey>Delete</Keys.HardKey> und klickt auf das zu löschende Element im Layout.
+
+### Fixtures per Copy hinzufügen
+
+Drücken Sie die Taste <Keys.HardKey>Copy</Keys.HardKey>, wählen Sie die gewünschten Geräte aus, und klicken Sie im layout auf die Stelle, an der die Geräte eingefügt werden sollen.
+
+-   Die Geräte werden alle nebeneinander in einer Zeile angeordnet. Die Positionierung lässt sich später ändern.
+
+### Fixtures aus Gruppenlayouts per Record hinzufügen
+
+Werden die Geräte nicht einzeln, sondern gleich als Gruppe angewählt, und wurde für die Gruppe bereits die Geräteanordnung (also das Gruppenlayout) editiert, siehe [Gruppenlayout](../controlling-fixtures/fixture-groups.md#gruppenlayout), so wird dieses auch in das Layout übertragen.
+
+Wählen Sie dazu Gerätegruppen aus, drücken <Keys.HardKey>Record</Keys.HardKey>, und klicken auf einen Layout-Button im **Fenster Layouts**. Wählen Sie eine der Menüoptionen:
+
+-   <Keys.SoftKey>Replace</Keys.SoftKey> alle vorhandenen Elemente werden aus dem Layout gelöscht und die Elemente der ausgewählten Gruppen neu eingefügt.
+-   <Keys.SoftKey>Merge</Keys.SoftKey> die Elemente der Gruppen werden zu den bereits vorhandenen hinzugefügt.
+-   <Keys.SoftKey>Update Fixture Positions from Programmer</Keys.SoftKey> die selektierten Geräte werden anhand des Gruppenlayouts neu positioniert.
+
+Eingefügt wird immer von oben links an beginnend. Enthalten die Gruppen kein Gruppenlayout oder wurden die Fixtures einzeln angewählt, so werden diese nebeneinander in einer Zeile ind das Layout eingefügt.
+
+### Playbacks, Gruppen und Macros hinzufügen
+
+Buttons für Playbacks, Gruppen und Macros können ebenfalls in eine Layout eingefügt werden, so dass man damit arbeiten kann, ohne laufend Fenster wechseln zu müssen.
+
+Drücken Sie die Taste <Keys.HardKey>Copy</Keys.HardKey>, wählen das Playback, die Gruppe oder das Macro aus, und klicken im Layout an die gewünschte Stelle. Es können auch mehrere Elemente gleichzeitig ausgewählt und eingefügt werden.
+
+![Group handles in Layout](/docs/images/Layouts-Group-Handles.png)
+
+-  Ist das Layout *entsperrt*, so kann man Elemente löschen, indem man auf <Keys.HardKey>Delete</Keys.HardKey> drückt und die zu löschenden Elemente im Layout auswählt. Die originalen Objekte (Playbacks, Fixtures etc.) werden damit nicht gelöscht. Ist das Layout dagegen *gesperrt*, so werden beim Löschen der Layout-Elemente auch die originalen Objekte gelöscht.
+
+## Anordnen der Elemente in einem Layout
+
+Die Elemente eines Layouts können sowohl manuell als auch unter Zuhilfenahme einiger Werkzeuge angeordnet werden.
+
+### Elemente manuell anordnen
+
+Wählen Sie ein oder mehrere Elemente aus und ziehen Sie diese im Layout auf die gewünschte Position. Dabei folgen die Elemente immer dem Raster.
+
+Ebenso kann man die Elemente mit den Encodern verschieben und drehen. Die Steuerung mit den Encodern kann man deaktivieren: klicken Sie auf die Kontext-Option <Keys.ContextKey>Position & Angle</Keys.ContextKey> (womit diese wechselt auf <Keys.ContextKey>No Wheel Control</Keys.ContextKey>).
+
+Positioniert man Elemente mit den Encodern, so kann man sie auch gegen das Raster verschieben. Dazu dient die Kontext-Option <Keys.ContextKey>Wheels Move Full Pixel</Keys.ContextKey> / <Keys.ContextKey>Wheels Move Sub Pixel</Keys.ContextKey>. Sind Elemente einmal vom Raster getrennt, so behalten sie ihre Verschiebung aus dem Raster, bis sie entweder mit den Encodern wieder genau am Raster ausgerichtet wurden oder die Kontext-Funktion <Keys.ContextKey>Snap Selected Elements to Grid</Keys.ContextKey> verwendet wurde.
+
+Solange die Option <Keys.ContextKey>Wheels Move Full Pixel</Keys.ContextKey> aktiviert ist, erfolgt das Drehen von Objekten in 45°-Schritten, anderenfalls kann stufenlos gedreht werden. Sind mehrere Elemente ausgewählt, so kann man mit der Option <Keys.ContextKey>Wheels Rotate Individual Elements</Keys.ContextKey> / <Keys.ContextKey>Wheels Rotate Selection</Keys.ContextKey> einstellen, ob jedes Element individuell oder aber alle um das gemeinsame Zentrum gedreht werden sollen.
+
+### Elemente in Formen anordnen
+
+Elemente können automatisch als Rechteck, Oval/Kreis, oder als Dreieck angeordnet werden.
+
+1. Klicken Sie auf <Keys.ContextKey>Arrange Elements</Keys.ContextKey> im Kontextbereich.
+2. Wählen Sie die Option <Keys.ContextKey>Shape</Keys.ContextKey>.
+3. Legen Sie im Menü mit <Keys.SoftKey>All Elements</Keys.SoftKey> / <Keys.SoftKey>Selected Elements</Keys.SoftKey> fest, ob alle Elemente des Layouts oder nur die angewählten Elemente entsprechend angeordnet werden sollen. 
+4. Wählen Sie im Menü mit <Keys.SoftKey>Shape=</Keys.SoftKey> die gewünschte Form der Anordnung.
+5. Geben Sie die Anzahl von Zeilen und Spalten des Rasters vor, wie groß die Anordnung sein soll. Dazu dienen die Menütasten <Keys.SoftKey>Width=</Keys.SoftKey> (Breite) und <Keys.SoftKey>Height=</Keys.SoftKey> (Höhe).
+6. Bestimmen Sie mit <Keys.SoftKey>Arrange in Rows</Keys.SoftKey> / <Keys.SoftKey>Arrange in Columns</Keys.SoftKey>, in welcher Reihenfolge die Geräte/Elemente angeordnet werden (erst von links nach rechts und dann von oben nach unten, oder umgekehrt).
+7. Klicken Sie zum Abschluss auf <Keys.SoftKey>OK</Keys.SoftKey>.
+
+### Anordnen von Geräten aus dem Visualiser
+
+Wurden Fixtures bereits im internen Capture-Visualiser positioniert, , so kann diese Positionierung auch in Layouts verwendet werden.
+
+1. Klicken Sie auf <Keys.ContextKey>Arrange Elements</Keys.ContextKey> im Kontextbereich.
+2. Wählen Sie die Option <Keys.ContextKey>From Capture</Keys.ContextKey>.
+3. Legen Sie im Menü mit <Keys.SoftKey>All Elements</Keys.SoftKey> / <Keys.SoftKey>Selected Elements</Keys.SoftKey> fest, ob alle Elemente des Layouts oder nur die angewählten Elemente entsprechend angeordnet werden sollen. 
+4. Wählen Sie im Menü mit <Keys.SoftKey>Projection=</Keys.SoftKey> die gewünschte Perspektive (Top, Front, Side) der Anordnung.
+5. Wenn erforderlich stellen Sie mit <Keys.SoftKey>Scale=</Keys.SoftKey> die Skalierung ein, z.B. so, dass die Geräte nicht überlappend angezeigt werden.
+6. Klicken Sie auf <Keys.SoftKey>Apply</Keys.SoftKey>, um eine Vorschau des Ergebnisses zu sehen.
+7. Ist alles wie gewünscht, so drücken Sie auf <Keys.SoftKey>Apply and Exit</Keys.SoftKey> um die Positionierung zu übernehmen.
+
+### Rasteroptionen
+
+Das angezeigte Raster kann vergrößert werden, um mehr Geräte platzieren zu können. Ebenso kann es komplett ausgeblendet werden.
+
+Um den Rasterbereich zu vergrößern oder zu verkleinern, klicken und ziehen Sie die Anfasser in den Ecken des Rasters auf die gewünschte Größe. Das Layout muss dazu *entsperrt* sein. Mit der Kontext-Option <Keys.ContextKey>Crop Grid</Keys.ContextKey> kann das Raster genau auf die passende Größe gebracht werden, um alle vorhandenen Elemente anzuzeigen.
+
+Um das Raster ein- oder auszublenden, öffnen Sie die Optionen des Layouts über den Kontext-Button <Keys.ContextKey>Options</Keys.ContextKey>. Auf der Seite Layout kann mit dem Schalter <Keys.ContextKey>Show Grid</Keys.ContextKey> das Raster ein- und ausgeblendet werden.
+
+### Einen Plan als Hintergrund eines Layouts laden
+
+Optional kann ein Plan - oder ein sonstiges Bild - als Hintergrund eines Layouts geladen werden.
+
+![Layout with imported plan](/docs/images/Layouts-With-Plan.png)
+
+1. Speichern Sie den Plan als Grafik (png, bmp, jpg - nicht als PDF).
+2. Öffnen Sie die Optionen des Layouts über den Kontext-Button <Keys.ContextKey>Options</Keys.ContextKey>und dort die Seite Layout.
+3. Klicken Sie auf 'Background Image', um den Dateibrowser zu öffnen.
+4. Wählen Sie das gewünschte Bild.
+
+Mit <Keys.SoftKey>Scaling Mode</Keys.SoftKey> lässt sich festlegen, wie das Bild skaliert werden soll:
+- None (keine Skalierung)
+- Letterbox (Skalierung, so dass Höhe und Breite passt, mit schwarzen Rändern wenn zu klein)
+- Fill (Skalierung, so dass Höhe und Breite passt; was zu groß ist, wird abgeschnitten)
+- Stretch (Verzerrung, so dass alles angezeigt wird, aber das Seitenverhältnis gestaucht/gestreckt wird)
+
+Die Helligkeit/Transparenz des Hintergrundbildes kann mit <Keys.SoftKey>Background Image Opacity</Keys.SoftKey> eingestellt werden (numerisch eingeben oder mit Encoder A; 0% = voll transparent, 100% = keine Transparenz, volle Helligkeit).
+
+## Umschalten zwischen Layouts
+
+Zum Wechseln zwischen Layouts klicken Sie entweder auf ein anderes Layout im Fenster **Layouts**, oder Sie verwenden die Kontext-Funktion <Keys.ContextKey>Open Layout</Keys.ContextKey> und wählen das gewünschte Layout mit den Menütasten

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/viewing-and-editing-fixture-values.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/controlling-fixtures/viewing-and-editing-fixture-values.md
@@ -1,0 +1,172 @@
+---
+id: viewing-and-editing-fixture-values
+title: Anzeigen/Verändern von Attribut-Werten
+sidebar_label: Anzeigen/Verändern von Attribut-Werten
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Übersicht über die Kanäle: Das 'Channel Grid'-Fenster
+
+Zuweilen ist es sinnvoll, die genauen Einstellungen jedes Gerätes
+einzeln anzeigen und ändern zu können. Das 'Channel Grid'-Fenster
+ermöglicht genau das. Um es aufzurufen, drücken Sie zweimal auf
+[<Keys.HardKey>Open/View</Keys.HardKey>](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster) 
+und wählen <Keys.SoftKey>Channel Grid</Keys.SoftKey>.
+
+![Channel Grid](/docs/images/Channel-Grid.png)
+
+Das Fenster lässt sich mit den Kontext-Schaltflächen links vom Menü in
+verschiedene Modi schalten:
+
+-   All/Stage/Programmer/Selected: Auswahl der angezeigten Geräte
+    (Alle/Mit Dimmer an/Im Programmer/In der Auswahl)
+-   Sort: Sortierung nach Nummer, DMX-Adresse oder zuletzt gewählt
+-   Open Intensity View: damit kann man direkt das Intensity-Fenster
+    öffnen (und von dort mit der gleichen Funktion wieder
+    zurückwechseln)
+-   Show/Hide Palettes: Anzeigen von Paletten oder diskreten Werten
+-   Playbacks/Levels/Shapes/Effects/Times: nur einer dieser Modi kann
+    jeweils angezeigt werden.
+
+Zur **Auswahl** von Geräten klicken Sie einfach links auf den
+Gerätenamen; wird ein Attributwert ausgewählt, so wird automatisch das
+zugehörige Gerät angewählt.
+
+Zum **Löschen** eines Attributwerts im 'Channel Grid'-Fenster klicken
+Sie auf den zu löschenden Wert (oder wählen mit Klicken-Ziehen mehrere
+aus) und wählen <Keys.SoftKey>Clear</Keys.SoftKey>.
+
+Zum **Ändern** wählen Sie den oder die zu ändernden Wert(e) aus und
+ändern den Wert mit den Rädern, oder geben den gewünschten Wert mit den
+Zifferntasten ein und schließen die Eingabe mit <Keys.HardKey>Enter</Keys.HardKey> ab.
+
+Die Anzeige lässt sich über die Schaltflächen oben links weiter filtern:
+entweder mit den Buttons IPCGBES für die einzelnen Attribute, oder mit
+den Buttons darunter nach Gerätetyp.
+
+## Das Fenster "Intensity View"
+
+Um einen raschen Überblick über die momentan aktiven Scheinwerfer zu
+gewinnen, dient das Fenster "Intensity View" (die Intensity-Ansicht). Um
+dieses zu öffnen, drücken Sie zweimal auf
+[<Keys.HardKey>Open/View</Keys.HardKey>](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster) und wählen <Keys.SoftKey>Intensity View</Keys.SoftKey>.
+
+![Intensity View](/docs/images/Intensity-View.png)
+
+Für jedes Gerät wird ein Button angezeigt mit einer Balkenanzeige und
+numerischer Anzeige des aktuellen Helligkeitswerts. Der Kopfbereich
+jedes Buttons zeigt wie gewohnt den Auswahl- und Programmerstatus
+(blau=angewählt, cyan=im Programmer).
+
+Einfadende Werte werden durch einen blauen Pfeil nach oben, ausfadende
+Werte durch einen grünen Pfeil nach unten dargestellt.
+
+Getrackte Werte erscheinen in Magenta mit einem "=".
+
+Getrackte Werte in einem Solo- oder Block-Cue erscheinen rot mit einem
+Verbotszeichen.
+
+![Solo/Block Cue](/docs/images/Solo-Block-Cue.png)
+
+Werte, die von einem Effekt beeinflusst werden, erscheinen gelb mit
+einer Tilde ( \~ ).
+
+Wird ein Wert von einem Playback gesteuert, so wird dieses angezeigt.
+
+Ist ein Gerät im Programmer, so werden die relevanten Attribut-Bänke
+IPCGBESFX entsprechend angezeigt.
+
+Wurden für die Geräte Halos eingestellt, so werden diese auch hier
+angezeigt. Dies kann wie beschrieben so geändert werden, dass die
+automatisch vergebenen Farben angezeigt werden.
+
+-   Mittels der Buttons links kann nach einzelnen Gerätetypen gefiltert
+    werden.
+
+-   Die Reihenfolge der Anzeige kann man mittels <Keys.SoftKey>Sort</Keys.SoftKey> verändern:
+    User Number, zuletzt gewählt, oder DMX-Adresse.
+
+-   Jedes Gerät lässt sich direkt anklicken und man kann sofort den
+    Helligkeitswert editieren.
+
+-   Zur Anzeige weiterer Informationen zu dem einzelnen Gerät drücken
+    Sie <Keys.HardKey>Open/View</Keys.HardKey> gefolgt von dem jeweiligen
+    Geräte-Button.
+
+### Filtern der angezeigten Geräte
+
+Mit den Kontext-Optionen lässt sich Inhalt und Anzeige des
+Intensity-Fensters genau steuern.
+
+Der erste Button steuert, welche Geräte überhaupt angezeigt werden:
+
+- <Keys.SoftKey>All</Keys.SoftKey> zeigt alle gepatchten Geräte
+- <Keys.SoftKey>Stage</Keys.SoftKey> zeigt alle Geräte mit Intensität >0%
+- <Keys.SoftKey>Programmer</Keys.SoftKey> zeigt nur die im Programmer befindlichen Geräte
+- <Keys.SoftKey>Selected</Keys.SoftKey> zeigt nur die aktuell ausgewählten Geräte
+- <Keys.SoftKey>Live Cues</Keys.SoftKey>: Anzeige der Geräte, die gerade von aktivierten Cues 
+gesteuert werden
+- <Keys.SoftKey>Connected Cue</Keys.SoftKey>: Geräte im gerade connected (verbundenen) Cue (bei Cuelisten und Chasern)
+- <Keys.SoftKey>Frozen</Keys.SoftKey> zeigt nur aktuell fixierte Geräte an
+
+Mit dem zweiten Button lässt sich wie oben beschrieben die Sortierung
+der Anzeige umschalten.
+
+Klickt man auf den Button <Keys.SoftKey>Search</Keys.SoftKey> (Suche), so 
+kann man ein Suchwort eingeben, nach dem gefiltert werden soll. Dabei 
+wird sowohl nach der Gerätenummer als auch der Bezeichnung gesucht. 
+Die Such-Eingabe wird oben im Intensity-Fenster angezeigt. Rechts daneben 
+ist eine Schaltfläche mit einem <Keys.ContextKey>X</Keys.ContextKey> -- 
+mit dieser wird die Suche gelöscht/abgebrochen.
+
+<Keys.SoftKey>View If</Keys.SoftKey> (Zeige wenn) zeigt nur die in einzelnen Gruppen oder
+Playbacks vorhandenen Geräte. Handelt es sich dabei um eine Cueliste
+oder einen Chaser, so gilt das für alle Cues. Der aktuelle Anzeigefilter
+wird oben im Intensity-Fenster angezeigt und kann zum Ändern einfach
+angeklickt werden. Klickt man auf das <Keys.ContextKey>X</Keys.ContextKey>, so wird der Filter
+gelöscht.
+
+Es gibt ferner den Kontext-Button <Keys.SoftKey>Open Channel Grid</Keys.SoftKey> (Öffne Channel
+Grid), mit dem direkt die Kanal-Übersicht [Channel Grid](viewing-and-editing-fixture-values.md#übersicht-über-die-kanäle-das-channel-grid-fenster) 
+geöffnet werden kann.
+
+### Fenster-Einstellungen
+
+In den **Fenster-Einstellungen** (klicken Sie dazu auf das <Keys.ContextKey>Zahnrad</Keys.ContextKey>
+in der Titelleiste des Fensters) gibt es weitere Einstellmöglichkeiten, 
+um den Platz bestmöglich auszunutzen:
+
+-   Fixture Filters Shown/Hidden (Geräte Filter angezeigt/verborgen)
+    blendet links eine Spalte ein/aus, mit der nach Gerätetyp gefiltert
+    werden kann.
+
+-   User Number Hidden/User Number Shown/DMX Address Shown (Nummer
+    angezeigt/DMX Adresse angezeigt/Nummer verborgen) bestimmt die
+    Anzeige von DMX-Adresse oder Gerätenummer.
+
+-   Legend Shown/Hidden (Legende angezeigt/verborgen): Anzeige der
+    Legende.
+
+-   Cue Information Shown/Hidden (Cue Information angezeigt/verborgen):
+    Anzeige des Playbacks, das das jeweilige Gerät momentan steuert.
+
+-   Attribute Mask Shown/Hidden (Attribut Maske angezeigt/verborgen):
+    Einblenden der IPCGBESFX Attributmaske zur Anzeige aktiver
+    Attribute.
+
+-   Halo Colour Custom/Auto (Halo Colour Benutzer/Auto): steht dies auf
+    Auto, so wird der Rahmen für jedes Gerät, für das nicht bereits eine
+    benutzerdefinierte Farbe vorgegeben ist, durch eine Farbe pro
+    Gerätetyp dargestellt. Gibt es bereits eine benutzerdefinierte
+    Farbe, so hat diese Vorrang. Steht die Option dagegen auf
+    ‚Benutzer', so werden nur benutzerdefinierte Farben dargestellt.
+
+-   Fixture Cells Shown/Hidden (Geräte Zellen angezeigt/verborgen):
+    falls aktiviert werden für vorhandene Gerätezellen jeweils eigene
+    Gerätebuttons angezeigt.
+
+-   Tracked Fixtures Shown/Hidden (getrackte Geräte
+    angezeigt/verborgen): (Nur verfügbar bei Filterung nach Live Cue
+    oder Connected Cue) Anzeige getrackter Geräte.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists.md
@@ -1,0 +1,37 @@
+---
+id: cue-lists
+title: Cuelisten
+sidebar_label: Cuelisten
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Cuelisten - Szenenfolgen - gestatten das Programmieren einer Abfolge
+von [Cues](cues.md), von denen jeder eigene [Zeitvorgaben](cue-lists/cue-list-timing.md) enthalten kann und die
+entweder Schritt für Schritt mit der [<Keys.HardKey>Go</Keys.HardKey>-Taste gesteuert werden oder
+automatisch ablaufen können](cue-lists/cue-list-playback.md). Damit lassen sich selbst komplexe Shows in nur einer Liste programmieren, etwa bei 
+[Theateraufführungen](cue-lists/theatre-programming.md), wo der
+Showablauf jedes Mal exakt gleich sein muss. Cuelisten können aber auch
+bei spontan gedrückten Shows sehr hilfreich sein, insbesondere auf
+Pulten mit wenigen Fadern, indem man sich mehrere verschiedene Bilder
+auf einen Fader legt.
+
+Cuelisten unterscheiden sich von [Chasern](chases.md) in der Art und Weise der
+Behandlung von Änderungen zwischen den einzelnen Schritten: während
+[Chaser](chases.md) zwischen den einzelnen Schritten überblenden (und damit nicht
+enthaltenen Geräte ausblenden), wird bei Cuelisten der aktuelle Status
+der Geräte aus den vorangegangenen Änderungen/Befehlen ermittelt
+(Tracking). Wurde ein Gerät nicht verändert, so werden auch keine
+Änderungen im jeweiligen Cue gespeichert, und das Gerät bleibt beim
+Starten des Cues unverändert.
+
+Das [Tracking-Verhalten](cue-lists/cue-list-playback.md#tracking) der 
+Cueliste lässt sich detailliert steuern; dazu gehören - pro Cue - die 
+Optionen Block, This Cue Only und Solo (Siehe auch [Abrufen einer Cueliste](cue-lists/cue-list-playback.md)).
+
+Zur Anzeige des Inhalts einer Cueliste berühren Sie den Touchscreen im
+'Playback'-Bereich oberhalb des jeweiligen Reglers oder drücken <Keys.HardKey>Open/View</Keys.HardKey>
+und die zugehörige **Auswahltaste**.
+
+![Playback View of Cue List](/docs/images/Cue-List-Window-with-Autoload-playback.png)

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/copying-moving-linking-and-deleting.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/copying-moving-linking-and-deleting.md
@@ -1,0 +1,31 @@
+---
+id: copying-moving-linking-and-deleting
+title: Kopieren, verschieben, verlinken, löschen
+sidebar_label: Kopieren, verschieben, verlinken, löschen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+In diesem Abschnitt wird das Verschieben/Kopieren kompletter Cuelisten
+erläutert; zum Kopieren/Verschieben/Löschen einzelner Cues innerhalb
+einer Liste siehe [Kopieren, Verschieben und Löschen einzelner Cues](editing-cue-lists.md#kopieren-verschieben-und-löschen-einzelner-cues).
+
+## Eine Cueliste verschieben oder kopieren
+
+Mit den Tasten <Keys.HardKey>Copy</Keys.HardKey> und <Keys.HardKey>Move</Keys.HardKey> können Cuelisten 
+kopiert oder auf einen anderen Speicherplatz verschoben
+werden, oder Sie können eine Verknüpfung auf eine bestehende Cueliste
+erstellen. Verschieben ist sinnvoll zum Erhalt einer aufgeräumten
+Arbeitsoberfläche. Verknüpfungen bieten sich an, wenn aus Gründen des
+Showablaufs die gleiche Cueliste auf mehreren Playback-Seiten abrufbar
+sein soll.
+
+Die Vorgehensweise ist die gleiche wie für Cues, und ist in Abschnitt
+[Kopieren, verschieben, verlinken, löschen](../cues/copying-moving-linking-and-deleting.md) genau beschrieben.
+
+## Löschen einer Cueliste
+
+Um eine komplette Cueliste zu löschen, drücken Sie <Keys.HardKey>Delete</Keys.HardKey>, dann die
+&nbsp;**Auswahltaste** der zu löschenden Cueliste, und schließlich die
+Auswahltaste nochmals (oder <Keys.SoftKey>Confirm</Keys.SoftKey> oder <Keys.HardKey>Enter</Keys.HardKey>).

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/creating-a-cue-list.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/creating-a-cue-list.md
@@ -1,0 +1,248 @@
+---
+id: creating-a-cue-list
+title: Anlegen einer Cueliste
+sidebar_label: Anlegen einer Cueliste
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Programmieren einer Cueliste
+
+<Video videoId="Kp6XhdG6keM" title="Cuelist Basics" />
+
+Das Programmieren einer Cueliste gleicht dem [Programmieren eines
+Chasers](../chases/creating-a-chase.md).
+
+Sie erstellen jeweils das gewünschte Bild und fügen dies als Schritt zu
+der Cueliste hinzu. Zeiten lassen sich entweder sofort oder [später
+hinzufügen](cue-list-timing.md).
+
+1. Drücken Sie die Taste <Keys.HardKey>Record</Keys.HardKey> und wählen die Option <Keys.SoftKey>Create Cue List</Keys.SoftKey> 
+(auf dem Tiger Touch I drücken Sie <Keys.HardKey>Record Chase or List</Keys.HardKey>
+zweimal, oder drücken Sie die Taste einmal und wählen die Option
+<Keys.SoftKey>Create Cue List</Keys.SoftKey>).
+2. Drücken Sie die blaue **Select**-Taste des gewünschten
+Speicherplatzes *(auch Cuelisten lassen sich auf die Schaltflächen im
+'Playbacks'-Fenster speichern)*.
+3. Wählen Sie den gewünschten [Record Mode](#speichermodusrecord-mode) (Speichermodus) des Pultes:
+'by Fixture' (pro Gerät), 'by Channel' (nur geänderte Kanäle), 'Record
+Stage' oder ‚Quick Build'. <Keys.SoftKey>Record Mode Channel</Keys.SoftKey> ist in der Regel die sicherste
+Option, da nur die tatsächlich geänderten Attribute gespeichert werden.
+Es empfiehlt sich aber in jedem Falle zu überprüfen, was denn nun genau
+abgespeichert wird (ggf. müssen weitere Attribute in den
+Programmierspeicher übernommen werden).
+4. Stellen sie mit <Keys.SoftKey>Set Times</Keys.SoftKey> die generellen Überblend- und
+Verzögerungszeiten sowie die Verknüpfung aufeinanderfolgender Schritte
+ein; diese Einstellungen gelten dann für alle neu gespeicherten
+Schritte.
+5. Stellen Sie das Bild für den ersten Schritt zusammen, entweder
+manuell oder unter Verwendung von <Keys.HardKey>Include</Keys.HardKey> (siehe  [Cues wiederverwenden - die 'Include'-Funktion](../cues/editing-cues#cues-wiederverwenden---die-include-funktion)).
+Nutzen Sie wenn gewünscht auch den [Shape Generator](../effects/shape-generator.md) oder den [Pixelmapper](../effects/pixel-mapper.md).
+6. Wollen Sie für den Schritt eine **Bezeichnung/Legende** vergeben, so drücken Sie
+dazu <Keys.SoftKey>Cue Legend</Keys.SoftKey>. Das lässt sich auch später nachholen oder ändern,
+entweder mit [Unfold](editing-cue-lists.md#editieren-einer-cueliste-mit-unfold) oder mit [Set Legend](#vergeben-von-bezeichnern-für-einzelne-schritte) (siehe nächster Abschnitt).
+7. Drücken Sie die **Select**-Taste des Speicherplatzes, oder wählen
+Sie <Keys.SoftKey>Append Cue</Keys.SoftKey>(Schritt anfügen), um den Inhalt des
+Programmierspeichers als Schritt 1 der Cueliste abzuspeichern.
+8. Wiederholen Sie ab Schritt 5 für den nächsten Schritt der Cueliste.
+Drücken Sie nicht <Keys.HardKey>Clear</Keys.HardKey>, es sei denn, Sie wollen explizit Pegel aus
+vorherigen Schritten übernehmen, da ansonsten Reglerwerte auch von ‚0'
+nicht gespeichert werden. Stellen Sie also sicher, dass alle
+Geräte/Kanäle, die im aktuellen Schritt verändert werden sollen,
+angewählt oder im Programmierspeicher sind (invertierte Anzeige).
+9. Drücken Sie <Keys.HardKey>Exit</Keys.HardKey>, wenn alle gewünschten Schritte programmiert
+sind.
+
+-   Um an eine existierende Cueliste [weitere Schritte anzufügen](editing-cue-lists.md),
+    wiederholen Sie obiges Vorgehen; bereits vorhandene Schritte werden
+    davon nicht beeinflusst. 
+
+-   Zum Anfügen von Schritten an das Ende der Liste wählen Sie <Keys.SoftKey>Append Cue</Keys.SoftKey>.
+
+-   Um einen bestehenden Schritt zu ändern, drücken Sie <Keys.SoftKey>Cue Number=</Keys.SoftKey>
+    und geben die Nummer des Schrittes mit den Zifferntasten ein. Nehmen
+    Sie die Änderungen vor und drücken Sie <Keys.SoftKey>Update Cue x</Keys.SoftKey>.
+
+-   Zum Einfügen neuer Schritte siehe [Editieren einer Cueliste](editing-cue-lists.md).
+
+-   Das Menü **Advanced Options** gestattet das Neu-Nummerieren der
+    Schritte, und das Ändern der einzelnen Schrittnummern.
+
+-   In jeder Cueliste kann eine unbegrenzte Zahl von Schritten
+    gespeichert werden.
+
+-   Bei Cuelisten gibt es auch eine **MID (Move-In-Dark)** - Funktion:
+    damit werden Geräte bereits für den nächsten Einsatz vorbereitet
+    (positioniert etc.), solange sie aktuell nicht aktiv sind. Details
+    siehe Abschnitt [Move In Dark (MID)](../cue-lists/cue-list-playback.md#move-in-dark-mid---funktionen)
+
+-   Für jeden Cue lassen sich die [Tracking-Optionen](cue-list-options.md#tracking) getrennt einstellen.
+
+### Speichermodus/Record Mode
+
+Mit der Menütaste <Keys.SoftKey>Record Mode</Keys.SoftKey> (Speichermodus) wählt man zwischen **Record By
+Fixture** (‚Speichern pro Gerät', alle Attribute aller veränderten/
+ausgewählten Geräte werden gespeichert), **Record By Channel**
+('Speichern pro Kanal', nur die geänderten Attribute werden
+gespeichert), **Record Stage** ('Bühne speichern', alle Geräte mit
+Helligkeit > 0 werden gespeichert), oder **Quick Build** zum raschen
+Erstellen aus vorhandenen Cues und Paletten.
+
+> **Record By Channel** bietet sich an, wenn sich mehrere Cuelisten -
+für unterschiedliche Attribute - gegenseitig überlagern sollen.
+
+
+## Vergeben von Bezeichnern für einzelne Schritte
+
+Für jeden Schritt lässt sich eine Bezeichnung vergeben, welche beim
+Ablauf der Cueliste im Display erscheint - eine hilfreiche Sache bei der
+Navigation.
+
+1.  Drücken Sie <Keys.SoftKey>Set Legend</Keys.SoftKey> im Hauptmenü. Wollen Sie mehrere
+    Bezeichnungen vergeben, so rasten Sie das Menü mit der Taste <Keys.HardKey>Menu
+    Latch</Keys.HardKey> ein.
+2.  Drücken Sie die **Select-Taste** der entsprechenden Cueliste.
+3.  Die Schritte der Cueliste werden nun auf dem Bildschirm angezeigt.
+    Klicken Sie auf den gewünschten Cue oder nutzen Sie das Rad A, um den zu
+    ändernden Schritt auszuwählen.
+4.  Klicken Sie <Keys.SoftKey>Cue Legend</Keys.SoftKey> und geben Sie die Bezeichnung mit der
+    Tastatur ein, gefolgt von <Keys.HardKey>Enter</Keys.HardKey>.
+5.  Setzen Sie den Vorgang ggf. für weitere Schritte fort, oder drücken
+    Sie <Keys.HardKey>Exit</Keys.HardKey>, um den Vorgang abzuschließen.
+
+## Tracking von Shapes in Cuelisten
+
+Ab Version 10 können auch Shapes innerhalb von Cuelisten tracken. Ist
+das Tracking für Shapes aktiviert, läuft ein in einem Cue gestarteter
+Shape auch in den folgenden Cues. Zum Aktivieren des Trackings für
+Shapes dient die Option <Keys.SoftKey>Shape Tracking</Keys.SoftKey> in den [Optionen](cue-list-options.md#tab-playback) der
+Cueliste.
+
+Cues, die Shapes enthalten, verfügen für jeden Shape über einen extra
+Button.
+
+![Cue List window showing tracking shapes](/docs/images/Cue-List-window-showing-tracking-shapes.png)
+
+In den darauffolgenden Cues gibt es für jeden getrackten Shape einen
+Schalter:
+
+| Einstellung | Wirkung |
+| --- | --- |
+| T | Shape wird in den folgenden Cue getrackt |
+| B | Shape wird geblockt, läuft also nicht in den folgenden Cues |
+
+Für den Cue selbst gibt es dazu die Option <Keys.SoftKey>Block All Shapes</Keys.SoftKey>, siehe
+[Cuelisten-Optionen](cue-list-options.md#tab-playback).
+
+Darüber hinaus können auch Shapes für einzelne Attribute geblockt
+werden, dies erfolgt über das **@**-Menü. Wählen Sie das zu blockende
+&nbsp;**Attribut**, drücken die entsprechende **@**-Taste und dann den Attribut-Button
+&nbsp;**FX**. Auf den Menütasten gibt es nun die Optionen <Keys.SoftKey>Block 
+Shape</Keys.SoftKey> und <Keys.SoftKey>Unblock Shape</Keys.SoftKey>. Wurde ein 
+Attribut auf **Block Shape** gesetzt, so wird das im Display bei den Encodern 
+mit *"Blocked"* angezeigt.
+
+Ist das **Shape-Tracking** in den [Cuelist-Optionen](cue-list-options.md#tab-playback) dagegen nicht aktiviert, so sind die Shapes in
+jedem Cue unabhängig voneinander. Wird der identische Shape - gleiche
+Parameter, Größe und Geschwindigkeit - in mehrere aufeinanderfolgende
+Cues programmiert, so läuft er einfach durch, ohne unterbrochen zu
+werden.
+
+## Autoloading: Laden eines externen Cues
+
+Schritte einer Cueliste lassen sich auch so programmieren, dass sie
+automatisch den Inhalt eines oder mehrerer Speicherplätze -- Cues,
+Chaser oder wiederum Cuelisten -- aufrufen, wenn der jeweilige Schritt
+gestartet wird. Dies ist hilfreich, um etwa Chaser oder Effekte in die
+Cueliste zu integrieren.
+
+Man kann entweder die **Autoloads** manuell programmieren, oder automatisch
+alle aktiven Speicherplätze als **Autoload** definieren.
+
+Zum automatischen Definieren gehen Sie wie folgt vor:
+
+1.  Nach dem Aktivieren von **Cue List Record** (beim Anlegen der
+    Cueliste) wählen Sie <Keys.SoftKey>Advanced Options</Keys.SoftKey>, 
+	dann <Keys.SoftKey>Autoload Live Playbacks</Keys.SoftKey>.
+2.  Aktivieren Sie die Cues/Chaser/Cuelisten, die Sie als Autoload
+    einbinden möchten.
+3.  **Speichern Sie den Cue**. Dabei werden die aktivierten
+    Speicherplätze automatisch als Autoload eingebunden.
+
+Das manuelle Programmieren der Autoloads erfolgt am einfachsten in der
+Playback-Ansicht der Cueliste:
+
+1.  Drücken Sie <Keys.HardKey>Open/View</Keys.HardKey>
+2.  Drücken Sie die blaue **Select-Taste** der Cueliste.
+3.  Im Display erscheinen die Schritte der Cueliste. Klicken Sie auf die
+    betreffende **Autoload**-Zelle (Spalte Autoload des betreffenden Cues).
+    *Am besten bringen Sie dazu das Fenster in die Vollbild-Ansicht. Ist
+    die Spalte Autoload gar nicht sichtbar, klicken Sie links auf <Keys.SoftKey>Show
+    All</Keys.SoftKey>*.<br/>
+    ![Cue List Window with Autoload playback](/docs/images/Cue-List-Window-with-Autoload-playback.png)
+4.  Drücken Sie die **Select-Taste** des Speicherplatzes, dessen Inhalt
+    mit dem Schritt geladen werden soll. Dabei erscheint die vergebene
+    Bezeichnung auf den Funktionstasten.
+5.  Sie können nun weitere 'Autoloads' definieren. Verlassen Sie den
+    Modus schließlich mit <Keys.HardKey>Exit</Keys.HardKey>.
+
+Der Inhalt des mittels 'Autoload'
+verknüpften Speicherplatzes wird beim Start des jeweiligen Schrittes
+geladen, und beim Start des nächsten Schritts wieder deaktiviert, es sei
+denn, auch der nächste Schritt enthält diesen 'Autoload'.
+
+Für jeden 'Autoload' lassen sich verschiedene Optionen vergeben; rufen
+Sie diese durch die entsprechende Schaltfläche auf (dort wird jeweils
+der verknüpfte Speicherplatz angezeigt).
+
+Für einfache Cues ist die einzige Option A <Keys.SoftKey>Remove this Autoload</Keys.SoftKey>
+(diesen Autoload löschen).
+
+Für Chaser und Cuelisten lässt sich mit **Option B** wählen, ob die
+jeweilige Sequenz *am Beginn* oder *bei einem bestimmten Schritt* gestartet
+werden soll, oder ob für die gewählte Folge *Go* betätigt werden soll.
+
+Klickt man in die Spalte 'Autoload Times' des betreffenden Cues, so kann
+man für Fade-In, Fade-Out und Delay des Autoloads getrennte Zeiten
+vergeben. Normalerweise werden die Zeiten verwendet, die in der Cueliste
+für diesen Cue vergeben wurden. Alternativ kann man mit <Keys.SoftKey>Use Individual
+Target Times</Keys.SoftKey> die Zeiten des externen Cues/Chasers/Cueliste verwenden, 
+oder man vergibt direkt spezielle Zeiten.
+
+## Abrufen einer Tastenfolge (Makro) aus einer Cueliste
+
+Es lassen sich Cues in Cuelisten programmieren, die eine vorgegebene
+Tastenfolge ausführen. Damit lassen sich spezielle Aktionen ausführen,
+sobald ein Cue gestartet wird. So lassen sich z.B. mit dem ersten Cue
+alle Geräte zünden.
+
+1.  Drücken Sie <Keys.SoftKey>Open/View</Keys.SoftKey>, gefolgt von 
+	der **Select**-Taste der Cueliste, um diese im Playback View zu öffnen.
+2.  Im Übersichtsfenster der Cueliste (Playback View) wählen Sie den
+    Schritt, dem ein Makro hinzugefügt werden soll.
+3.  Scrollen Sie nach rechts bis zur Spalte **Macros** und klicken Sie auf die 
+	Macro-Zelle des betreffenden Cues.
+4.  Drücken Sie die Tasten/Schaltflächen der Makros, die mit diesem Schritt ausgeführt 
+    werden sollen. Oder drücken Sie <Keys.SoftKey>Add</Keys.SoftKey> und wählen
+    ein Macro aus der Liste aus.
+5.  Die Spalte **Macros** zeigt die hinzugefügten Makros.  
+
+> Zum Entfernen der Makros aus dem Schritt wählen Sie den Schritt aus, wählen dann das 
+zugefügte Makro, und betätigen die Kontext-Taste <Keys.SoftKey>Remove Link</Keys.SoftKey>.
+
+## Tastatursyntax für Cuelisten
+
+Zum schnellen Speichern und Editieren von Cuelisten stehen
+folgende Tastenkombinationen zur Verfügung; diese wirken auf die
+aktuell mit der Steuerung verbundene (connected) Cueliste; **n**
+bezeichnet die Cue-Nummer. Siehe auch [Tipps für Theater-Programmierer](../cue-lists/theatre-programming.md) 
+und die [Titan Befehlsreferenz](../titan-reference.md).
+
+Tasten                                    | Funktion
+----------------------------------------- | ------------------------------------------
+<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Connect / Cue</Keys.HardKey> **n** <Keys.HardKey>Enter</Keys.HardKey>    | Cue **n** speichern
+<Keys.HardKey>Copy</Keys.HardKey> <Keys.HardKey>Connect / Cue</Keys.HardKey> **n**                | Cue **n** kopieren
+<Keys.HardKey>Delete</Keys.HardKey> <Keys.HardKey>Connect / Cue</Keys.HardKey> **n**              | Cue **n** löschen
+<Keys.HardKey>Include</Keys.HardKey> <Keys.HardKey>Connect / Cue</Keys.HardKey> **n**             | Cue **n** includen (in den Speicher laden)
+<Keys.HardKey>Connect / Cue</Keys.HardKey> **n** <Keys.HardKey>Go</Keys.HardKey>                  | Go Cue **n**

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/cue-list-options.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/cue-list-options.md
@@ -1,0 +1,119 @@
+---
+id: cue-list-options
+title: Cuelisten-Optionen
+sidebar_label: Cuelisten-Optionen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+ 
+Über das Menü [Options](../cues/playback-options.md) sind weitere Optionen 
+verfügbar. Drücken Sie dafür die Taste <Keys.HardKey>Options</Keys.HardKey> 
+oder im Hauptmenü die Menütaste <Keys.SoftKey>Options</Keys.SoftKey>, und 
+wählen Sie die gewünschte Cueliste (**blaue Taste**).
+
+Oder drücken Sie <Keys.HardKey>Open/View</Keys.HardKey>, dann die 
+entsprechende **Select-Taste**, und klicken links in der Playback-Ansicht 
+auf <Keys.SoftKey>Options</Keys.SoftKey>.
+
+## Tab "Handle"
+
+Alle Optionen dieser Rubrik funktionieren genauso wie im Kapitel [Playback Options](../cues/playback-options.md#playback-options----tab-handle) beschrieben.
+
+## Tab "Playback"
+
+Blind, Cross Fade HTP, Priority, Run On Startup funktionieren genauso wie im 
+Kapitel für Cues beschrieben (siehe [Options](../cues/playback-options.md)).
+
+### Cue Links Disabled:
+Damit lassen sich sämtliche Cues so einstellen,
+dass sie nur per Go-Taste starten (und nicht automatisch folgen).
+
+### Loop Action
+Damit wird bestimmt, ob die Cueliste nach dem Durchlaufen wiederholt werden soll.
+
+Einstellung | Beschreibung
+--- | ---
+Stop on final cue | Die Cueliste wird nur einmal durchlaufen und stoppt beim letzten Schritt.
+**Loop** | Die Cueliste wird nach Erreichen des letzten Cues wieder von Cue 1 wiederholt, *wobei auch Move in Dark entsprechend ermittelt wird*.
+
+### Move In Dark
+Einstellung für die gesamte Cueliste: Vorladen von
+LTP-Werten, solange Geräte nicht benutzt werden (keinen Output
+erzeugen), siehe [Move In Dark (MID)](cue-list-playback.md#move-in-dark-mid---funktionen).
+
+Einstellung | Beschreibung
+--- | ---
+**Off** | Schaltet MID für die gesamte Cueliste ab; MID kann aber für einzelne Cues aktiviert werden *(Vorgabewert)*.
+Disabled | Deaktiviert MID für die gesamte Cueliste, auch wenn es ggf. für einzelne Cues aktiviert ist.
+Early | Startet die Bewegung zum frühestmöglichen Zeitpunkt, sofern nicht pro Cue anders vorgegeben.
+Late | Beginnt die Bewegung zum spätestmöglichen Zeitpunkt, sofern nicht pro Cue anders vorgegeben.
+
+### Shape Tracking
+Bestimmt, wie Shapes getrackt werden.
+
+Einstellung | Beschreibung
+--- | ---
+Off | Kein Tracking von Shapes - Shapes stoppen, wenn der Cue beendet wird.
+On  | Shapes tracken, bis sie geblockt werden.
+Local | Die allgemeine Tracking-Einstellung gilt. *(Vorgabewert)*
+
+### Timecode Source 
+Bestimmt, welcher Timecode diese Cueliste steuert.
+
+### Tracking
+Aktivieren/Deaktivieren von Tracking (also der
+Nachverfolgung unveränderter Werte)  *Vorgabewert: aktiviert*.
+
+## Tab "Times"
+
+Die Times-Optionen sind die gleichen wie für [einzelne Cues](../cues/playback-options.md#playback-options----tab-times).
+
+## Tab "Fader"
+
+### Fader Mode
+Bestimmt das Verhalten des Faders.
+
+Einstellung | Beschreibung
+--- | ---
+Fader Mode Intensity Kill With Off | Der Fader bestimmt die Werte der HTP-Kanäle, und die Cueliste bleibt aktiv, auch wenn der Regler auf '0' gestellt wird. 
+Fader Mode Intensity Kill At 0 | Der Fader ist ebenfalls für die HTP-Werte zuständig, jedoch wird die Cueliste deaktiviert, sobald der Regler auf ‚0' gestellt wird.
+Manual Crossfader | Sorgt dafür, dass der Fader als manueller Überblendregler fungiert, d.h. beim Verlassen der Reglerstellung ‚100%' oder ‚0%' wird jeweils einen Schritt weitergeschaltet. 
+
+Bei **Manual Crossfade** gilt außerdem folgendes:
+
+-   Eine gerade laufende Überblendung kann mit dem Fader ‚übernommen'
+    werden.
+-   Wird eine Cueliste mit ‚Manual Crossfader' gestartet, so springt der
+    Pegel sofort auf 100%, sobald der Fader über 0 bewegt wird.
+-   Shapes und Pixelmapper-Effekte werden ebenfalls mit dem Fader
+    übergeblendet. Wird der Fader auf 0 gezogen, so bleiben sie aber
+    aktiv.
+-   Autoloads folgen ihrer jeweiligen Fadezeit unabhängig vom Crossfade.
+-   Angehaltene Fades können mit <Keys.HardKey>Go</Keys.HardKey> fortgesetzt werden.
+
+### Fire First Cue
+Ist diese Option aktiviert, so wird mit Bedienen des
+Faders direkt Cue 1 der Cueliste gestartet. Als Vorgabewert ist diese
+Option deaktiviert. Ansonsten muss immer erst <Keys.HardKey>Go</Keys.HardKey> gedrückt werden.
+
+Wurde mit Next Cue/Prev. Cue oder per Tastatur ein bestimmter Cue angewählt, dann wird beim Aktivieren der Cueliste dieser - und nicht der erste Cue - aufgerufen, sobald der Fader bedient wird, wenn 'Fire First Cue' aktiv ist.
+
+## Tab "Effects"
+
+Alle Optionen dieser Rubrik funktionieren genauso wie im Kapitel [Effekte](../cues/playback-options.md#playback-options----tab-effects) beschrieben.
+
+## Tab "Release"
+
+Release Mask und Release Time funktionieren genauso wie im Kapitel [Release](../cues/playback-options.md#playback-options----tab-release) beschrieben.
+
+### Cue Release
+
+Damit werden einzelne Werte released, wenn nicht im
+nächsten Cue Werte dafür hinterlegt sind. Damit lassen sich manche
+Effekte erstellen.
+
+> Die früher hier zu findenden **Cue Options** sind nun in der Playback-Ansicht
+  zu finden und zu editieren. Um diese zu öffnen, drücken Sie <Keys.HardKey>Open/
+  View</Keys.HardKey>  und die **Select-Taste** der Cueliste.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/cue-list-playback.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/cue-list-playback.md
@@ -1,0 +1,192 @@
+---
+id: cue-list-playback
+title: Abrufen
+sidebar_label: Abrufen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Abrufen einer Cueliste
+
+Stellen Sie den Regler der Cueliste auf den gewünschten Wert und drücken
+die <Keys.HardKey>Go</Keys.HardKey>-Taste, um den ersten Schritt zu starten. Unten im Display
+erscheint die Cueliste, der aktuelle Schritt ist dabei grau
+hervorgehoben, der nächste Schritt ist durch eine Umrandung
+gekennzeichnet (auf dem Diamond 9 wird der Status der Cueliste unten im Editor-Display 
+angezeigt).
+
+![Connected Cue List view](/docs/images/Connected-Cue-List-view.png)
+
+Das Display direkt oberhalb des jeweiligen Reglers zeigt Informationen
+zur aktuellen Cueliste: der aktuellen Cue wird oben hellblau
+dargestellt, darunter der nächste dunkelblau.
+
+Die Überblendung wird durch einen Fortschrittsbalken angezeigt. Zeiten
+werden durch Pfeile nach oben (Fade-In) bzw. unten (Fade-Out), mit
+Buchstaben (d = Delay, f = Fade) sowie mit einem M (bei manuellem
+Crossfade) dargestellt.
+
+![Playback handle of running cue list](/docs/images/Playback-handle-of-running-cue-list.png)
+
+Für eine bessere Übersicht können Sie auch die Playback-Ansicht der
+Cueliste öffnen (einfach im Display auf die Cueliste klicken, oder <Keys.HardKey>Open/View</Keys.HardKey> 
+und die **Select-Taste** der Cueliste drücken). Hier hat man
+sämtliche Cues, Zeiten und Optionen (z.B. Autoload, Macros, MID etc.) im
+Überblick, was vor allem im [Theater](theatre-programming.md) sehr hilfreich ist.
+
+Mit der Benutzereinstellung **'Auto View On Connect'** auf dem Tab [Wheels](../system-settings/user-settings.md#wheels) 
+lässt sich erreichen, dass beim Connecten einer Cueliste sofort deren Detail-Fenster aufgeht.
+
+![Playback View of Cue List with cue fade in progress](/docs/images/Playback-View-of-Cue-List-with-cue-fade-in-progress.png)
+
+Ist gerade eine zeitlich gesteuerte Aktion im Gange, dann wird dies
+durch grüne Fortschrittsbalken angezeigt - links für den gesamten Cue,
+in den einzelnen Spalten jeweils für die einzelnen Fade- und
+Delayzeiten.
+
+Die Playback-Ansicht scrollt normalerweise mit, so dass immer der
+aktuelle Cue dargestellt wird. Dies kann in den Optionen des Fensters
+genauer eingestellt und geändert werden (klicken Sie dazu auf das kleine
+<Keys.ContextKey>Zahnrad</Keys.ContextKey> in der Titelleiste des Fensters).
+
+-   Die HTP-Pegel der Schritte werden durch die Stellung des Reglers
+    bestimmt.
+
+-   Ein Überblendprozess lässt sich mit der <Keys.HardKey>Stop</Keys.HardKey>-Taste (oberhalb 
+    der <Keys.HardKey>Go</Keys.HardKey>-Taste) anhalten, und mit der <Keys.HardKey>Go</Keys.HardKey>-Taste fortsetzen.
+
+-   Um direkt einen bestimmten Schritt anzuspringen, wählen Sie diesen mit Rad A oder 
+    mit den links/rechts-Pfeilen aus. Drücken Sie nun <Keys.HardKey>Go</Keys.HardKey>, 
+	um den angewählten Schritt aufzurufen. Soll der Vorgang abgebrochen werden, so drücken 
+	Sie gleichzeitig <Keys.HardKey>Prev. Cue</Keys.HardKey> und <Keys.HardKey>Next 
+	Cue</Keys.HardKey>.
+
+-   Ist die Cueliste gerade pausiert, so kann man mit <Keys.HardKey>Stop</Keys.HardKey> zum
+    vorherigen Cue incl. Einfadezeiten springen.
+
+-   Auf den vorigen Schritt schalten Sie mit der Taste <Keys.HardKey>Snap back</Keys.HardKey>
+    (sofern vorhanden).
+
+-   Aktiviert man die <Keys.HardKey>Snap</Keys.HardKey>-Taste, so kann man mit den 
+    Tasten <Keys.HardKey>Prev Step</Keys.HardKey>/<Keys.HardKey>Next Step</Keys.HardKey> 
+    ohne Berücksichtigung der programmierten Zeiten direkt auf den nächsten/vorigen Cue springen. 
+    Für Pulte, die diese Taste nicht haben, gibt es die [Benutzereinstellungen](../system-settings/user-settings.md#general-allgemein) **Chase Snap** bzw. **Cue List Snap**.
+
+-   Zur Direktanwahl eines Schritts drücken Sie die Taste <Keys.HardKey>Connect / Cue</Keys.HardKey>,
+    gefolgt von der Schrittnummer und <Keys.HardKey>Enter</Keys.HardKey> oder Funktionstaste 
+	A.<br/>Alternativ tippen Sie im Hauptmenü einfach die Schrittnummer ein und
+    drücken <Keys.HardKey>Connect / Cue</Keys.HardKey>. (Diese Taste heißt je nach Pult <Keys.HardKey>Connect</Keys.HardKey>
+	oder <Keys.HardKey>Cue</Keys.HardKey>).
+
+-   Mittels der [Tastenbelegungen ('Key Profiles')](../system-settings/key-profiles.md) lässt sich die
+    Funktion der grauen und blauen Tasten an die Erfordernisse anpassen,
+    etwa **Go**, **Stop**, **Connect**, **Next
+    Cue** (nächster Schritt), **Prev Cue** (voriger Schritt), **Cut Next Cue To Live** (nächsten Schritt
+    ohne Überblend-/Verzögerungszeiten aktivieren), und **Snap Back**, siehe [Key Profiles](../system-settings/key-profiles.md#cue-lists).
+
+-   Beim Ausblenden des Reglers einer Cueliste werden die enthaltenen
+    HTP-Kanäle ausgeblendet, die Cueliste an sich bleibt jedoch aktiv.
+    [Im nächsten Abschnitt](#eine-cueliste-deaktivieren) wird erläutert, 
+	wie die Cueliste deaktiviert werden kann.
+
+-   Mittels **Timecode** kann eine Cueliste [automatisch gesteuert werden](cue-list-timing.md#steuern-einer-cueliste-per-timecode).
+
+-   Die Zeit für den nächsten Schritt lässt sich einfach ändern, indem
+    man mit den Zifferntasten die neue Zeit eingibt und <Keys.HardKey>Go</Keys.HardKey> drückt.
+    Wollen Sie in einer neuen Zeit auf einen anderen Cue springen, so
+    geben Sie die Nummer des neuen Cues ein, drücken <Keys.HardKey>Connect / Cue</Keys.HardKey>, geben
+    die gewünschte Zeit ein und drücken <Keys.HardKey>Go</Keys.HardKey>
+
+## Eine Cueliste deaktivieren
+
+Sobald eine Cueliste gestartet wurde, bleibt sie aktiv, bis sie explizit
+deaktiviert wird. Dazu halten Sie die <Keys.HardKey>AVO</Keys.HardKey>-Taste gedrückt und
+betätigen die blaue **Select-Taste** der Cueliste.
+
+Das Verhalten lässt sich im Menü [Options](../cues/playback-options.md) ändern, so dass die
+Cueliste automatisch entladen wird, wenn man den Regler auf '0' bringt:
+drücken Sie dazu <Keys.SoftKey>Options</Keys.SoftKey> im Programmier-Menü, dann die
+&nbsp;**Select-Taste** der Cueliste, und wählen die Option <Keys.SoftKey>Fader</Keys.SoftKey>, <Keys.SoftKey>Fader Mode Intensity Kill At 0</Keys.SoftKey>.
+
+Per [Tastenprofil (Key Profiles)](../system-settings/key-profiles.md#cue-lists) lässt sich auch eine der Tasten mit der
+Release-Funktion belegen.
+
+> Solange eine Cueliste aktiv ist, laufen darin programmierte Shapes und Effekte weiter - auch, wenn der Fader auf 0 steht. Stellen Sie also unerfindliche Bewegungen/Effekte fest, so überprüfen Sie, ob alle Cuelisten auch wieder deaktiviert wurden.
+
+## Tracking
+
+<Video videoId="B2fTri0G2-A" title="Tracking in Cuelists" />
+
+Normalerweise laufen Cuelisten im Tracking-Betrieb. Dabei werden nur
+Änderungen einzelner Werte aufgezeichnet und wiedergegeben. Alles andere
+wird als unverändert angenommen und bleibt erhalten. Tracking ist
+insbesondere für [Theater](theatre-programming.md) die bevorzugte Arbeitsweise, da man z.B. einen
+Dimmer nur am Beginn einer Szene aktivieren und nicht in jeden einzelnen
+Cue der ganzen Szene hineinprogrammieren muss. Entsprechend schnell
+lassen sich erforderlichenfalls auch Änderungen realisieren.
+
+Tracking lässt sich sowohl für die komplette Cueliste aktivieren/
+deaktivieren, als auch für die einzelnen Cues der Cueliste genau
+einstellen (entweder in der Playback-Ansicht oder unter <Keys.SoftKey>Options</Keys.SoftKey><Keys.SoftKey>Cue Options</Keys.SoftKey>).
+
+Mögliche Einstellungen:
+
+Einstellung | Wirkung
+--- | ---
+<Keys.SoftKey>Global</Keys.SoftKey> *(Vorgabe)* | es gelten die Einstellungen der gesamten Cueliste.
+<Keys.SoftKey>Track</Keys.SoftKey> | der Cue wird getrackt.
+<Keys.SoftKey>Block</Keys.SoftKey> | dieser Cue übernimmt keinerlei Tracking-Informationen; im weiteren Verlauf wird das Tracking ab diesem Cue ermittelt.
+<Keys.SoftKey>Solo Excluding Shapes</Keys.SoftKey> | Der Cue wird als Solo-Cue, also ohne jegliches Tracking, behandelt, allerdings werden Shapes, die keine Dimmershapes sind, getrackt. Damit kann z.B. eine Bewegung auch in einem Solo-Cue fortgesetzt werden.
+<Keys.SoftKey>Cue Only</Keys.SoftKey> | Änderungen in diesem Cue werden nicht auf die nachfolgenden Cues weitergegeben; getrackte Werte von vorherigen Cues tracken aber in die folgenden Cues weiter.
+<Keys.SoftKey>Solo</Keys.SoftKey> | Dieser Cue unterliegt überhaupt nicht dem Tracking und verändert auch nicht nachfolgende Cues; Informationen aus vorherigen Cues werden unverändert an nachfolgende weitergegeben.
+<Keys.SoftKey>Block Shapes</Keys.SoftKey> | Sämtliche Shapes von vorherigen Cues werden geblockt, alle anderen Attribute werden normal getrackt. Damit wird sichergestellt, dass alle Shapes stoppen.
+
+Das Tracking von Werten von einem Cue zum anderen lässt sich im [Tracking View](../cue-lists/editing-cue-lists.md#editieren-getrackter-cues-mit-dem-tracking-view) genauer anzeigen und editieren.
+
+## Move In Dark (MID) - Funktionen
+
+Insbesondere bei der Verwendung von Movinglights im Theater
+möchte man diese meist 'im Off' vorbereiten, also positionieren,
+solange sie nicht aktiv verwendet werden, damit die Bewegung
+nicht wahrgenommen wird. Dies lässt sich mit Move-In-Dark
+schnell und einfach automatisch erreichen.
+
+Die Move-In-Dark-Einstellungen lassen sich wahlweise für
+einzelne Cues oder für die gesamte Cueliste vornehmen.
+
+Zum Festlegen der Optionen für die gesamte Cueliste drücken Sie
+<Keys.SoftKey>Options</Keys.SoftKey>, gefolgt von der Auswahltaste der Cueliste,
+und klicken dann <Keys.SoftKey>Playback</Keys.SoftKey> gefolgt von <Keys.SoftKey>Move In Dark</Keys.SoftKey>.
+
+Einstellung | Wirkung
+---|---
+<Keys.SoftKey>Disabled</Keys.SoftKey> | deaktiviert MID für die gesamte Cueliste, auch wenn es ggf. für einzelne Cues aktiviert ist
+<Keys.SoftKey>Early</Keys.SoftKey> | startet die Bewegung zum frühestmöglichen Zeitpunkt, sofern nicht pro Cue anders vorgegeben
+<Keys.SoftKey>Late</Keys.SoftKey> | beginnt die Bewegung zum spätestmöglichen Zeitpunkt, sofern nicht pro Cue anders vorgegeben
+<Keys.SoftKey>Off</Keys.SoftKey> *(Vorgabe)* | schaltet MID für die gesamte Cueliste ab; MID kann aber für   einzelne Cues aktiviert werden
+
+Zum Einstellen der Optionen für einzelne Cues nutzen Sie hingegen das Fenster ‚Playback View' der Cueliste. Es gibt folgende Optionen:
+
+Einstellung | Wirkung
+---|---
+<Keys.SoftKey>Global</Keys.SoftKey> *(Vorgabe)* | Es werden die Einstellungen der gesamten Cueliste angewendet
+<Keys.SoftKey>Cue Number</Keys.SoftKey> | zur Angabe eines bestimmten Cues, zu dem MID stattfinden soll
+<Keys.SoftKey>Cue Offset</Keys.SoftKey> | gibt eine bestimmte Anzahl von Cues vor dem aktuellen an, wann MID beginnen soll
+<Keys.SoftKey>Disabled</Keys.SoftKey> | deaktiviert MID für den aktuellen Cue
+<Keys.SoftKey>Early</Keys.SoftKey> | MID so zeitig wie möglich
+<Keys.SoftKey>Late</Keys.SoftKey> | MID so spät wie möglich
+
+Für jeden einzelnen Cue wie auch für die gesamte Liste lassen sich für
+MID getrennt Fade- und Delayzeit einstellen. Ebenso gibt es für jeden
+Cue eine 'MID unterdrücken'-Funktion (Inhibit), um während dieses Cues
+jede andere Bewegung zu verhindern; in diesem Falle - oder falls
+anderweitig die Intensität nicht auf 0 ist - wird MID zum
+nächstmöglichen Zeitpunkt nach diesem Cue ausgeführt.
+
+
+## Tastenprofile für Cuelisten
+
+Mit [Tastenprofilen/Key Profiles](../system-settings/key-profiles.md), lassen sich den einzelnen Tasten *(das Sapphire Touch verfügt auch über eine schwarze 
+Taste)* sowie der Schaltfläche einer Cueliste (wenn sie im Fenster 'Playbacks' 
+gespeichert ist) verschiedene Funktionen zuweisen. Im Abschnitt [Key Profiles](../system-settings/key-profiles.md#cue-lists) sind alle verfügbaren Funktionen aufgelistet.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/cue-list-timing.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/cue-list-timing.md
@@ -1,0 +1,162 @@
+---
+id: cue-list-timing
+title: Zeiten für Cuelisten
+sidebar_label: Zeiten für Cuelisten
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Zeit- und Überblendoptionen für Cuelisten
+
+Zeiten für Cuelisten lassen sich am einfachsten im Playback View (tabellarische Anzeige der Cues einer Cueliste) einstellen. Drücken Sie <Keys.HardKey>Open/View</Keys.HardKey> gefolgt von der **Select**-Taste der Cueliste. Klicken Sie nun auf den Wert, den Sie ändern möchten, oder markieren Sie mehrere Werte auf einmal. Ebenso lässt sich der zu bearbeitende *aktive* Cue mit **Encoder A** wählen, oder Sie drücken <Keys.SoftKey>Select Cue Number</Keys.SoftKey> im Menü **Edit Times** der Cueliste. Mehrere Cues gleichzeitig kann man auch mit **Encoder B** auswählen.
+
+Ist der zu ändernde Wert ausgewählt, dann werden verschiedene Optionen mit den Menütasten angeboten.
+
+![Cue List Timings](/docs/images/Cue-View-Timings.png)
+
+Für jeden Cue kann man einzeln die Einfadezeit (für Geräte, die einfaden, also heller werden) und die Ausfadezeit (für Geräte, die ausfaden/dunkler werden) einstellen. Die Ausfadezeit steht per Default auf 'As In', so dass Aus- und Einfadezeit gleich sind.
+
+LTP-Kanäle (alle Attribute außer Dimmern) folgen der 'Fade In'-Zeit.
+
+-   <Keys.SoftKey>Fade In</Keys.SoftKey> bestimmt die Fadezeit für Geräte, die heller werden, also auf einen höheren Dimmerpegel als vorher wechseln. Außerdem ist das auch die Fadezeit für LTP-Attribute. Steht Fade out auf "As In", so ist dies auch die Fadezeit für ausfadende (dunkler werdende) Geräte. Geben Sie die Zeit in Sekunden ein und drücken Sie <Keys.HardKey>Enter</Keys.HardKey>.
+-   <Keys.SoftKey>Delay In</Keys.SoftKey> bestimmt das Delay (Verzögerung) zwischen dem Drücken der <Keys.HardKey>Go</Keys.HardKey>-Taste (oder anderem Starten des Cues) und dem Beginn des Einfadens. 
+-   <Keys.SoftKey>Fade Out</Keys.SoftKey> bestimmt die Fadezeit für Geräte, die dunkler werden, also auf einen niedrigeren Dimmerpegel als vorher wechseln. Per Default ist das "As In", übernimmt also die Einfadezeit. War eine Zeit eingegeben und will man auf "As In" zurück, so muss die Zeit gelöscht werden. 
+-   <Keys.SoftKey>Delay Out</Keys.SoftKey> bestimmt das Delay (Verzögerung) zwischen dem Drücken der <Keys.HardKey>Go</Keys.HardKey>-Taste (oder anderem Starten des Cues) und dem Beginn des Ausfadens. Per Default ist das "As In", übernimmt also die Delay-In-Zeit. War eine Zeit eingegeben und will man auf "As In" zurück, so muss die Zeit gelöscht werden. 
+
+## Schrittfolge und Versatz
+
+Schritte in Cuelisten können miteinander verbunden werden, womit
+sich komplexe automatische Sequenzen realisieren lassen. Die
+Optionen werden mit den Funktionstasten eingestellt und
+umfassen:
+
+Link Option | Action
+---|---
+&nbsp;**<Keys.SoftKey>Link Wait For Go</Keys.SoftKey>** | 'Warten auf Go': der Schritt wartet auf das Betätigen der <Keys.HardKey>Go</Keys.HardKey>-Taste und startet dann sofort; *ein Versatz zwischen Schritten ist nicht möglich.*
+&nbsp;**<Keys.SoftKey>Link After Previous Cue</Keys.SoftKey>** | 'Start nach vorigem Schritt': der Schritt startet, wenn der vorige seine Warte- und Überblendzeiten durchlaufen hat. Zusätzlich lässt sich ein Versatz (Offset) eingeben, als Verzögerung zwischen dem Ende des vorigen und dem Start des neuen Schritts. Der Versatz kann entweder in Sekunden, oder als Prozentsatz der Überblendzeit des vorigen Schrittes, eingegeben werden.
+&nbsp;**<Keys.SoftKey>Link With Previous Cue</Keys.SoftKey>** | 'Start mit dem vorigen Schritt': der Schritt startet gleichzeitig mit dem vorigen. Ein Versatz (Offset), anzugeben in Sekunden oder in Prozent der Überblendzeiten des vorigen Schrittes, bestimmt die Verzögerung zwischen den Schritten.
+
+![Cue List Linking Diagram](/docs/images/Cue-List-Linking-Diagram.png)
+
+Mit diesen Optionen lassen sich komplexe automatische Abläufe von einzelnen 
+Schritten realisieren. Ist etwa folgender Effekt gewünscht:
+
+-   Nach Druck auf <Keys.HardKey>Go</Keys.HardKey> blendet Gerät 1 über 20s ein
+-   Nach 10s blendet Gerät 2 über 15s ein
+-   Beide Geräte bleiben für 5s an
+-   Beide Geräte blenden über 3s aus
+
+so könnte man das wie folgt programmieren:
+
+-   **Cue 1**: Gerät 1 @ 100%, Fade In 20s, Link Wait For Go
+-   **Cue 2**: Gerät 2@ 100%, Fade In 15s, Link With Previous, Link Offset 10s
+-   **Cue 3**: Geräte 1 und 2 @ 0%, Fade Out 3s, Link After Previous, Link Offset 5s
+
+> Für einen Effekt, der als 'Cue Overlap' (Schritt-Überlappen) in früheren Versionen verfügbar war, verwenden Sie <Keys.SoftKey>Link With Previous Cue</Keys.SoftKey>, und geben den Versatz (Offset) in % an. Link Offset = 100% ergibt ein 'Overlap' von 0% und umgekehrt.
+
+## Individuelle Einblendzeiten für Attribute
+
+Für jede Attributgruppe **IPCGBES** lassen sich getrennte Einblendzeiten
+vergeben. Ebenso lässt sich bestimmen, für welches Gerät diese Zeit
+gilt. So lässt sich etwa bestimmen, dass die Position in 2s wechselt,
+der Farbwechsel aber 10s dauert.
+
+Zusätzlich lassen sich auch pro einzelnem Attribut unterschiedliche
+Zeiten vergeben, so dass etwa Pan (Schwenken) anders als Tilt (Neigen)
+überblendet.
+
+Zum Vorgeben von Zeiten für Attributgruppen öffnen Sie zunächst das 
+Menü <Keys.SoftKey>Edit Times</Keys.SoftKey>, gehen zu dem Schritt, den Sie bearbeiten 
+möchten [wie oben beschrieben](#zeit--und-überblendoptionen-für-cuelisten), und
+drücken <Keys.SoftKey>Next</Keys.SoftKey>, um auf die nächste Optionsseite umzuschalten. 
+
+1.  Drücken Sie <Keys.SoftKey>Attribute Group Times</Keys.SoftKey>.
+2.  Damit werden sämtliche Geräte in dem Schritt angewählt. *Wollen Sie
+	die Zeiten nicht für alle Geräte einstellen, so ändern Sie jetzt die
+	Selektion*. Dazu können Sie die Taste <Keys.HardKey>All</Keys.HardKey> 
+	(unterhalb von <Keys.HardKey>Next Time</Keys.HardKey>) benutzen, um alle Geräte 
+	anzuwählen, oder <Keys.HardKey>AVO</Keys.HardKey>+<Keys.HardKey>All</Keys.HardKey>, um
+	alle abzuwählen.
+3.  Drücken Sie die Auswahltaste der gewünschten Attributgruppe.
+4.  Drücken Sie <Keys.SoftKey>Delay</Keys.SoftKey> zum Einstellen 
+	der **Verzögerung**	oder <Keys.SoftKey>Fade</Keys.SoftKey> zum Einstellen 
+	der **Überblendzeit**. Mit <Keys.SoftKey>Use Global</Keys.SoftKey> oder der Taste 
+	<Keys.HardKey>Back</Keys.HardKey> entfernen Sie die individuellen Zeiten wieder und 
+	kehren zu den normalen/allgemeinen Zeiten für den Schritt zurück.
+
+>  Nutzen Sie <Keys.SoftKey>Individual Attributes</Keys.SoftKey> zur Vergabe von Zeiten für
+    einzelne Attribute aus einer Gruppe, etwa für ‚Pan' aus der Gruppe
+    ‚Positions'. Gleiches lässt sich mit dem Fenster [Cue View](editing-cue-lists.md#editieren-von-werten-im-fenster-cue-view)
+    realisieren. 
+
+## Fixture Overlap - Geräteversatz
+
+Mit Fixture Overlap - Geräte-Überlappung - werden Änderungen von einem 
+Cue zum nächsten auf die einzelnen Fixtures nacheinander statt gleichzeitig 
+angewendet. Genauer ist dies in [Einstellen von Überblendzeiten und Geräteversatz](../cues/cue-timing.md#einstellen-von-überblendzeiten-und-geräteversatz) erläutert.
+
+## Steuern einer Cueliste per Timecode
+
+<Video videoId="1abZT_ffIvs" title="Recording Timecode" />
+
+In den Titan-Pulten lässt sich auch Timecode zum Steuern einer Cueliste
+verwenden. Dies ist hilfreich etwa bei komplexen Shows, die stets
+absolut zeitgenau laufen müssen, oder bei unbeaufsichtigten Abläufen.
+Dabei wird jedem Schritt der Cueliste eine Startzeit zugeordnet, zu der
+er beginnen soll.
+
+> Siehe auch [Timelines](../timelines.md), eine andere Möglichkeit, um Timecode-gesteuerte
+  Shows zu realisieren.
+
+Es können vier getrennte Timecode-Quellen definiert werden. Für jede
+kann der Timecode selbst aus der Systemuhr stammen, intern generiert
+oder per MIDI, je nach Pult SMPTE oder Winamp (auf dem Pult oder dem Titan-Computer 
+installiert) eingespeist werden. Der interne Timecode ist besonders hilfreich beim 
+Programmieren einer Show, die später von einem externen Timecode gesteuert werden soll.
+
+> Bei der Verwendung von Winamp empfiehlt sich der Einsatz von WAV-Dateien und nicht von MP3,
+da ansonsten mitunter der generierte Timecode falsch ist. Wenn man dann auf Winamp programmiert 
+und die Show später von einer anderen Timecode-Quelle steuert, dann ist das sonst nicht mehr synchron.
+
+1. **Connecten** Sie die Cueliste, für die Sie den Timecode aktivieren möchten.
+2. Wählen Sie <Keys.SoftKey>Timecode</Keys.SoftKey> aus dem Hauptmenü.
+3. Wählen Sie mit **Menütaste A** Timecode 1, 2, 3 oder 4, und mit
+&nbsp;**Taste B** die Timecode-Quelle.
+4. Drücken Sie <Keys.SoftKey>Record</Keys.SoftKey>.
+5. Starten Sie die Timecode-Quelle. *Nutzen Sie den internen Timecode,
+so drücken Sie jetzt <Keys.SoftKey>Play</Keys.SoftKey>, um ihn zu starten*.
+6. Betätigen Sie die rote <Keys.HardKey>Go</Keys.HardKey>-Taste, um jeden Schritt zum
+gewünschten Zeitpunkt zu starten.
+7. Drücken Sie <Keys.SoftKey>Record</Keys.SoftKey>, um den Vorgang abzuschließen.
+
+Zur Wiedergabe einer Timecode-gesteuerten Cueliste drücken Sie im
+Timecode-Menü <Keys.SoftKey>Connected Cue Lists</Keys.SoftKey> und wählen die gewünschte Cueliste
+aus. Dann drücken Sie <Keys.SoftKey>Timer Disabled/Enabled</Keys.SoftKey>, um den jeweiligen
+Timecode-Eingang zu aktivieren. **Timer Disabled/Enabled** ist ein globaler Schalter und 
+aktiviert/deaktiviert alle Timecode-Quellen. Soll nur ein bestimmter Timecode 
+deaktiviert werden, so wählen Sie dagegen für diesen in Schritt 3 (s.o.) als Quelle **No Timecode**.
+
+Sobald nun der Timecode läuft (bei internem Timecode drücken Sie dazu
+auf <Keys.SoftKey>Play</Keys.SoftKey>), wird jeder Schritt der Cueliste zur programmierten
+Zeitmarke gestartet.
+
+Zum Ändern einzelner Timecode-Zeiten klicken Sie entweder in der 
+Playback-Ansicht in die entsprechende Zelle und geben die korrekte Zeit 
+mit den Zifferntasten ein, oder Sie drücken <Keys.SoftKey>Edit Times</Keys.SoftKey>, wählen den 
+zu ändernden Cue aus, wechseln mit <Keys.SoftKey>Next</Keys.SoftKey> auf die dritte Menüseite und 
+ändern dort den Wert bei <Keys.SoftKey>Timecode = </Keys.SoftKey>. 
+
+![Playback View Window showing timecoded cues](/docs/images/Playback-View-Window-showing-timecoded-cues.png)
+
+Beim Ändern einer Zeit lassen sich mit Encoder B mehrere Schritte
+auswählen. Mit den Menütasten lassen sich weitere Zeitänderungen
+vornehmen: gibt man bei <Keys.SoftKey>Offset =</Keys.SoftKey> einen Wert ein, so kann man 
+mit <Keys.SoftKey>Add + </Keys.SoftKey> bzw. <Keys.SoftKey>Subtract - </Keys.SoftKey> 
+alle gewählten Zeitmarken um diesen Wert nach vorn oder hinten verschieben.
+
+Zur Kontrolle des anliegenden Timecodes lässt sich jeweils für Timecode
+1 bis 4 ein extra Fenster öffnen: drücken Sie zweimal auf <Keys.HardKey>Open/View</Keys.HardKey>
+und dann auf <Keys.SoftKey>Timecode x</Keys.SoftKey> (wobei das x für eine Zahl 1 bis 4 steht).
+
+![Timecode 1 Workspace Window](/docs/images/Timecode-1-Workspace-Window.png)

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/editing-cue-lists.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/editing-cue-lists.md
@@ -1,0 +1,399 @@
+---
+id: editing-cue-lists
+title: Editieren
+sidebar_label: Editieren
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Dieses Kapitel beschreibt, wie Cues in Cuelisten editiert werden. 
+Geht es hingegen darum, die ganze Cueliste zu verschieben, zu kopieren oder 
+zu löschen, sei auf das Kapitel [Kopieren, verschieben, verlinken, löschen](../cue-lists/copying-moving-linking-and-deleting.md) verwiesen.
+
+- Zum Editieren von Cues per Tastatursyntax siehe [Tipps für Theater-Programmierer](./theatre-programming.md).
+
+## Das Fenster Playback View
+
+Am einfachsten lässt sich eine Cueliste in der Playback-Ansicht
+(Playback View) editieren, dazu drücken Sie <Keys.HardKey>Open/View</Keys.HardKey>,
+gefolgt von der **Auswahltaste** der gewünschten Cueliste. Diese Ansicht
+besteht aus einer Tabelle, wobei jeder Cue mit seinen Details in einer
+Zeile aufgelistet ist. Durch Anklicken einzelner Zellen lassen sich die
+jeweiligen Werte verändern, und auf den Funktionstasten stehen
+verschiedene Optionen zur Auswahl.
+
+![Playback view](/docs/images/Cue-List-Window-with-Autoload-playback.png)
+
+Um mehrere Cues auf einmal zu editieren, ziehen Sie in der Ansicht eine
+Box um die zu ändernden Zellen.
+
+Ferner bietet die [Intensity-Ansicht](../controlling-fixtures/viewing-and-editing-fixture-values.md#das-fenster-intensity-view) eine gute Möglichkeit, alle
+aktiven Geräte und deren Werte zu überblicken. 
+
+## Editieren von Werten im Fenster Cue View
+
+Jeder einzelne Attributwert jedes Gerätes kann in der Cue-Ansicht (Cue
+View) angezeigt und verändert werden. Dazu klicken Sie in der
+[Playback-Ansicht](#das-fenster-playback-view) beim gewünschten Cue auf die 
+Schaltfläche **View** (Spalte *View Cue* weit rechts). 
+
+![Cue View Window](/docs/images/Cue-View-Window.png)
+
+Nun können Sie wiederum einzelne oder mehrere Zellen anklicken, um die
+Werte direkt zu ändern.
+
+-   Über das Kontextmenü kann man die Anzeige von Pegeln, Shapes,
+    Effekten und Zeiten aktivieren.
+
+-   Einzelne Werte können deaktiviert werden, indem man sie anklickt und aus dem Menü die Funktion <Keys.SoftKey>Off</Keys.SoftKey> wählt. Auf **Off** gesetzte Werte können später mit <Keys.SoftKey>On</Keys.SoftKey> wieder aktiviert werden.
+
+-   Um ganze Fixtures aus einem Cue zu entfernen, wählt man die Geräte in der linken Spalte aus und drückt im Menü auf  <Keys.SoftKey>Remove Fixtures</Keys.SoftKey>.
+
+-   Wenn Werte von einer Palette stammen, so schaltet die Kontext-Option <Keys.ContextKey>View Palettes</Keys.ContextKey> zwischen der Anzeige der Werte und der Anzeige der Palette um.
+
+-   Je nach Tracking-Verhalten werden die Werte in verschiedenen Farben angezeigt. Im Fenster [Tracking View](./editing-cue-lists.md#editieren-getrackter-cues-mit-dem-tracking-view) lässt sich das Tracking genauer einstellen.
+    -  **Weiß** sind unveränderte harte (fest programmierte) ungetrackte Werte.
+    -  **Grün** sind fest programmierte Werte, die gegenüber dem vorigen Cue kleiner sind.
+    -  **Cyan** sind fest programmierte Werte, die gegenüber dem vorigen Cue größer sind, oder die erstmalig gesetzt werden.
+    -  **Magenta** sind getrackte Werte (In der Spalte *Tracking* steht dazu *Tracked*).
+    -  **Rot** sind geblockte Werte.
+
+-   Die Anzeige getrackter Werte lässt sich im Kontextmenü mit <Keys.ContextKey>Show/Hide Tracked Values</Keys.ContextKey> aktivieren/deaktivieren.
+
+## Kopieren, Verschieben und Löschen einzelner Cues
+
+Es lassen sich auf verschiedene Weise einzelne oder mehrere Cues innerhalb 
+einer oder zwischen mehreren Cuelisten kopieren oder verschieben:
+
+Man kann die **Unfold-Funktion** ([siehe nächster Abschnitt](#editieren-einer-cueliste-mit-unfold)) nutzen.
+
+Um einen Cue zu verschieben, kann man diesen im Fenster [Playback View](#das-fenster-playback-view) anklicken und verschieben, oder man klickt 
+auf die Nummer des Cues und ändert diese mit der Menütaste <Keys.SoftKey>Change To</Keys.SoftKey>
+(sobald die Nummer geändert wurde, ändert sich auch die Reihenfolge der Cues).
+
+Um einen Cue zu löschen, drücken Sie die <Keys.HardKey>Delete</Keys.HardKey>-Taste, wählen 
+den Cue im Playback-View aus, und klicken zur Bestätigung den Cue nochmals 
+an oder drücken <Keys.HardKey>Enter</Keys.HardKey> oder <Keys.SoftKey>Confirm</Keys.SoftKey>.
+
+Ebenso lässt sich eine Tastensyntax verwenden: 
+
+- Dabei ist **<Keys.ContextKey>fader select</Keys.ContextKey>** die Auswahltaste des aktuellen
+  Speicherplatzes und **n** die Nummer des jeweiligen Cues; Abschnitte
+  in **[eckigen Klammern]** sind optional. Die <Keys.HardKey>@</Keys.HardKey>-Taste ist die bei 
+  den Zifferntasten.
+
+Tastenfolge                                                  | Ergebnis
+------------                                                 |---------
+<Keys.HardKey>Copy</Keys.HardKey> <Keys.ContextKey>fader select</Keys.ContextKey> **n** <Keys.HardKey>@</Keys.HardKey> **m** <Keys.HardKey>Enter</Keys.HardKey>          | Kopieren von Cue **n** nach Cue **m** in der gleichen Cueliste
+<Keys.HardKey>Move</Keys.HardKey> <Keys.ContextKey>fader select</Keys.ContextKey> **n** <Keys.HardKey>@</Keys.HardKey> **m** <Keys.HardKey>Enter</Keys.HardKey>          | Verschieben von Cue **n** nach Cue **m** in der gleichen Cueliste
+<Keys.HardKey>Copy</Keys.HardKey> <Keys.ContextKey>fader select</Keys.ContextKey> **n** <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey>                    | Kopieren von Cue **n** als neuer Cue an das Ende der Cueliste
+<Keys.HardKey>Delete</Keys.HardKey> <Keys.ContextKey>fader select</Keys.ContextKey> **n** <Keys.HardKey>Enter</Keys.HardKey> <Keys.HardKey>Enter</Keys.HardKey>          | Löschen von Cue **n**
+<Keys.HardKey>Copy</Keys.HardKey> <Keys.ContextKey>fader select</Keys.ContextKey> **n** <Keys.ContextKey>fader select</Keys.ContextKey> **m** <Keys.HardKey>Enter</Keys.HardKey> | Kopieren von Cue **n** nach Cue **m** in einer anderen Cueliste
+<Keys.HardKey>Copy</Keys.HardKey> <Keys.ContextKey>fader select</Keys.ContextKey> **n** <Keys.ContextKey>fader select</Keys.ContextKey> <Keys.HardKey>Enter</Keys.HardKey>       | Kopieren von Cue **n** an das Ende einer anderen Cueliste
+
+- Anstelle von <Keys.HardKey>Copy</Keys.HardKey> lässt sich <Keys.HardKey>Move</Keys.HardKey>
+ verwenden, um Cues nicht zu kopieren, sondern zu **verschieben**. Auf älteren Pulten ohne 
+eine <Keys.HardKey>Move</Keys.HardKey>-Taste drücken Sie <Keys.HardKey>Avo</Keys.HardKey> 
+und <Keys.HardKey>Copy</Keys.HardKey>.
+
+- Zum Kopieren/Verschieben **mehrerer** Cues verwenden Sie <Keys.HardKey>Thru</Keys.HardKey>
+, <Keys.HardKey>And</Keys.HardKey> und <Keys.SoftKey>Not</Keys.SoftKey>. Um z.B. die Cues 3, 
+4, 5, 7, 10 als neuen Block ab Cue 20 zu kopieren, drücken 
+Sie <br/><Keys.HardKey>Copy</Keys.HardKey> <Keys.ContextKey>fader select</Keys.ContextKey> 
+3 <Keys.HardKey>Thru</Keys.HardKey> 7 <Keys.SoftKey>Not</Keys.SoftKey> 
+6 <Keys.HardKey>And</Keys.HardKey> 10 <Keys.HardKey>@</Keys.HardKey> 
+20 <Keys.HardKey>Enter</Keys.HardKey>
+
+- Sie können auch <Keys.HardKey>Enter</Keys.HardKey> statt <Keys.HardKey>@</Keys.HardKey> 
+verwenden, wenn Sie damit eher vertraut sind. Um z.B. einen Cue an das Ende der aktuellen 
+Cueliste zu kopieren, drücken Sie in diesem Fall <Keys.HardKey>Copy</Keys.HardKey>
+&nbsp; <Keys.ContextKey>fader select</Keys.ContextKey> n <Keys.HardKey>Enter</Keys.HardKey>
+&nbsp; <Keys.HardKey>Enter</Keys.HardKey>
+
+## Editieren einer Cueliste mit 'Unfold'
+
+Alternativ kann man Cuelisten bearbeiten, indem mit der Taste <Keys.HardKey>Unfold</Keys.HardKey> 
+('Aufklappen') jeder Schritt einer Cueliste auf einen einzelnen Regler abgebildet wird. Damit lässt sich jeder
+Schritt einzeln aufrufen und editieren, als wäre er ein eigener Cue.
+
+1. Drücken Sie die <Keys.HardKey>Unfold</Keys.HardKey>-Taste, gefolgt von der **Auswahltaste**
+der zu ändernden Cueliste.
+2. Die ersten zehn Schritte werden auf die **Playback-Fader** gelegt. Im
+Display wird die jeweilige Schrittnummer und Bezeichnung angezeigt. 
+*(Sind mehr Cues als Fader vorhanden, so kann man mit den Menütasten 
+F und G auf die vorige/nächste Seite Fader umschalten)*.
+3. **Betätigen Sie einen Fader**, um den jeweiligen Schritt aufzurufen
+*(dabei werden die programmierten Überblendzeiten mit berücksichtigt)*.
+4. *Es gibt diverse Optionen bei der 'Unfold'-Funktion, die Details dazu
+sind unten aufgeführt*.
+5. Drücken Sie <Keys.HardKey>Unfold</Keys.HardKey> nochmals, um den Modus zu verlassen.
+
+-   Zum **Editieren** eines Schrittes drücken Sie <Keys.HardKey>Clear</Keys.HardKey> zum Leeren des
+    Programmierspeichers, aktivieren den Fader des Schrittes, nehmen
+    die gewünschten Änderungen vor, drücken dann <Keys.SoftKey>Record Step</Keys.SoftKey> und
+    schließlich die **Select-Taste** des Schrittes.
+
+-   Um den Inhalt des Programmierspeichers in den aktuellen Schritt zu
+    integrieren (**mergen**), klicken Sie zweimal auf <Keys.SoftKey>Record Step</Keys.SoftKey>.
+
+-   Zum Ändern der Zeiten oder der Folge des Schrittes drücken Sie <Keys.SoftKey>Edit 
+	Times</Keys.SoftKey>, gefolgt von der **Select-Taste** des 
+	Schrittes, und nehmen die Änderungen vor, siehe [Zeiten für Cuelisten](cue-list-timing.md).
+
+-   Um einen neuen Schritt **einzufügen**, stellen Sie das gewünschte Bild
+    ein, drücken B <Keys.SoftKey>Insert Step</Keys.SoftKey>, dann die Taste des Schrittes, auf
+    die dieser programmiert werden soll. Alle folgenden Schritte werden
+    um eins verschoben, und der neue Schritt erhält eine Nummer zwischen
+    den beiden existierenden Schritten (*drückt man etwa die Taste für
+    Schritt 3, so erhält dieser die Schrittnummer 2.5*).
+
+-   Zum **Verschieben** oder **Kopieren** eines Cues drücken Sie <Keys.HardKey>Copy</Keys.HardKey> (ggf.
+    mehrfach) oder <Keys.HardKey>Move</Keys.HardKey>, dann die **Auswahltaste** des gewünschten Cues,
+    und schließlich die **Auswahltaste** für den gewünschten Ziel-Cue.
+
+-   Zum Löschen eines Schrittes drücken Sie die blaue <Keys.HardKey>Delete</Keys.HardKey>-Taste,
+    gefolgt von der **Select-Taste** des zu löschenden Schrittes.
+    Drücken Sie zur Bestätigung die **Select-Taste** nochmals.
+
+-   Zum Ändern der Bezeichnung drücken Sie <Keys.SoftKey>Set Step Legend</Keys.SoftKey>, gefolgt
+    von der **Select-Taste** des betreffenden Schrittes.
+
+-   Enthält die Cueliste mehr Schritte als Fader vorhanden sind, so
+    lässt sich mit den Funktionstasten F und G die Seite umschalten
+
+
+## Editieren getrackter Cues mit dem Tracking View
+
+Im Fenster **Tracking View** wird eine gute Übersicht über die aktuellen Werte von Dimmer- und anderen Kanälen angezeigt, und man sieht, ob diese in diesem Cue gespeichert oder aber aus vorigen Cues getrackt sind. Das ist sehr nützlich, um eine Cueliste nach hektischem Programmieren aufzuräumen, wenn versehentlich Werte hart einprogrammiert wurden, oder um rauszubekommen, aus welchem Cue denn ein falscher getrackter Wert stammt.
+
+Das Fenster 'Tracking View' öffnet man durch einen Klick auf den Kontext-Button <Keys.ContextKey>View Tracking</Keys.ContextKey> im Playback View der Cueliste.
+
+- Sie können auch zweimal auf <Keys.HardKey>Open/View</Keys.HardKey> drücken und das Fenster 'Tracking View' auswählen, müssen aber in diesem Fall die Cueliste, die angezeigt werden soll, mit den Menütasten wählen.
+- Um eine andere Cueliste anzuzeigen, verwenden Sie <Keys.ContextKey>Select Cue List</Keys.ContextKey> aus dem Kontextmenü.
+
+![Tracking View Window](/docs/images/Tracking-View.png)
+
+Die Cues der Cueliste werden tabellarisch angezeigt. Je nach Tracking-Verhalten werden die Werte der einzelnen Attribute in verschiedenen Farben angezeigt
+-  **Weiß** sind unveränderte harte (fest programmierte) ungetrackte Werte.
+-  **Grün** sind fest programmierte Werte, die gegenüber dem vorigen Cue kleiner sind.
+-  **Cyan** sind fest programmierte Werte, die gegenüber dem vorigen Cue größer sind, oder die erstmalig gesetzt werden.
+-  **Magenta** sind getrackte Werte (In der Spalte *Tracking* steht dazu *Tracked*).
+-  **Rot** sind geblockte Werte.
+
+Auf der linken Seite des Fensters sind verschiedene Filter verfügbar. So kann man
+- die Attribute nur einer oder aller Attributbänke anzeigen
+- die Werte der Attributbank anzeigen, die mit den normalen Tasten des Pultes angewählt ist
+- die Werte der aktuell angewählten Geräte anzeigen
+- die Werte der Geräte eines bestimmten Typs anzeigen.
+
+Klickt man einzelne oder mehrere der Werte im Display an, so werden auf den Menütasten verschiedene Funktionen verfügbar; mit <Keys.HardKey>Exit</Keys.HardKey> wird die Auswahl beendet.
+
+- &nbsp;<Keys.SoftKey>Select Function</Keys.SoftKey> öffnet ein Untermenü zur Eingabe von Werten oder Auswahl einer bestimmten Funktion. 
+- &nbsp;<Keys.SoftKey>Tracking</Keys.SoftKey> öffnet ein Untermenü zur Auswahl des Trackingmodus.
+- &nbsp;<Keys.SoftKey>Set Hard Value</Keys.SoftKey> speichert die angewählten Werte als harte Werte in die betreffenden Cues.
+- &nbsp;<Keys.SoftKey>Delete</Keys.SoftKey> löscht harte (in die Cues programmierte) Werte aus den betreffenden Cues. Getrackte Werte bleiben unverändert.
+- &nbsp;<Keys.SoftKey>Delete Redundant</Keys.SoftKey> löscht harte Werte, soweit die gleichen Werte ohnehin getrackt sind. Damit können versehentlich gespeicherte harte Werte auch in mehreren Cues und Attributen auf einmal gelöscht werden, so dass die Cueliste wieder sauber trackt. man kann auch ganze Spalten und Zeilen auswählen.
+- &nbsp;<Keys.SoftKey>Off</Keys.SoftKey> deaktiviert die angewählten Werte.
+- &nbsp;<Keys.SoftKey>On</Keys.SoftKey> aktiviert die angewählten Werte, soweit sie vorher deaktiviert wurden.
+Weitere Informationen zu On/Off siehe [Off](../cues/editing-cues.md#deaktivieren-von-attributen-in-cues-mit-off).
+
+Wurden für Fixtures oder Attribute spezielle Tracking-Anweisungen programmiert, so wird dies durch T (Track), B (Block), C (Cue Only) or S (Solo) angezeigt.
+
+### Anzeigeoptionen für den Tracking View
+
+Mit dem Button <Keys.ContextKey>Cog</Keys.ContextKey> werden die Anzeigeoptionen aufgerufen, und es lässt sich folgendes einstellen:
+
+- &nbsp;<Keys.ContextKey>Column Size</Keys.ContextKey> (Spaltenbreite), Small (schmal), Normal, Large (breit), Super Size (sehr breit).
+- &nbsp;<Keys.ContextKey>Window Scroll</Keys.ContextKey> Bildlauf, entweder automatisch mit <Keys.ContextKey>Next Cue</Keys.ContextKey>, oder manuell mit <Keys.ContextKey>Manual</Keys.ContextKey>.
+- &nbsp;<Keys.ContextKey>Scroll offset from top</Keys.ContextKey> bestimmt, wie viele Cues vorher angezeigt werden.
+- &nbsp;<Keys.ContextKey>Palettes</Keys.ContextKey> legt die Anzeige bei Verwendung von Paletten fest:<br/>
+  -  &nbsp;<Keys.ContextKey>Hidden</Keys.ContextKey> nur der Wert wird gezeigt <br/>
+  -  &nbsp;<Keys.ContextKey>Legend Only</Keys.ContextKey> nur die Legende der Palette wird gezeigt.<br/>
+  -  &nbsp;<Keys.ContextKey>Legend and Value</Keys.ContextKey> Legende wird gezeigt, dazu der Wert, sofern der Platz dafür ausreicht.
+
+Für eine bessere Übersicht können auch verschiedene Bereiche ausgeblendet werden:
+- <Keys.ContextKey>Attribute Filters</Keys.ContextKey>
+- <Keys.ContextKey>Selection Filters</Keys.ContextKey>
+- <Keys.ContextKey>Fixture Filters</Keys.ContextKey>
+- <Keys.ContextKey>Tracking Column</Keys.ContextKey>
+- <Keys.ContextKey>Legend Column</Keys.ContextKey>
+- <Keys.ContextKey>Fixture Legends</Keys.ContextKey>
+- <Keys.ContextKey>Scroll Bars</Keys.ContextKey>
+
+Im Kontextmenü für den Tracking View gibt es verschiedene Filter und Sortierungen. 
+
+Sortierungen:
+- <Keys.ContextKey>Attributes</Keys.ContextKey> können entweder in der normalen IPCGBES Reihenfolge angezeigt werden, oder mit der der gerade ausgewählten Attributbank als erstes, und die anderen Attributbänke folgen.
+- <Keys.ContextKey>Fixtures</Keys.ContextKey> können sortiert werden nach User Number, Last Selected (zuletzt angewählt) und DMX-Adresse.
+- Die Spalten können sortiert werden als <Keys.ContextKey>Fixture then Attribute</Keys.ContextKey> (Geräte zuerst; jedes Fixture wird mit allen Attributen angezeigt) oder als <Keys.ContextKey>Attribute then Fixture</Keys.ContextKey> (gleiche Attribute werden zusammen aufgelistet).
+
+Filter:
+- <Keys.ContextKey>Bank Selection</Keys.ContextKey> wenn aktiviert, werden nur die Attribute der aktuell angewählten Attributbank angezeigt (damit folgt die Attributauswahl umgekehrt auch dem Filter im Fenster Tracking View).
+- <Keys.ContextKey>Fixture Selection</Keys.ContextKey> wenn aktiviert, werden nur aktuell angewählte Geräte angezeigt.
+
+
+## Update und Cue-Tracking
+
+Da in einer Cueliste die einzelnen Werte für die einzelnen Cues
+nachverfolgt werden [Tracking](cue-list-playback.md#tracking), muss 
+beim Ändern eines bestimmten Schritts ermittelt werden, in welchem 
+Cue die zu ändernden Werte ursprünglich programmiert wurden. 
+
+Die **Update**-Funktion geht die vorherigen Schritte durch und ermittelt,
+welcher Schritt genau geändert werden muss.
+
+1. Bei gestarteter Cueliste wählen Sie die Geräte aus und ändern sie
+wie gewünscht.
+2. Drücken Sie <Keys.HardKey>Update</Keys.HardKey> *(auf 
+alten Pulten <Keys.HardKey>Record Cue</Keys.HardKey>, dann <Keys.SoftKey>Update</Keys.SoftKey>)*.
+3. Drücken Sie <Keys.HardKey>Enter</Keys.HardKey>, um die neuen Werte direkt in die Cueliste zu
+übernehmen.
+
+> Alternativ wird bei den Funktionstasten eine Liste der Paletten und
+Playbacks angezeigt, die aktualisiert werden können. Wählen Sie den zu ändernden
+Eintrag.
+
+Haben Sie die Funktionstasten-Option verwendet, drücken Sie <Keys.HardKey>Enter</Keys.HardKey>,
+ um den Vorgang abzuschließen.
+
+Stammten die geänderten Attribute von einem vorherigen Cue, so wird
+dieser - und nicht der aktuell laufende - geändert, siehe 
+ [Tracking](cue-list-playback.md#tracking).
+
+## Editieren einer laufenden Cueliste
+
+Ebenso lassen sich Schritte einer laufenden Cueliste ändern, ohne
+[Unfold](#editieren-einer-cueliste-mit-unfold) nutzen zu müssen: 
+
+1. **Starten Sie die Cueliste** mit dem entsprechenden Fader.
+2. Wählen Sie mit **Encoder A** den zu ändernden Schritt, und aktivieren Sie
+diesen mit der <Keys.HardKey>Go</Keys.HardKey>-Taste. *(Beim Pearl Expert/Tiger Touch Mk1 
+drücken Sie statt der Go-Taste die Taste <Keys.HardKey>↔</Keys.HardKey> oberhalb der Taste Snap Back)*
+3. Drücken Sie <Keys.HardKey>Clear</Keys.HardKey>, um den Programmierspeicher zu leeren.
+4. Nehmen Sie die gewünschten Änderungen vor.
+5. Drücken Sie <Keys.HardKey>Record</Keys.HardKey>, <Keys.HardKey>Connect / Cue</Keys.HardKey> *(bzw. <Keys.HardKey>Rec. Step</Keys.HardKey> bei älteren 
+Pulten)*, und wählen dann <Keys.SoftKey>Replace</Keys.SoftKey> (Ersetzen), <Keys.SoftKey>Merge</Keys.SoftKey>(Verschmelzen),
+oder <Keys.SoftKey>Insert After</Keys.SoftKey> (danach einfügen), um die Änderungen zu speichern (ein
+nochmaliger Druck auf <Keys.HardKey>Rec. Step</Keys.HardKey> wählt automatisch <Keys.SoftKey>Merge</Keys.SoftKey>).
+6. Drücken Sie <Keys.HardKey>Go</Keys.HardKey>, um zum nächsten Schritt zu gelangen *(Beim Pearl 
+Expert/Tiger Touch Mk1 drücken Sie statt der Go-Taste die Taste <Keys.HardKey>↔</Keys.HardKey>)*.
+
+> Die vorgenommenen Änderungen lassen sich auch wie folgt in den aktuellen Cue 
+  speichern <br/><Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Connect / 
+  Cue</Keys.HardKey> <Keys.HardKey>Connect / Cue</Keys.HardKey>.
+
+
+## Ändern der Zeiten einer laufenden Cueliste
+
+Die Zeiten jedes Schritts lassen sich wie folgt mit den 
+Tasten <Keys.HardKey>Live Time</Keys.HardKey> und <Keys.HardKey>Next 
+Time</Keys.HardKey> *(nicht auf allen Pulten)* ändern:
+
+1.  **Starten Sie die Cueliste** mit dem entsprechenden Fader.
+2.  Wählen Sie mit **Encoder A** den zu ändernden Schritt, und aktivieren
+    Sie diesen mit der <Keys.HardKey>Go</Keys.HardKey>-Taste. (Beim Pearl Expert/Tiger Touch Mk1:
+	Taste <Keys.HardKey>↔</Keys.HardKey>).
+3.  Drücken Sie die Taste <Keys.HardKey>Live Time</Keys.HardKey>, um die Zeiten für den
+    aktuellen, oder <Keys.HardKey>Next Time</Keys.HardKey>, um die für den nächsten Schritt
+    einzugeben. Die Schrittnummern für den aktuellen sowie den nächsten
+    Schritt werden im Display oberhalb der Räder angezeigt.
+4.  Geben Sie die Zeiten, Schrittverknüpfung (Link) und Versatz (Overlap)
+    mit den Funktionstasten ein (siehe [Zeiten für Cuelisten](cue-list-timing.md)).
+	Ändern Sie die die Link-Option auf <Keys.SoftKey>Link With Previous 
+	Cue</Keys.SoftKey> oder <Keys.SoftKey>Link After Previous Cue</Keys.SoftKey>, so wartet 
+	dieser Schritt nicht auf die <Keys.HardKey>Go</Keys.HardKey>-Taste, sondern startet 
+	automatisch.
+5.  Drücken Sie <Keys.HardKey>Go</Keys.HardKey> (bzw. <Keys.HardKey>↔</Keys.HardKey>), 
+	um zum nächsten Schritt zu gelangen.
+
+- Die Taste <Keys.HardKey>Review</Keys.HardKey> dient zur Überprüfung des aktuellen Schritts
+mit den neuen Zeitvorgaben.
+
+*Alternativ kann man die <Keys.HardKey>Unfold</Keys.HardKey>-Funktion verwenden, um die Zeiten
+zu ändern, siehe [vorheriger Abschnitt](#editieren-einer-cueliste-mit-unfold).*
+
+## Editieren einer Cueliste während des Programmierens
+
+Einzelne Schritte lassen sich editieren, noch während man die Cueliste
+programmiert:
+
+1. Drücken Sie <Keys.SoftKey>Cue Number=x</Keys.SoftKey> und geben die Nummer des gewünschten
+Schritts an.
+2. Der gewählte Schritt wird angezeigt.
+3. Nehmen Sie die gewünschten Änderungen vor, oder ändern Sie die
+Zeiten mit <Keys.SoftKey>Edit Cue x Times</Keys.SoftKey>
+4. Drücken Sie <Keys.SoftKey>Update Cue x</Keys.SoftKey> (bzw. <Keys.HardKey>Rec. 
+Step</Keys.HardKey>) zum Speichern der Änderungen.
+
+### Update-Modus
+
+Mit der Menütaste <Keys.SoftKey>Update Mode</Keys.SoftKey> lässt sich einstellen, wie
+Änderungen getrackt werden. 
+
+Update-Modus | Beschreibung
+---|---
+&nbsp;**Forwards** ![Cue List Update Mode Forwards](/docs/images/Cue-List-Update-Mode-Forwards.png) | Ändert die Werte in diesem Cue und trackt die Änderungen in alle folgenden Cues, bis die betreffenden Kanäle erneut geändert werden. Vorherige Cues werden nicht geändert.
+&nbsp;**Backwards** ![Cue List Update Mode Backwards](/docs/images/Cue-List-Update-Mode-Backwards.png) | Setzt die Änderungen rückwirkend bis zur letzten Änderung um.
+&nbsp;**Both** ![Cue List Update Mode Both](/docs/images/Cue-List-Update-Mode-Both.png) | Tracking in beide Richtungen, d.h. rückwirkend ab der letzten Änderung, sowie in allen folgenden Cues bis zur nächsten Änderung.
+&nbsp;**Cue Only** ![Cue List Update Mode Cue Only](/docs/images/Cue-List-Update-Mode-Cue-Only.png) | Nur der aktuelle Cue wird geändert.
+
+> Die Schrittnummer lässt sich auf diese Weise nicht ändern; ein Druck
+  auf <Keys.SoftKey>Cue Number</Keys.SoftKey> ändert die Nummer des aktuell neu zu speichernden
+  Schrittes. Wählen Sie <Keys.SoftKey>Advanced Options</Keys.SoftKey>, um die Schrittnummern zu
+  ändern.
+
+## Werte in mehreren Cues gleichzeitig aktualisieren
+
+Werte können auch in mehreren Cues einer Cueliste/eines Chasers
+gleichzeitig aktualisiert (mittels **Merge/Verschmelzen** oder
+&nbsp;**Replace/Ersetzen**) werden. Dies kann sowohl mit numerischer Eingabe als
+auch in der [Playback-Ansicht](#das-fenster-playback-view) erfolgen. 
+
+In der Playback-Ansicht drücken Sie die Taste <Keys.HardKey>Record</Keys.HardKey> und klicken
+dann im Bildschirm auf den gewünschten Cue/die Cues. Wählen Sie nun <Keys.SoftKey>
+Merge</Keys.SoftKey> oder <Keys.SoftKey>Replace</Keys.SoftKey> (oder drücken 
+Sie <Keys.HardKey>Enter</Keys.HardKey>, um zu Mergen). Damit wird der momentane 
+Inhalt des Programmers in die ausgewählten Cues übernommen.
+
+Bei Verwendung der Zifferntasten verbinden Sie zunächst die Cueliste
+mittels <Keys.HardKey>Connect / Cue</Keys.HardKey> mit der Steuerung und klicken auf <Keys.SoftKey>Rec. Step</Keys.SoftKey>. Nun
+verwenden Sie die Syntax n <Keys.HardKey>THRU</Keys.HardKey> m, um eine Folge von Cues zu
+ändern, oder n <Keys.HardKey>AND</Keys.HardKey> m, um mehrere Cues einzeln auszuwählen. Ist
+die [Playback-Ansicht](#das-fenster-playback-view) geöffnet, so werden die 
+gewählten Cues rot markiert. Sind alle zu ändernden Cues ausgewählt, 
+drücken Sie <Keys.HardKey>Enter</Keys.HardKey> und wählen <Keys.SoftKey>Merge</Keys.SoftKey> oder <Keys.SoftKey>Replace</Keys.SoftKey> (nochmaliges 
+Betätigen von <Keys.HardKey>Enter</Keys.HardKey> wählt Merge).
+
+## Deaktivieren eines Cues
+
+Einzelne Cues können vorübergehend deaktiviert werden. Klicken Sie dazu
+auf die Zelle 'Disabled' ganz rechts beim jeweiligen Cue in der
+Playback-Ansicht. Mit den Funktionstasten wählen Sie nun <Keys.SoftKey>Cue Disabled Yes</Keys.SoftKey>. 
+Ist ein Cue deaktiviert (disabled), so wird er übersprungen,
+als wäre er nicht vorhanden, kann aber später wieder aktiviert werden
+
+## Einzelne Cues mit Include in den Programmer laden
+
+Mit der [Include-Funktion](../cues/editing-cues.md#cues-wiederverwenden---die-include-funktion) 
+können einzelne Cues aus einer Cueliste in den Programmer
+geladen werden. Drücken Sie dazu <Keys.HardKey>Include</Keys.HardKey>, wählen die Cueliste aus, geben die Cuenummer ein und drücken <Keys.SoftKey>Include Cue</Keys.SoftKey>.
+
+Soll ein Cue aus der gerade verbundenen Cueliste included werden, so
+drücken Sie <Keys.HardKey>Include</Keys.HardKey>, <Keys.HardKey>Connect / Cue</Keys.HardKey>, geben die Nummer des Cues ein und
+wählen <Keys.SoftKey>Include Cue</Keys.SoftKey>.
+
+Auf diese Weise kann man Cues aus Cuelisten auch anderweitig
+weiterverwenden sowie Shapes/Effekte in diesem Cue editieren (geht auch
+per [Playback View](#das-fenster-playback-view)).
+
+## Mergen/verschmelzen einzelner Werte
+
+Beim Mergen/Verschmelzen von Werten in Cuelisten auf **die gleichen Geräte** wird das immer "by channel" 
+gespeichert unabhängig vom Recordmode. Ansonsten würden sämtliche Werte überschrieben werden. Daher werden 
+für die bereits vorhandenen Geräte nur die Kanäle im Programmer gespeichert. Man kann also beruhigt den 
+Recordmode auf 'by Fixture' belassen.
+
+Geräte, die in diesem Cue noch gar nicht vorhanden sind, werden hingegen "by fixture" gespeichert, also 
+mit allen Attributen. Das ist für die Theaterprogrammierung normalerweise der beste Weg, einen definierten 
+Ausgangszustand zu haben. Erforderlichenfalls können die WErte später geändert oder gelöscht werden.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/theatre-programming.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cue-lists/theatre-programming.md
@@ -1,0 +1,229 @@
+---
+id: theatre-programming
+title: Tipps für Theater-Programmierer
+sidebar_label: Tipps für Theater-Programmierer
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Wenn Sie bereits mit anderen Theater-Lichtpulten gearbeitet haben, sind
+Sie vermutlich eher an das Arbeiten mit Tasten, Nummern und Befehlen als
+an Touchscreens wie bei Titan gewöhnt. Aber keine Angst: auch bei Titan
+lässt sich eine Show mit Tasten, Nummern und Befehlen programmieren und
+fahren.
+
+- 'Richtige' Tasten mit Beschriftungen sind hier als graues Rechteck dargestellt, wie z.B. <Keys.HardKey>Enter</Keys.HardKey>.
+- Für befehle mit einem + halten Sie die erste Taste gedrückt und betätigen dazu die zweite. So bedeutet z.B. <Keys.HardKey>Clear</Keys.HardKey> + <Keys.HardKey>All</Keys.HardKey> die <Keys.HardKey>Clear</Keys.HardKey>-Taste gedrückt halten und dazu die Taste <Keys.HardKey>All</Keys.HardKey> drücken.
+- Die <Keys.HardKey>@</Keys.HardKey>-Taste ist die direkt bei den Zifferntasten, nicht eine bei den Encodern.
+- Die <Keys.HardKey>Cue</Keys.HardKey>-Taste heißt auf manchen älteren Pulten 
+  noch <Keys.HardKey>Connect</Keys.HardKey> oder <Keys.HardKey>Connect/Cue</Keys.HardKey>. 
+- Die <Keys.HardKey>Through</Keys.HardKey>-Taste heißt auf manchen älteren Pulten 
+  noch <Keys.HardKey>Thro</Keys.HardKey>.
+- Die Tasten <Keys.HardKey>And</Keys.HardKey> und <Keys.HardKey>Through</Keys.HardKey> gibt es auf manchen Pulten nicht als 'richtige' Taste, sondern als Funktionstaste <Keys.SoftKey>And</Keys.SoftKey> bzw. <Keys.SoftKey>Through</Keys.SoftKey>.
+
+Dimmer und andere Geräte haben eine User Number (Benutzer-Nummer) (*entspricht  der Channel Number auf anderen Pulten*). Diese wird links oben
+in der jeweiligen Schaltfläche angezeigt. In den hier aufgeführten
+Befehlen wird die Nummer als **n** dargestellt. Die User Number lässt sich
+über das Menü <Keys.SoftKey>Set Legend</Keys.SoftKey> ändern, siehe [Legende eingeben](../patching/changing-the-patch.md#legendenbezeichnungen-eingeben). Auch Gruppen
+haben jeweils eine User Number.
+
+![Fixtures Window showing user numbers](/docs/images/Fixtures-Window-showing-user-numbers.png)
+
+- Befehle können aneinandergefügt werden, bis mit <Keys.HardKey>Enter</Keys.HardKey> die Eingabe abgeschlossen und der Befehl ausgeführt wird. So können z.B. direkt Geräte ausgewählt und auf einen bestimmten Pegel gesetzt werden.
+- Wurden Geräte ausgewählt, kann man an diesen Änderungen vornehmen, bis <Keys.HardKey>Clear</Keys.HardKey> gedrückt wird oder bis andere Geräte ausgewählt werden.
+- Dimmerpegel werden normalerweise zweistellig angegeben (z.B. "50" für 50%). Das kann in den Benutzereinstellungen auf einstellige Eingabe in Zehner-Schritten umgestellt werden, siehe [Formatting (Formate)](../system-settings/user-settings.md#formatting-formate).
+
+## Zu steuernde Geräte auswählen
+
+ Keypresses | Action
+------------|-------------------
+ **n** <Keys.HardKey>Enter</Keys.HardKey> | Gerät **n** auswählen
+**n** <Keys.HardKey>Through</Keys.HardKey> **m** <Keys.HardKey>Enter</Keys.HardKey>	| Geräte von **n** bis **m** auswählen
+<Keys.HardKey>Group</Keys.HardKey> **n** <Keys.HardKey>Enter</Keys.HardKey> | Gerätegruppe **n** auswählen
+**n** <Keys.HardKey>Through</Keys.HardKey> **m** <Keys.HardKey>And</Keys.HardKey> **p** | Geräte von **n** bis **m** und **p** auswählen
+**n** <Keys.HardKey>Through</Keys.HardKey> **m** <Keys.HardKey>And</Keys.HardKey> **p** <Keys.HardKey>Through</Keys.HardKey> **q** | Geräte von **n** bis **m** und von **p** bis **q** auswählen
+**n** <Keys.HardKey>Through</Keys.HardKey> **m** <Keys.HardKey>Not</Keys.HardKey> **p** | Geräte von **n** bis **m** außer **p** auswählen
+
+- Haben die Geräte Zellen oder Subfixtures (z.B. LED-Pixelbars), dann lassen sich die einzelnen Zellen mit "Punkt"-Syntax aufrufen. Z.B. wählt **n** <Keys.HardKey>.</Keys.HardKey> 1 <Keys.HardKey>Through</Keys.HardKey> 4  <Keys.HardKey>Enter</Keys.HardKey> die ersten vier Zellen von Gerät **n** aus. Siehe [Geräte mit Zellen (Sub Fixtures)](../titan-reference.md#geräte-mit-zellen-sub-fixtures).
+
+## Dimmerwerte setzen
+
+Tasten | Ergebnis
+---- | ----
+ <Keys.HardKey>@</Keys.HardKey> **v** <Keys.HardKey>Enter</Keys.HardKey> | Dimmer/Gerät auf **v%** *(siehe Anmerkung zur 2-stelligen Eingabe)*
+ <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> | Dimmer/Gerät auf 100%
+ **n** <Keys.HardKey>@</Keys.HardKey> **v** <Keys.HardKey>Enter</Keys.HardKey> | Dimmer/Gerät **n** auf **v%**
+ **n** <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> | Dimmer/Gerät **n** auf 100%
+&nbsp;**n** <Keys.HardKey>Through</Keys.HardKey> **m** <Keys.HardKey>@</Keys.HardKey> **v** <Keys.HardKey>Enter</Keys.HardKey> | Dimmer/Geräte **n** bis **m** auf **v%**
+&nbsp;**n** <Keys.HardKey>And</Keys.HardKey> **m** <Keys.HardKey>And</Keys.HardKey> **p** <Keys.HardKey>@</Keys.HardKey> **v** <Keys.HardKey>Enter</Keys.HardKey> | Dimmer/Geräte **n**, **m**, **p** auf **v%**
+<Keys.HardKey>Group</Keys.HardKey> **n** <Keys.HardKey>@</Keys.HardKey> **v** <Keys.HardKey>Enter</Keys.HardKey> | Dimmer/Geräte in Gruppe **n** auf **v%**
+
+
+## Andere Parameter bei Movinglights etc. einstellen
+
+Tasten | Ergebnis
+---- | ----
+ <Keys.HardKey>@</Keys.HardKey> **b** <Keys.HardKey>/</Keys.HardKey> **v** | Farbnummer **v** von Marke **b** für die ausgewählten Geräte. (1=Marke L, 2=Marke R, 3=Marke G)
+ <Keys.HardKey>Gobo</Keys.HardKey> (Encoder) | Einstellen des Gobos auf den im Display für die Encoder angezeigten Wert.
+ <Keys.HardKey>Gobo</Keys.HardKey> <Keys.HardKey>Wheel @</Keys.HardKey> <Keys.SoftKey>Gobo 1</Keys.SoftKey> | Auswahl des Gobos für die ausgewählten Geräte mit den Menütasten. (Hierbei ist <Keys.HardKey>Wheel @</Keys.HardKey> die Taste bei dem betreffenden Encoder).
+
+- Verfügt das Pult nicht über eine <Keys.HardKey>/</Keys.HardKey>-Taste, so verwendet man bei der Auswahl der Farbnummer entweder die Bildschirmtastatur oder eine externe Tastatur, siehe [Farbmischung: Filters](../controlling-fixtures/changing-fixture-attributes.md#farbmischung-filters). 
+
+## Clear-Funktionen
+
+Tasten | Ergebnis
+---- | ----
+<Keys.HardKey>Clear</Keys.HardKey> | Sofortiges Clearen des Programmers - der Programmer wird geleert, editierte HTP-Werte (Dimmerkanäle) auf die vorigen Werte zurückgesetzt und die Geräteauswahl gelöscht *(ähnlich wie Sneak bei ETC-Pulten, jedoch nur für Intensity)*
+<Keys.HardKey>Release</Keys.HardKey> + <Keys.HardKey>Clear</Keys.HardKey> | Clearen des Programmers - der Programmer wird geleert, editierte HTP- **und LTP-**Werte auf die vorigen Werte zurückgesetzt und die Geräteauswahl gelöscht *(wie Sneak bei ETC-Pulten)*
+**t** <Keys.HardKey>Clear</Keys.HardKey> | Release der editierten Kanäle in **t** Sekunden
+<Keys.HardKey>Clear</Keys.HardKey> + <Keys.HardKey>All</Keys.HardKey> | Geräteauswahl löschen, aber Werte im Programmer behalten
+
+- Die Funktion der Clear-Taste lässt sich auf zweistufiges Clear ändern, so dass entweder zuerst die Geräteauswahl und mit dem zweiten Tastendruck der Programmer gelöscht wird oder umgekehrt. Siehe [Action Precedence](../system-settings/user-settings.md#clear) in den Benutzereinstellungen/Clear.
+
+Hält man <Keys.HardKey>Clear</Keys.HardKey> gedrückt, so stehen auf den Menütasten weitere Funktionen zur Verfügung. So kann man z.B. die Werte nur der gerade angewählten Geräte löschen oder eine bestimmte Maske zum Löschen ausgewählter Attribute verwenden. Siehe [Das Clear-Menü](../controlling-fixtures.md#das-clear-menü)
+
+## Programmieren von Cues
+
+Titan kann mehrere Cuelisten parallel laufen lassen. Zum Programmieren
+einer Cueliste drückt man auf <Keys.HardKey>Record</Keys.HardKey> und wählt im 
+Menü <Keys.SoftKey>Create Cue List</Keys.SoftKey>. Dann drückt man die **Auswahltaste** 
+bei einem Fader, um dort die Cueliste zu speichern.
+
+Beim Programmieren werden zunächst alle Änderungen seit dem letzten Betätigen 
+der <Keys.HardKey>Clear</Keys.HardKey>-Taste in den Programmierspeicher, kurz Programmer, geschrieben. 
+
+Mit den Menüoptionenen <Keys.SoftKey>Record Mode</Keys.SoftKey> wird nun bestimmt, was genau in den Cue gespeichert wird:
+
+- **Record by Channel** speichert die einzelnen Attribute der Geräte im Programmer. Hat man z.B. ein Fixture angewählt 
+und Pan/Tilt verändert, so wird auch nur Pan/Tilt gespeichert, nicht aber die anderen Attribute. Das eignet sich z.B., 
+um andere  Cues zu überlagern (z.B. um nur die Farbe zu ändern).
+
+- **Record by Fixture** speichert sämtliche Attribute der Geräte im Programmer. Hat man z.B. ein Fixture angewählt 
+und Pan/Tilt verändert, so werden trotzdem sämtliche Attribute des Fixtures gespeichert. Das eignet sich vor allem 
+für Cues, bei denen man sichergehen will, dass das Ergebnis genauso aussieht wie es programmiert wurde, unabhängig 
+von zuvor gestarteten Cues.
+
+- **Record by Stage** ignoriert den Programmer uns speichert sämtliche Geräte, die gerade aktiv sind (Dimmer > 0).
+
+Das bedeutet, *dass andere gerade aktive Playbacks nicht mit in den Cue gespeichert werden*, 
+außer bei **Record by Stage**, da Playbacks nicht im Programmer sind, 
+siehe [Erstellen eines Cues](../cues/creating-a-cue.md#anlegen-eines-cues). Mit der [Include-Funktion](../cues/editing-cues#cues-wiederverwenden---die-include-funktion) kann man Playbacks in den Programmer laden, um sie anderweitig weiterzuverwenden.
+
+Ist [Tracking](../cue-lists/cue-list-playback.md#tracking) aktiviert (Voreinstellung), so werden Werte nur dann in eine 
+Cueliste gespeichert, wenn sie gegenüber den vorigen Cues verändert wurden. Das ist das normale Verhalten von 
+Theater-Konsolen und erleichtert das Editieren, da so gezielt nur der Cue geändert werden muss, in dem der Wert
+ursprünglich programmiert wurde.
+
+Tasten | Ergebnis
+-------|---------
+<Keys.HardKey>Record</Keys.HardKey> <Keys.SoftKey>Create Cue List</Keys.SoftKey> <Keys.ContextKey>fader select</Keys.ContextKey> | Beginn einer neuen Cueliste auf dem ausgewählten Fader
+<Keys.HardKey>Record</Keys.HardKey> <Keys.ContextKey>fader select</Keys.ContextKey> <Keys.ContextKey>fader select</Keys.ContextKey> | speichert den nächsten Cue an das Ende dieser Cueliste
+<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> **n** <Keys.HardKey>Enter</Keys.HardKey> | Speichert Cue **n** (existiert bereits ein solcher Cue, erfolgt eine Rückfrage zum Mergen/Überschreiben)
+<Keys.HardKey>Time</Keys.HardKey> **t** <Keys.HardKey>Enter</Keys.HardKey> | Setzen der Fadezeit im Programmer (wird in nachfolgend gespeicherte Cues übernommen; bereits angelegte Cues  bleiben unbeeinflusst)
+<Keys.HardKey>View</Keys.HardKey> <Keys.ContextKey>fader select</Keys.ContextKey> | Anzeige aller Cues der Cueliste als Liste, um z.B. deren Zeiten zu überprüfen und zu ändern.
+
+### Kopieren, Verschieben, Löschen von Cues
+
+Tasten | Ergebnis
+-------|---------
+<Keys.HardKey>Copy</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> **n** <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> **m** <Keys.HardKey>Enter</Keys.HardKey> | Kopieren von Cue **n** in neuen Cue **m**
+<Keys.HardKey>Copy</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> **n** <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>Enter</Keys.HardKey> | Kopieren von Cue **n** an das Ende der Cueliste
+<Keys.HardKey>Delete</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> **n** <Keys.HardKey>Enter</Keys.HardKey> <Keys.HardKey>Enter</Keys.HardKey> | Löscht Cue **n** (2. <Keys.HardKey>Enter</Keys.HardKey> bestätigt)
+
+- Mit <Keys.HardKey>Move</Keys.HardKey> (statt Copy) können Cues verschoben werden.<br/>
+  Verfügt das Pult über keine Move-Taste, drücken Sie <Keys.HardKey>Avo</Keys.HardKey> 
+  und <Keys.HardKey>Copy</Keys.HardKey>.
+
+- Mehrere Cues auf einmal lassen sich mit den Tasten <Keys.HardKey>Through</Keys.HardKey>, <Keys.HardKey>And</Keys.HardKey> und <Keys.SoftKey>Not</Keys.SoftKey> auswählen. Um z.B. die Cues 3, 4 ,5 ,7, 10 zu kopieren und ab Cue 20 einzufügen, drücken Sie <br/><Keys.HardKey>Copy</Keys.HardKey> <Keys.ContextKey>fader select</Keys.ContextKey> **3** <Keys.HardKey>Through</Keys.HardKey> **7** <Keys.SoftKey>Not</Keys.SoftKey> **6** <Keys.HardKey>And</Keys.HardKey> **10** <Keys.HardKey>@</Keys.HardKey> **20** <Keys.HardKey>Enter</Keys.HardKey>.
+
+### Block-Cues und Follow-On-Cues
+
+Zum Einstellen von Block und Follow-On öffnen Sie die Cueliste wie oben beschrieben mit <Keys.HardKey>View</Keys.HardKey> <Keys.ContextKey>fader select</Keys.ContextKey>.
+
+- Zum Erstellen eines **Block**-Cues (Änderungen werden nicht getrackt) klickt man in der Spalte 'Tracking' auf
+  die Zelle des entsprechenden Cues und wählt <Keys.SoftKey>Block</Keys.SoftKey> mit den Menütasten.
+
+- Um Cues [miteinander zu verlinken](cue-list-timing.md#schrittfolge-und-versatz), 
+  klickt man auf die entsprechende Zelle der Spalte ‚Link' (dort steht normalerweise 
+  ‚Wait For Go'). Dann kann	man mit den Menütasten auf <Keys.SoftKey>Link After Previous 
+  Cue</Keys.SoftKey> oder <Keys.SoftKey>Link With Previous Cue</Keys.SoftKey> wechseln. 
+  Für 'Link After...' bestimmt dann der Wert für 'Delay	Out', wie lange nach dem vorigen 
+  der neue Cue automatisch startet.
+
+## Cues und Cuelisten abfahren
+
+Schiebt man den Fader einer Cueliste hoch, so wird sie mit der Steuerung
+verbunden *("connected")* und kann z.B. mit der <Keys.HardKey>Go</Keys.HardKey>-
+Taste gesteuert werden.
+
+Tasten | Ergebnis
+-------|---------
+<Keys.HardKey>Cue</Keys.HardKey> <Keys.ContextKey>fader select</Keys.ContextKey> | Verbinden einer anderen Cueliste
+<Keys.HardKey>Go</Keys.HardKey> | Nächster Cue wird mit den programmierten Zeiten eingeblendet
+<Keys.HardKey>Cue</Keys.HardKey> **n** <Keys.HardKey>Go</Keys.HardKey> | Cue n wird mit den programmierten Zeiten eingeblendet
+&nbsp;**t** <Keys.HardKey>Go</Keys.HardKey> | Nächster Cue wird in **t** Sekunden eingeblendet
+&nbsp;**n** <Keys.HardKey>Cue</Keys.HardKey> **t** <Keys.HardKey>Go</Keys.HardKey> | Cue **n** wird in **t** Sekunden eingeblendet
+
+-	Sollen Movinglights bereits im Off auf Position, in Gobo oder Farbe
+	fahren, aktivieren Sie die Funktion [<Keys.SoftKey>Move In Dark</Keys.SoftKey>](cue-list-options.md#move-in-dark).
+
+## Updaten von Cues 
+
+Einzelne wie auch mehrere Cues können wie folgt mit dem Inhalt das Programmer aktualisiert werden:
+
+Tasten | Ergebnis
+-------|---------
+<Keys.HardKey>Record</Keys.HardKey><Keys.HardKey>Cue</Keys.HardKey> **n** <Keys.HardKey>Enter</Keys.HardKey> <Keys.HardKey>Enter</Keys.HardKey> | Updaten von Cue **n** mit dem Inhalt des Programmers und Tracken in die folgenden Cues *(existiert der Cue noch nicht, so wird er neu erstellt)*. 
+<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> **n** <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> | Updaten von Cue **n** mit dem Inhalt des Programmers ohne zu tracken. 
+<Keys.HardKey>Cue</Keys.HardKey> **n** <Keys.HardKey>Time</Keys.HardKey> **t** <Keys.HardKey>Enter</Keys.HardKey> | Setzen von **t** Sekunden Fadezeit in Cue **n**.
+<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> **n** <Keys.HardKey>Through</Keys.HardKey> **m** <Keys.SoftKey>Merge</Keys.SoftKey> | Verschmelzen des Programmers in alle Cues von **n** bis **m** *(nicht existierende Cues werden erstellt)*.
+<Keys.HardKey>Update</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> **n** <Keys.HardKey>Through</Keys.HardKey> **m** <Keys.SoftKey>Update</Keys.SoftKey> | Updaten der Werte in den Cues von **n** bis **m** mit den Werten des Programmers *(es werden weder fehlende Cues erstellt noch Attribute hinzugefügt, siehe Anmerkung unten)*.
+<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Update</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> **n** <Keys.HardKey>Through</Keys.HardKey> **m** <Keys.SoftKey>Update</Keys.SoftKey> | Verschmelzen des Programmers in alle Cues von **n** bis **m** *(Fehlende Cues werden **nicht** erstellt, aber die neuen Attribute werden in alle Cues hinzugefügt)*.
+
+- Für **Update** lässt sich einstellen, ob neue Attribute mit gespeichert werden sollen. Ist <Keys.SoftKey>Add Channels</Keys.SoftKey> aktiviert, so werden den Cue ggf. neue Attribute hinzugefügt; ist diese Option nicht aktiv, so werden nur die Werte bereits existierender Attribute aktualisiert. Der Befehl **Record Update** erzwingt in jedem Fall das Hinzufügen neuer Attribute.
+
+## Cues live editieren
+
+Oft müssen Änderungen an bereits programmierten Cues vorgenommen werden,
+während diese gerade live sind. Es empfiehlt sich, <Keys.HardKey>Clear</Keys.HardKey> zu drücken,
+um den Programmer zu leeren und nicht versehentlich unerwünschte Werte mit zu speichern.
+
+Tasten | Ergebnis
+-------|---------
+<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> | Speichern der aktuell eingestellten Werte in den aktuellen Cue und Tracken in die folgenden Cues. 
+<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> | Speichern der aktuell eingestellten Werte in den aktuellen Cue ohne zu tracken.
+<Keys.HardKey>Update</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> | Speichern der aktuell eingestellten Werte in den aktuellen Cue und Tracken in die folgenden Cues *(für getrackte Werte wird der Cue geändert, in dem die aktuellen Werte ursprünglich gesetzt wurden)*.
+<Keys.HardKey>Update</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> | Speichern der aktuell eingestellten Werte in den aktuellen Cue ohne zu tracken *(für getrackte Werte wird der Cue geändert, in dem die aktuellen Werte ursprünglich gesetzt wurden)*.
+<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Update</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> | Speichern der aktuell eingestellten Werte in den aktuellen Cue und Tracken in die folgenden Cues *(neue Attribute werden zum Cue hinzugefügt, wenn sie noch nicht enthalten waren; für getrackte Werte wird der Cue geändert, in dem die aktuellen Werte ursprünglich gesetzt wurden)*.
+<Keys.HardKey>Time</Keys.HardKey> **t** <Keys.HardKey>Enter</Keys.HardKey> <Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> | Speichern der Fadezeit **t** in den aktuellen Cue.<br/>Eine andere Möglichkeit ist, die Cueliste mit <Keys.HardKey>View</Keys.HardKey> zu öffnen und dort die Änderungen vorzunehmen.
+
+## Weitere Optionen zu Zeiten
+
+Tasten | Ergebnis
+-------|---------
+<Keys.HardKey>Time</Keys.HardKey> **t1** <Keys.HardKey>And</Keys.HardKey> **t2** <Keys.HardKey>Enter</Keys.HardKey> | **t1** Sekunden Fade-In und **t2** Sekunden Fade-Out im Programmer setzen (zum Speichern in die nächsten Cues).
+<Keys.HardKey>Time</Keys.HardKey> **t1** <Keys.HardKey>And</Keys.HardKey> **t2** <Keys.HardKey>Enter</Keys.HardKey> <Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> | **t1** Sekunden Fade-In und **t2** Sekunden Fade-Out für den aktuellen Cue programmieren.
+<Keys.HardKey>Time</Keys.HardKey> <Keys.HardKey>Fixture</Keys.HardKey> **t** <Keys.HardKey>Enter</Keys.HardKey> | **t** Sekunden Fade-In für die aktuell ausgewählten Geräte im Programmer setzen.
+<Keys.HardKey>Time</Keys.HardKey> **t1** <Keys.HardKey>@</Keys.HardKey> **t2** <Keys.HardKey>Enter</Keys.HardKey> | **t1** Sekunden Fade-In und **t2** Sekunden Delay im Programmer setzen (zum Speichern in die nächsten Cues).
+<Keys.HardKey>Time</Keys.HardKey> <Keys.HardKey>Fixture</Keys.HardKey> **t1** <Keys.HardKey>@</Keys.HardKey> **t2** <Keys.HardKey>Enter</Keys.HardKey> <Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> | **t1** Sekunden Fade-In und **t2** Sekunden Delay für die aktuell ausgewählten Geräte in den aktuellen Cue speichern.
+
+## Shapes und Effekte
+
+Shapes und Effekte lassen sich zwar nicht mit dem Ziffernblock auswählen, es ist aber trotzdem nicht schwer:
+
+1. Zu steuernde Geräte wählen
+2. Im Hauptmenü drückt man <Keys.SoftKey>Shapes and Effects</Keys.SoftKey>
+  , <Keys.SoftKey>Shape Generator</Keys.SoftKey>, <Keys.SoftKey>Create</Keys.SoftKey>
+3. Den gewünschten Shape-Typ wählen, z.B. <Keys.SoftKey>Dimmer</Keys.SoftKey>, <Keys.SoftKey>Pan/Tilt</Keys.SoftKey> etc.
+4. Den gewünschten Shape wählen (Menütasten oder Shapes-Fenster)
+5. Speed, Size, Spread mit den Wheels einstellen
+
+Shapes können ganz normal in Cues gespeichert werden und tracken in
+folgende Cues, bis das Tracken gestoppt wird. Zum Stoppen klicken Sie in der Playback-Ansicht der Cueliste auf den Button **T/B** in der Spalte 'View Shape', siehe [Tracking von Shapes in Cuelisten](../cue-lists/creating-a-cue-list.md#tracking-von-shapes-in-cuelisten).
+
+## Macros
+
+Folgen von Tastendrücken können als *Macro* gespeichert werden, so dass die ganze Folge durch nur einen Klick ausgeführt wird, siehe [Macros](../titan-basics/front-panel-buttons.md#macros----tastenfolgen).
+
+Macros können in Cuelisten eingefügt werden, indem man ind der Spalte 'Macros' in der Playback-Ansicht in die betreffende Zelle klickt.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues.md
@@ -1,0 +1,45 @@
+---
+id: cues
+title: Cues
+sidebar_label: Cues
+---
+
+Nun haben Sie das gewünschte Licht auf der Bühne erstellt und möchten
+die Einstellung gern speichern und später wieder aufrufen. Dabei gibt es
+vier verschiedene grundsätzliche Speichermöglichkeiten:
+
+**Cues** (Szenen): dies sind einzelne Lichtstimmungen oder Bilder. Diese
+können Abläufe (Shapes) enthalten, und können mit Zeiten zum Ein- und
+Ausblenden versehen sein.<br/>
+**Chaser** (Lauflichter): eine Folge mehrerer einzelner Cues, die
+automatisch abläuft.<br/>
+**Cueliste**: eine Folge mehrerer Cues oder Chaser, die durch getrennte
+Kommandos der "Go"-Taste gesteuert wird.<br/>
+**Timeline:** Eine zeitgesteuerte Sequenz aus verschiedenen Playbacks, womit man z.B. 
+komplexe Looks zu Musik oder zu Timecode realisieren kann.
+
+[Chaser](chases.md), [Cuelisten](cue-lists.md) und [Timelines](timelines.md) 
+werden in separaten Kapiteln behandelt.
+
+Speicherplätze, auf die Cues, Cuelisten und Chaser abgelegt werden
+können, werden **Playbacks** genannt. Dafür kommen in Frage:
+
+-   Playbacks mit **Fadern** (und zugehörigen Tasten). Dabei steuert der
+    Fader normalerweise die Helligkeit, kann aber auch andere Parameter
+    steuern (umzustellen in den [Options](cues/playback-options.md)).
+	
+-   **Virtuelle Fader** im [Fenster 'Virtual Faders'](running-the-show/playback-controls.md#virtuelle-fader). 
+    Diese funktionieren genauso wie echte Fader.
+
+-   **Buttons** (Schaltflächen) im Playbacks-Fenster; dabei lässt sich per
+    [Tastenprofil (Key Profile)](system-settings/key-profiles.md) einstellen, 
+	wie sich der Button verhält (einrasten, Flash, Solo).
+
+-   **Macro/Exekutor-Tasten** - auch deren Verhalten lässt sich per
+    [Tastenprofil (Key Profile)](system-settings/key-profiles.md) definieren.  
+
+Sollten einmal die Fader nicht ausreichen, so gibt es optionale [Faderwings](about-the-consoles/fader-wings), 
+mit denen sich weitere Fader nachrüsten lassen.
+
+Die Cue-Funktionen der Titan-Pulte sind äußerst mächtig; der erste Teil
+dieses Kapitels erklärt die Grundzüge, wie Cues verwendet werden.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues.md
@@ -38,7 +38,7 @@ können, werden **Playbacks** genannt. Dafür kommen in Frage:
 -   **Macro/Exekutor-Tasten** - auch deren Verhalten lässt sich per
     [Tastenprofil (Key Profile)](system-settings/key-profiles.md) definieren.  
 
-Sollten einmal die Fader nicht ausreichen, so gibt es optionale [Faderwings](about-the-consoles/fader-wings), 
+Sollten einmal die Fader nicht ausreichen, so gibt es per USB angeschlossene Faderwings, 
 mit denen sich weitere Fader nachrüsten lassen.
 
 Die Cue-Funktionen der Titan-Pulte sind äußerst mächtig; der erste Teil

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues/copying-moving-linking-and-deleting.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues/copying-moving-linking-and-deleting.md
@@ -1,0 +1,89 @@
+---
+id: copying-moving-linking-and-deleting
+title: Kopieren, verschieben, verlinken, löschen
+sidebar_label: Kopieren, verschieben, verlinken, löschen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Kopieren eines Cues
+
+Mittels der Taste <Keys.HardKey>Copy</Keys.HardKey> lässt sich eine **Kopie** eines Cues anfertigen
+oder ein Speicherplatz als **Verknüpfung** zu einem bestehenden Cue anlegen. 
+Es lassen sich auch mehrere Speicherplätze (nicht nur Cues, sondern auch
+[Chaser](../chases.md) or [Cuelisten](../cue-lists.md)) in einem Arbeitsgang
+kopieren.
+
+Verknüpfungen bieten sich an, wenn ein Cue aus Ablaufgründen auf mehreren Seiten
+erscheinen soll; Verknüpfungen enthalten die gleichen Informationen wie
+der originale Cue, können aber individuelle [Zeiten](cue-timing.md) und 
+[Optionen](playback-options.md) zugewiesen bekommen.
+
+1. Drücken Sie die Taste <Keys.HardKey>Copy</Keys.HardKey>.
+2. Zum Anlegen einer Verknüpfung drücken Sie nochmals auf <Keys.HardKey>Copy</Keys.HardKey> oder wählen
+die Menütaste <Keys.SoftKey>Link</Keys.SoftKey>.
+3. Drücken Sie die **Auswahltaste** des Cues, den Sie kopieren möchten.
+Sie können eine Reihe von Cues auswählen, indem Sie die Taste des ersten
+gedrückt halten und die Taste des letzten dazu betätigen. Ebenso können
+mit <Keys.HardKey>Thro</Keys.HardKey> und <Keys.HardKey>And</Keys.HardKey> mehrere Cues auf einmal ausgewählt werden (ggf.
+<Keys.HardKey>And</Keys.HardKey> gedrückt halten).
+4. Drücken Sie eine unbelegte **Auswahltaste**, zu der der Cue
+kopiert/verknüpft werden soll; werden mehrere Playbacks kopiert, so werden 
+diese ab dort auf die folgenden freien Plätze eingefügt.
+
+-   Die Taste <Keys.HardKey>Menu Latch</Keys.HardKey> fixiert das Menü **Copy**, so dass
+    man bei wiederholtem Kopieren die Taste <Keys.HardKey>Copy</Keys.HardKey> nicht
+    erneut betätigen muss. Zum Freigeben des Menüs drücken Sie
+    nochmals <Keys.HardKey>Menu Latch</Keys.HardKey>, zum Verlassen drücken Sie <Keys.HardKey>Exit</Keys.HardKey>.
+
+-   <Keys.SoftKey>Retain Layout</Keys.SoftKey>(Layout erhalten) oder <Keys.SoftKey>Bunch Up</Keys.SoftKey>
+    (Zusammen­fassen) werden verwendet beim Kopieren einer Gruppe
+    von Cues, die auch unbelegte Speicherplätze enthält: diese lassen
+    sich entweder weiter als unbelegt behalten, oder die belegten
+    Speicherplätze werden aufeinanderfolgend zusammengefasst.
+
+-   Die Option <Keys.SoftKey>Copy Legends</Keys.SoftKey> (Bezeichnungen kopieren) kann geändert 
+	werden in <Keys.SoftKey>Don't copy legends</Keys.SoftKey> (Bezeichnungen nicht kopieren), so 
+	dass die kopierten Cues Standardbezeichner bekommen.
+
+## Verschieben eines Cues
+
+Mit der Taste <Keys.HardKey>Move</Keys.HardKey> lassen sich Playbacks (Cues, Chaser, Cuelisten) 
+auf andere Tasten und Fader verschieben. **Move/Verschieben** ist sinnvoll, 
+um das Pult 'aufzuräumen', Playbacks zu ordnen oder auf andere Seiten zu 
+gruppieren.
+
+Wie beim Kopieren lassen sich auch mehrere Playbacks auf einmal verschieben,
+indem Sie die Taste des ersten gedrückt halten und die Taste des letzten 
+dazu betätigen, oder sie wählen wieder mit <Keys.HardKey>Thro</Keys.HardKey> und <Keys.HardKey>And</Keys.HardKey> mehrere Cues 
+auf einmal aus. Und mit <Keys.HardKey>Menu Latch</Keys.HardKey> kann auch das **Move**-Menü fixiert werden.
+
+-   Einige Pulte haben eventuell keine Move-Taste. In diesem Fall halten
+	Sie die Taste <Keys.HardKey>Avo</Keys.HardKey> gedrückt und drücken dazu <Keys.HardKey>Copy</Keys.HardKey>, um die **Move**-Funktion 
+	zu aktivieren.
+
+-   Im Modus 'Move' (Verschieben) dient die Option <Keys.SoftKey>Swap Items if Required</Keys.SoftKey> 
+    (Tausch wenn erforderlich) dazu, bestehende Cues, die dem
+    Verschiebe-Vorgang im Wege wären, automatisch zu verschieben. Dies
+    bietet sich insbesondere beim ‚Aufräumen' nahezu voller Seiten an.
+
+## Einen Cue löschen
+
+Um einen Cue zu löschen:
+
+1. Drücken Sie die <Keys.HardKey>Delete</Keys.HardKey>-Taste.
+2. Betätigen Sie die **Auswahltaste** des zu löschenden Cues.
+3. Drücken Sie die **Auswahltaste** zur Bestätigung nochmals (oder
+bestätigen Sie mit <Keys.HardKey>Enter</Keys.HardKey>).
+
+-   Statt einen Cue zu löschen, kann man diesen auch mit der Option <Keys.SoftKey>Unassign</Keys.SoftKey> im 
+    Delete-Menü 'unbelegen' (unassign). Damit wird der
+    Cue von der jeweiligen Schaltfläche/Fader/Taste entfernt, bleibt
+    aber im [Show-Verzeichnis](../titan-basics/show-library.md) erhalten und kann später wieder verwendet werden.
+
+-   Verwenden Sie die Taste <Keys.HardKey>Menu Latch</Keys.HardKey>, um den Löschmodus aktiv zu
+    lassen, so können Sie mittels **Schritt 2 und 3** weitere Cues löschen,
+    ohne jeweils die <Keys.HardKey>Delete</Keys.HardKey>-Taste betätigen zu müssen. Zum Freigeben
+    des Menüs drücken Sie nochmals <Keys.HardKey>Latch Menu</Keys.HardKey>, zum Verlassen drücken
+    Sie <Keys.HardKey>Exit</Keys.HardKey>.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues/creating-a-cue.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues/creating-a-cue.md
@@ -1,0 +1,176 @@
+---
+id: creating-a-cue
+title: Erstellen eines Cues
+sidebar_label: Erstellen eines Cues
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Arbeitsweise des Pultes beim Programmieren
+Sobald ein oder mehrere Dimmer/Geräte zum Steuern ausgewählt werden,
+werden diese in den **Programmer** geladen. Nun lassen sich mit den [Encodern (Wheels)](../controlling-fixtures/changing-fixture-attributes#einstellen-von-attributen-mit-den-encodern) und
+[Paletten](../palettes.md) die Einstellungen der Geräte verändern; ebenso lassen sich
+[Effekte](../effects.md) anwenden. Alle so vorgenommenen Änderungen werden im Programmer gespeichert.
+
+Auch die Reihenfolge der Auswahl der Geräte wird dort gespeichert und ggf. etwa
+bei [Effekten](../effects.md) und beim Überblenden ([Geräte-Überlappung/Fixture Overlap](cue-timing.md#einstellen-von-überblendzeiten-und-geräteversatz)) verwendet. 
+
+Beim Speichern des Cues wird schließlich der Inhalt des Programmierspeichers 
+in das Playback geschrieben. Dabei wird der Inhalt des Programmers gespeichert,
+nicht der komplette Output des Pultes. Siehe der folgende Abschnitt zu den Record 
+Modes (Speichermodi).
+
+Wird ein anderes Gerät angewählt, nachdem bereits Änderungen vorgenom­men
+wurden, wird die aktuelle Geräteliste im Programmer geleert und eine neue begonnen,
+wobei die vorgenommenen Änderungen im Programmer verbleiben.
+
+Das Betätigen der Taste <Keys.HardKey>Clear</Keys.HardKey> (bei den Zifferntasten) löscht den
+Programmierspeicher. Damit stellt man sicher, dass beim
+weiteren Programmieren keine Geräte beeinflusst werden, die man nicht
+verändern will. Auch beim Beenden des Programmierens empfiehlt sich der
+Druck auf die <Keys.HardKey>Clear</Keys.HardKey>-Taste, da sämtliche Attribute im
+Programmierspeicher die Einstellungen der Playbacks sonst überlagern.
+
+Geräte, die aktuell im Programmspeicher sind, werden auf den
+[Geräte-Schaltflächen](../controlling-fixtures.md#dimmer-und-geräte-zum-steuern-auswählen) in einem mittleren Blau dargestellt. Attribute im
+Programmierer (also die geänderten Einstellungen) werden [in der Attribut-Anzeige](../controlling-fixtures/changing-fixture-attributes.md#einstellen-von-attributen-mit-den-encodern)
+in Cyan dargestellt.
+
+Beim Abrufen eines Cues werden dessen Werte nicht in den
+Programmierspeicher übernommen *(das lässt sich jedoch durch die
+[Include-Function](editing-cues.md#cues-wiederverwenden---die-include-funktion) erreichen; ebenso kann per 'Record Stage' der komplette Output gespeichert werden)*.
+
+
+## Anlegen eines Cues
+
+<Video videoId="X5g6DMVwlZU" title="Creating a Cue" />
+
+1. Drücken Sie <Keys.HardKey>Clear</Keys.HardKey>, um den Programmierspeicher zu leeren.
+*Damit wird eine saubere Arbeitsumgebung sichergestellt.*
+
+2. Stellen Sie das gewünschte Bild ein. Dabei können auch Shapes
+verwendet werden. Bedenken Sie, dass nur die von Ihnen angewählten
+Geräte bzw. veränderten Attribute im Cue gespeichert werden (je nach
+Speichermodus).
+
+3. Betätigen Sie die Taste <Keys.HardKey>Record</Keys.HardKey>.
+
+4. Drücken Sie die **Swop-Taste** eines freien Playbacks; freie
+Speicherplätze werden durch blinkende LEDs angezeigt. Ebenso lässt
+sich ein Cue auf eine Schaltfläche im Fenster 'Playbacks' speichern.
+
+5. Drücken Sie <Keys.HardKey>Clear</Keys.HardKey>, um den Programmierspeicher zu leeren.
+
+Wissenswerte Dinge zum Speichern von Cues:
+
+-   Cues können auf die Fader, auf Macro/Executor-Tasten sowie auf 
+Schaltflächen im Fenster 'Playbacks' gespeichert werden.
+
+-   Die Menütaste <Keys.SoftKey>Record Mode</Keys.SoftKey> bietet folgende Optionen:
+    -   <Keys.SoftKey>Record By Fixture</Keys.SoftKey> - Speichern pro Gerät - alle Attribute 
+	der Geräte, die angewählt oder verändert wurden, werden gespeichert
+    -   <Keys.SoftKey>Record By Channel</Keys.SoftKey> - Speichern pro Kanal - nur die veränderten 
+	Attribute werden gespeichert
+    -   <Keys.SoftKey>Record Stage</Keys.SoftKey> - gesamtes Bild speichern: sämtliche
+    Geräte mit nicht geschlossenem Dimmer werden gespeichert
+    -   &nbsp;<Keys.SoftKey>Quick Build</Keys.SoftKey> - siehe [nächster Abschnitt](#quick-build----cues-schnellspeichern)
+
+-   <Keys.SoftKey>Record By Channel</Keys.SoftKey> ist empfehlenswert, wenn mehrere Cues
+    übereinandergelegt werden sollen, um einen bestimmten Effekt zu
+    erzielen.
+
+-   Soll eine Vielzahl von Cues gespeichert werden, so lässt sich mit
+    der Taste <Keys.HardKey>Menu Latch</Keys.HardKey> das 'Record Cue'-Menu einrasten und dauerhaft
+    aktiv halten. Ein weiteres Betätigen von <Keys.HardKey>Menu Latch</Keys.HardKey> verlässt
+    diesen Modus wieder.
+
+-   Unten im Bildschirm wird eine Bezeichnung des jeweiligen Cues
+    angezeigt. Um diese einzustellen, drücken Sie <Keys.SoftKey>Set Legend</Keys.SoftKey>, dann
+    die jeweilige **Swop-Taste** des entsprechenden Playbacks, und geben
+    die Bezeichnung über die Tastatur ein oder machen eine Skizze auf dem 
+	Bildschirm. Beenden Sie die Eingabe mit <Keys.HardKey>Enter</Keys.HardKey>. *Handelt es sich um 
+	einen Speicherplatz ohne zugehörigen Bildschirmbereich - etwa nur eine 
+	Taste - so bezeichnen Sie diesen auf hergebrachte Art mit Tape und Stift.*
+
+![Playbacks stored on playback faders](/docs/images/Playbacks-stored-on-playback-faders.png)
+
+Auf dem Diamond 9 und Diamond 7 kann mit <Keys.SoftKey>Halo</Keys.SoftKey> im Menü **Set Legend** die 
+Farbe der Beleuchtung des Playback-Faders eingestellt werden.
+
+-   Das Fenster 'Static Playbacks' zeigt die Belegung der
+    Macro-/Exekutor-Tasten sowie - auf dem Tiger Touch - der 10 festen
+    Fader.
+
+## Quick Build -- Cues schnellspeichern
+
+Stellt man <Keys.SoftKey>Record Mode</Keys.SoftKey> auf **Quick Build**, so lassen sich Cues, Chaser und Cuelisten aus
+bereits programmierten Cues und Paletten erstellen (wie auch per
+[Include](editing-cues.md#cues-wiederverwenden---die-include-funktion)).
+
+1.  Drücken Sie <Keys.HardKey>Record</Keys.HardKey>.
+2.  Drücken Sie <Keys.SoftKey>Record Mode</Keys.SoftKey> und stellen den Record Mode auf "Quick Build".
+3.  Wählen Sie mit den Menütasten, ob ein Cue, ein Chaser oder eine Cueliste gespeichert werden soll.
+4.  Drücken Sie die **Select**-Taste oder den Button eines freien Speicherplatzes.
+5.  Starten Sie die playbacks und wählen Sie die Paletten aus, die Sie in dem Cue verwenden wollen.
+6.  Wenn Sie einen einfachen Cue/Memory speichern, drücken Sie <Keys.SoftKey>OK</Keys.SoftKey>, sobald alle gewünschten Playbacks und Paletten ausgewählt wurden. Speichern Sie dagegen einen Chaser oder eine Cueliste, so drücken Sie auf die Menütaste <Keys.SoftKey>Append</Keys.SoftKey>, um mit dem nächsten Cue/Step zu beginnen. Drücken Sie zum Abschluss auf <Keys.HardKey>Exit</Keys.HardKey>.
+
+-   Sollen nur einige der Lampen aus einem Speicherplatz/einer Palette verwendet werden, 
+    wählen Sie zuerst die Geräte aus, und klicken dann auf das Playback/die Palette.
+-   Ist das Speichern des Cues, Chasers oder der Cueliste abgeschlossen, so wird der Record Mode 
+    automatisch auf "Record By Fixture" zurückgesetzt.
+
+## Verwenden von Shapes und Effekten in Cues
+
+Erwartungsgemäß werden auch sämtliche aktivierten [Shapes und Pixel-Effekte](../effects.md)
+als Teil des Cues abgespeichert. 
+
+Ebenso können Sie einen Shape ohne Basiswerte speichern; ein Cue wie
+dieser kann gemeinsam mit anderen Cues abgerufen werden, überlagert dann
+die dort abgespeicherten Werte/Shapes und ergibt vielfältige
+Kombinationsmöglichkeiten. Zum Speichern eines solchen Cues nutzen Sie
+den Modus **Record by Channel** sowie die ['Off'-Funktion](editing-cues.md#deaktivieren-von-attributen-in-cues-mit-off), 
+um die anderen Attribute aus dem Programmierspeicher zu entfernen.
+
+## Blind-Modus
+
+Im Blind-Modus lassen sich Änderungen an der Programmierung vornehmen,
+ohne dabei die aktuellen Ausgangssignale zu verändern; damit lassen sich
+etwa während einer laufenden Show noch 'unsichtbar' Korrekturen
+vornehmen. Diese können gleichwohl im [Visualiser](../capture-visualiser.md) zur Kontrolle angezeigt werden.
+
+Zum Aktivieren des Blind-Modus drücken Sie auf die Taste <Keys.HardKey>Blind</Keys.HardKey> *(auf
+älteren Pulten ohne diese Taste halten Sie die <Keys.HardKey>AVO</Keys.HardKey>-Taste gedrückt
+und wählen die Option <Keys.SoftKey>Blind</Keys.SoftKey>; damit können Sie zwischen <Keys.SoftKey>Active</Keys.SoftKey>
+und <Keys.SoftKey>Inactive</Keys.SoftKey> umschalten)*.
+
+Sollen nur einzelne Speicherplätze z.B. im Visualiser kontrolliert
+werden, ohne auf die Bühne 'rauszugehen', so können sie per <Keys.SoftKey>Playback Options</Keys.SoftKey> 
+in den Blind-Modus geschaltet werden, oder man hält <Keys.HardKey>Blind</Keys.HardKey>
+gedrückt und drückt/klickt auf das jeweilige Playback. Wiederholt man
+das, so wird das Playback wieder ‚Live'.
+
+Die im Blind-Modus vorgenommenen Einstellungen lassen sich in den
+Live-Modus herüberfaden: dazu tippen Sie mit den Zifferntasten eine Zeit
+(in Sekunden) ein und drücken dann <Keys.HardKey>Blind</Keys.HardKey>. Damit können z.B. mehrere
+Paletten auf einmal abgerufen werden; oder Sie bereiten Blind einen
+neuen Look vor und rufen diesen ab, ohne erst einen Cue programmieren zu
+müssen.
+
+## Attribut-Speichermaske bei Cues
+
+Beim Speichern von Cues lässt sich eine Maske erstellen, mit der die zu
+speichernden Attribute festgelegt werden. Dies funktioniert genauso wie 
+beim [Speichern von Paletten](../palettes/creating-palettes.md#speichern-einer-palette).
+Drücken Sie <Keys.HardKey>Record</Keys.HardKey> und wählen die Option <Keys.SoftKey>Set Mask</Keys.SoftKey>. Wählen Sie 
+nun die zu speichernden Attribute mit den Attribut-Tasten.
+
+## Cues zu Chasern/Cuelisten umwandeln
+
+Bestehende Cues lassen sich ganz einfach zu [Chasern](../chases.md) oder
+[Cuelisten](../cue-lists.md) umwandeln, indem man einen weiteren Cue 
+hinzufügt und die entsprechende Option wählt. Nehmen Sie die gewünschten
+Einstellungen (für den zweiten Step) vor, drücken Sie <Keys.HardKey>Record</Keys.HardKey>, gefolgt 
+von der blauen Taste des bereits bestehenden Cues. Wählen Sie nun die Option 
+<Keys.SoftKey>Convert to Chase</Keys.SoftKey> (oder Cue List). Damit wird der bestehende Cue 
+Cue 1, der neu gespeicherte Cue wird Cue 2.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues/cue-playback.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues/cue-playback.md
@@ -1,0 +1,336 @@
+---
+id: cue-playback
+title: Einen Cue verwenden
+sidebar_label: Einen Cue verwenden
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Da eine Vielzahl von Cues/Chasern gleichzeitig abgerufen werden kann,
+folgt das Pult bestimmten Regeln zur Kombination der aufgerufenen Werte
+verschiedener Cues. Diese werden als **HTP**- und **LTP**-Regeln bezeichnet.
+
+## HTP und LTP
+
+Steuerkanäle können auf zwei Weisen verwaltet werden:
+
+-   Dimmer und Helligkeitskanäle arbeiten nach dem Prinzip **'der höchste 
+ Wert hat Priorität' (Highest Takes Precedence, HTP)**. Ist ein
+ HTP-Kanal mit verschiedenen Werten in mehreren Cues aktiv, so wird
+ der höchste Wert ausgegeben. Wird ein Cue ausgeblendet, so werden
+ die zugehörigen HTP-Kanäle ausgeblendet.
+
+-   Alle anderen Kanäle arbeiten nach dem Prinzip **'der letzte Wert hat
+ Priorität' (Latest Takes Precedence, LTP)**. Die letzte/neueste
+ Änderung überschreibt alle vorherigen Werte, folglich wird der Wert
+ des zuletzt aufgerufenen Cues ausgegeben. Beim Ausblenden eines Cues
+ behalten LTP-Kanäle ihren Wert, bis dieser durch einen anderen Cue
+ überschrieben wird.
+
+## Abrufen eines Cues
+
+ Zum Aufrufen eines Cues bewegen Sie den jeweiligen Regler (betätigen Sie
+ die <Keys.HardKey>Clear</Keys.HardKey>-Taste, um sicherzustellen, dass sich keine Werte im
+ Programmierspeicher befinden, da diese ansonsten die Werte der Playbacks
+ überschreiben würden).
+
+-   Es lassen sich mehrere Cues gleichzeitig abrufen.
+
+-   Die Werte der HTP-Kanäle werden durch den Regler beeinflusst; wird
+ dieser etwa auf 50% gestellt, so zeigen alle HTP-Kanäle 50% ihres
+ jeweils programmierten Wertes.
+
+-   LTP-Kanäle werden getriggert, sobald der Regler über 0% bewegt wird.
+ Ist eine Überblendzeit programmiert, so beginnen die LTP-Kanäle mit
+ der Überblendung; ist keine solche hinterlegt, so wechseln die
+ Kanäle sofort zu der neuen Einstellung *(außer falls der Cue auf
+ ‚Mode 2' gestellt ist; siehe [Fader Modes](cue-timing.md#fade-modes))*.
+
+-   Cues lassen sich ebenso mit der **Flash**-Taste aufrufen
+ (werden auf 100% geschaltet und zum sonstigen Ausgang addiert). Eine
+ Solo-Funktion ergibt sich mit der **Swop**-Taste (alle anderen
+ aktiven Cues werden ausgeblendet). 'Flash' und 'Swop' funktionieren
+ nur, sofern nicht ein anderes Tastenprofil hinterlegt ist, 
+ siehe [Tastenprofile/Key Profiles](../system-settings/key-profiles.md).
+
+-   Cues lassen sich vorab laden, indem die **Preload**-Funktion einer der
+ Tasten per [Tastenprofil/Key Profile](../system-settings/key-profiles.md) zugewiesen wird. *'Vorab
+ laden' (Preload) stellt die Attribute nicht anderweitig aktiver
+ Geräte auf die Werte des Cues ein, um zu verhindern, dass später
+ unerwünschte Schwenks, Gobo- oder Farbwechsel während des Aufrufs
+ des Cues sichtbar sind*. 
+
+ Zum Zuweisen der 'Preload'-Funktion halten
+ Sie die <Keys.HardKey>AVO</Keys.HardKey>-Taste und drücken <Keys.SoftKey>Edit Key Profile</Keys.SoftKey>, anschließend
+ drücken Sie die Taste, die Sie ändern möchten (siehe [Tastenprofile/Key Profiles](../system-settings/key-profiles.md)). 
+ Berücksichtigen Sie, dass diese Einstellung dann ggf. für sämtliche Tasten dieses Typs gilt.
+
+-   Einzelne Cues lassen sich auch mittels Tasten mit ihrem Timing
+ starten, indem man der entsprechenden Taste das [Tastenprofil/Key Profile](../system-settings/key-profiles.md) "Go"
+ zuweist. Die Taste muss nicht gedrückt gehalten werden, um das
+ Fade-In zu Ende zu führen. Der gleiche Cue kann mehrfach gestartet
+ werden, ohne ihn zu releasen.
+
+-   Wenn einzelne Playbacks nicht durch andere Playbacks für die
+ gleichen Geräte überlagert werden sollen, so geben Sie dem Playback
+ eine höhere **Priorität**. Wenn z.B. ein paar Movinglights sowohl als
+ Rednerlicht als auch als Effektlicht eingesetzt sind, so können Sie
+ dem Rednerlicht-Playback eine höhere Priorität geben. Siehe [Priority](playback-options.md#priority) in
+ [Options](playback-options.md).
+
+## Wechsel der Playback-Seiten
+
+Die Playback-Seiten lassen sich mit den Tasten 'Page+1' und 'Page-1' 
+neben den Fadern sowie mit dem obere und unteren Bereich der 
+Walzen-Schaltfläche im Display umschalten. Ebenso kann man in die Mitte 
+der Walzen-Schaltfläche klicken und eine Seitennummer eingeben.
+
+>   Wurden Cues auf den Schaltflächen gespeichert, so lassen sich die
+ Seiten mit den 'Pages'-Schaltflächen im 'Playbacks'-Fenster wählen.
+
+Die Benutzereinstellung [<Keys.SoftKey>Playback Paging</Keys.SoftKey>](../system-settings/user-settings.md#handles) bestimmt über 
+das Verhalten der Playbacks, wenn bei aktivierten Fadern die Playback-Seiten 
+umgeschaltet werden:
+
+### Pulte ohne Motorfader
+
+-   Aktuell aufgerufene Cues bleiben beim Seitenwechsel normalerweise
+ aktiviert (Playback Paging: **Always Hold**). Soll ein Cue aufgerufen 
+ werden, der sich auf einem Fader befindet, der von einer vorherigen 
+ Seite bereits aktiviert ist, so bewegen Sie diesen auf 0 und 
+ aktivieren ihn wieder. Der vorherige Cue wird damit gestoppt, und 
+ der neue aufgerufen. Jeder Fader kann somit stets nur auf einer Seite 
+ aktiv sein.
+
+-   Schaltet man die Einstellung dagegen auf **Never Hold**, dann kann jeder
+ Fader auf mehreren Seiten unabhängig voneinander aktiv sein.
+ Kehren Sie zu einer Seite zurück, von der bereits vorher ein Regler
+ aktiv ist, so erhält dieser erst wieder die Kontrolle, sobald er auf
+ dem bereits aktiven Wert steht; damit werden Sprünge bei der ersten
+ Reglerbewegung verhindert. Ist ein Playback-Regler auf einer anderen
+ Seite aktiviert, so wird das in pink angezeigt und die Seitennummer
+ eingeblendet. 
+	
+-   Die Einstellung **Normal** bezieht sich auf den Vorgabewert, also bei 
+ Pulten ohne Motorfader 'Always Hold'.
+
+### Pulte mit Motorfadern
+
+-   Voreinstellung: **Never Hold**. Cues bleiben beim Seitenwechsel aktiv, 
+ aber die Fader sind der neuen Seite zugeordnet. Zum Deaktivieren eines 
+ Cues von einer anderen Seite muss man auf diese zurückwechseln und den 
+ Fader auf 0 ziehen. Ist ein Playback-Regler auf einer anderen Seite 
+ aktiviert, so wird das in pink angezeigt und die Seitennummer eingeblendet.
+    
+-   Wechselt man die Einstellung auf **Always Hold**, so wird das von Pulten
+ ohne Motorfader bekannte Verhalten aktiviert, und jeder Fader kann nur
+ auf einer Seite aktiv sein.
+	
+-   Die Einstellung **Normal** bezieht sich auf den Vorgabewert, also bei 
+ Pulten mit Motorfadern 'Never Hold'.
+
+-   Für jede Playbackseite lässt sich eine Bezeichnung vergeben. Die
+ Bezeichnung wird auf der auf der virtuellen Walze angezeigt. Zum Vergeben
+ der Bezeichnung nutzen Sie im Hauptmenü <Keys.SoftKey>Set Legends</Keys.SoftKey>, 
+ dann <Keys.SoftKey>Page Legends</Keys.SoftKey>. Solange man sich in diesem Menü befindet, lassen sich für
+ mehrere Seiten Bezeichnungen vergeben.
+
+-   Die festen Playbacks bzw. Executor-Tasten (sofern jeweils vorhanden)
+ lassen sich mittels Makros ebenfalls umschalten. Die betreffenden
+ Makros sind Teil der Personality-Bibliothek. Sollten die
+ erforderlichen Makros auf Ihrem Pult nicht zur Verfügung stehen, so
+ aktualisieren Sie zunächst die Personalities (und damit auch die
+ Makros).
+
+## Anzeigen der aktuell laufenden Playbacks
+
+Im Fenster 'Active Playbacks' werden die aktuell laufenden Playbacks
+angezeigt. Insbesondere wenn mehrere Playbacks auf mehreren Seiten
+gestartet wurden, hat man damit einen schnellen Überblick, welche Cues
+gerade aktiv sind, wo sie gestartet wurden und welche Attribute dadurch
+gesteuert werden. Zum Aufrufen dieses Fensters drücken Sie zweimal auf
+[<Keys.HardKey>Open / View</Keys.HardKey>](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster) 
+und wählen <Keys.SoftKey>Active Playbacks</Keys.SoftKey>.
+
+![Active Playbacks Window](/docs/images/Active-Playbacks-Window.png)
+
+Klickt man eine der Schaltflächen an, so wird das betreffende Playback
+sofort deaktiviert (**gekillt**). Betätigt man <Keys.SoftKey>Playback Options</Keys.SoftKey>, gefolgt von einer
+der Playback-Schaltflächen, so kann man die jeweiligen Parameter ändern.
+
+## Master für Speed (Geschwindigkeit) und Size (Größe)
+
+Die einzelnen Playbacks lassen sich verschiedenen Speed- und
+Size-Masterreglern zuweisen; damit kann man das Tempo und die Größe von
+enthaltenen [Shapes und Effekten](../effects.md) zentral steuern, oder - im Fall von
+Chasern - direkt das [Chase-Tempo](../chases/chase-timing.md#rate--und-bpm-master) 
+beeinflussen. *Das ist sehr nützlich, um mehrere gleichzeitig laufende Cues 
+gemeinsam zu steuern*.
+
+Fader können aber auch Größe und Tempo der 'eigenen', also in diesem Cue
+gespeicherten Effekte steuern. Dies wird über die Playback-Optionen
+eingestellt, siehe [Tab "Fader"](playback-options.md#playback-options----tab-fader)
+
+Speed- und Size-Master sind detailliert beschrieben in [Speed and Size Masters](../running-the-show/playback-controls.md#speed--und-size-master).
+
+## Release
+
+Wenn der Fader eines Playbacks wieder auf 0 gestellt wird, dann bleiben die LTP-Attribute des Playbacks auf dem zuletzt 
+(also durch das Playback) vorgegebenem Wert. Mitunter ist dies nicht gewünscht, so soll z.B. nach dem Deaktivieren 
+eines Strobe-Cues das Stroben aufhören. Mit der **Release**-Funktion lässt sich bestimmen, wie Attribute nach dem 
+Deaktivieren auf den vorigen Status zurückkehren.
+
+Mittels einer Maske kann man festlegen, ob einzelne oder alle Attribute eines Cues nach dem Deaktivieren auf die vorigen 
+Werte zurückkehren, siehe [Release Mask](./playback-options.md#release-mask). Für einzelne Cues erfolgt das, sobald alle Fadezeiten abgelaufen 
+sind, außer dies wurde mit [Kill Point](./playback-options.md#fader-tab) in den Cue-Optionen anders gesetzt.
+
+Attribute releasen auf den Wert, der mit dem vorher gestarteten Playback vorgegeben wurde. Ist die 
+Einstellung <Keys.SoftKey>Release to Home</Keys.SoftKey> im Release-Menü aktiviert, so kehren die Attribute auf die 
+Release-/Power On-Werte zurück 
+(siehe [Werte für Release / Power On programmieren](./cue-playback.md#werte-für-release--power-on-programmieren)). Ist diese Einstellung 
+deaktiviert, so bleiben die Werte des letzten Playbacks.
+
+Mittels [Key Profile](../system-settings/key-profiles.md) lässt sich auch einzelnen Tasten die Release-Funktion zuweisen.
+
+Das Releasen erfolgt stets mit einer Überblendzeit. Deren Vorgabewert sind 2s, dies kann im Release-Menü 
+unter <Keys.SoftKey>Master Release Time</Keys.SoftKey> geändert werden. Ferner kann man jedem Playback eine individuelle
+Release-Zeit zuweisen ([Tab "Release"](./playback-options.md#tab-release) der Playback-Optionen).
+
+-   Um einen einzelnen Cue zu deaktivieren (‚Kill'), drücken Sie gleichzeitig die <Keys.HardKey>AVO</Keys.HardKey>-Taste
+und die **Auswahltaste** des Cues, das hat den gleichen Effekt wie das Stellen des Faders auf 0. Dabei wird die 
+Fade-Out-Zeit berücksichtigt und der Cue released, sobald er ausgefadet ist. Das ist ebenso sinnvoll bei Cuelisten, die
+je nach gewählter Option auf dem letzten Cue aktiv bleiben, auch wenn der Fader auf 0 steht.
+
+-   Ein aktuell laufendes Playback lässt sich releasen, indem man die Taste <Keys.HardKey>Release</Keys.HardKey> drückt,
+gefolgt von der **Auswahltaste** des Playbacks. Dabei wird eine [Temporäre Release-Maske](./playback-options.md#temporary-release-mask) 
+angewendet. Fadezeiten des Playbacks bleiben unberücksichtigt, nur die eingegebene Release-Zeit wird eingehalten.
+
+-   Um alle laufenden Playbacks zu releasen, drücken Sie zweimal <Keys.HardKey>Release</Keys.HardKey>. Mit der 
+Benutzereinstellung [Release Priority](../system-settings/user-settings.md#release) lässt sich vorgeben, welche Playbacks 
+welcher Priorität released werden sollen. Stellt man diese Einstellung auf 'Low', so kann man nicht versehentlich 
+alles releasen, außer es wurden gezielt einzelne Playbacks auf Priorität Low gesetzt.
+
+-   Während des Releasens werden die betreffenden Playbacks gelb angezeigt, um zu zeigen, dass diese noch aktiv sind.
+
+## Release Mask (Release einzelner Attribute)
+
+Mit der **Release-Maske** kann man einstellen, welche Attribute released werden. Es gibt eine **globale** 
+Release-Maske, die generell gilt, sofern nicht für einzelne Cues eine **lokale** Maske gesetzt wurde. Wird mittels 
+der <Keys.HardKey>Release</Keys.HardKey>-Taste released, so wird dagegen eine **temporäre** Release-Maske nur für diesen 
+einen Vorgang angewendet.
+
+### Globale Release-Maske
+
+Ist für den Cue keine lokale Release-Maske erstellt worden, so erfolgt das Release gemäß der globalen Release-Maske. 
+Die Vorgabe ist, dass keine Attribute released werden. So bleiben alle LTP-Attribute auf dem Wert des Playbacks.
+
+Um die globale Release-Maske zu ändern, drücken Sie die Taste <Keys.HardKey>Release</Keys.HardKey> und klicken
+auf <Keys.SoftKey>Global Release Mask</Keys.SoftKey>. Auf der Schaltfläche der Funktionstaste und den Buttons der 
+Attributbänke wird angezeigt, welche Attribute momentan angewählt sind.
+
+![Global Release Mask](/docs/images/Global-Release-Mask.png)
+
+### Lokale (individuelle) Release-Maske
+
+Um für das jeweilige Playback eine bestimmte Maske einzustellen, klicken Sie auf <Keys.SoftKey>Options</Keys.SoftKey> und 
+wählen das betreffende Playback aus. Auf dem Reiter [Release](./playback-options.md#tab-release) können Sie die 
+entsprechenden Einstellungen vornehmen.
+
+### Temporäre Release-Maske
+
+Wird ein Playback oder der Programmer mit der <Keys.HardKey>Release</Keys.HardKey>-Taste released, so wird eine temporäre 
+Release-Maske angewendet. Die Voreinstellung ist, dass alle Attribute released werden. Betätigen Sie die 
+Attributbank-Buttons, um die Maske zu ändern; sobald die erste Attributbank angewählt wurde, werden alle anderen 
+abgewählt. 
+
+- Geben Sie mit den Zifferntasten eine Zeit in Sekunden ein, bevor Sie die <Keys.HardKey>Release</Keys.HardKey>-Taste 
+drücken, so gilt diese temporär als Release-Zeit.
+
+## Weitere Release-Optionen
+
+### Playbacks seitenweise releasen
+
+Es können auch mehrere Playbacks auf einmal released werden. Drücken Sie dazu <Keys.HardKey>Release</Keys.HardKey> 
+und <Keys.HardKey>Goto Page</Keys.HardKey>, oder <Keys.HardKey>Release</Keys.HardKey> und die aktuelle
+Seite (auf der Playback-Walze). Es gibt folgende Optionen:
+
+&nbsp;<Keys.SoftKey>Release This Page</Keys.SoftKey> released alle aktiven Playbacks der aktuellen
+Seite und Fadergruppe.
+
+&nbsp;<Keys.SoftKey>Release Playbacks Not On This Page</Keys.SoftKey> released alle Playbacks, die momentan von anderen
+Seiten aus in dieser Fadergruppe aktiv sind - besonders zweckmäßig, um Playbacks zu releasen, die auf anderen Seiten
+auf dem gleichen Fader aktiv sind.
+
+&nbsp;<Keys.SoftKey>Release All Playbacks In This Group</Keys.SoftKey> released alle Playbacks in der
+jeweiligen Fadergruppe.
+
+Dabei findet jeweils die [Temporäre Release-Maske](#temporäre-release-maske) Anwendung.
+
+> **"Fader Group"** (Fadergruppe) bedeutet hier den jeweiligen Bereich von Fadern auf dem Pult, der getrennt Seiten
+wechseln kann. So sind etwa die 10 Fader unterhalb des Displays auf dem Arena bzw. dem Tiger Touch eine Gruppe. Die 15
+oberen sowie die 15 unteren Fader auf dem Tiger Touch Faderwing bzw. links auf dem Arena sind zwei weitere getrennte
+Fadergruppen.
+
+### Den Programmer releasen
+
+Der Inhalt des Programmers lässt sich releasen, indem man die <Keys.HardKey>Release</Keys.HardKey>-Taste drückt, dann
+die zu releasenden Attribute wählt und schließlich <Keys.HardKey>Clear</Keys.HardKey> drückt. Auch hier kann man vorher eine Release-Zeit mit den Zifferntasten eingeben.
+
+Um ein einzelnes Attribut, das gerade auf einem der Räder liegt, zu releasen, drückt 
+man <Keys.HardKey>Release</Keys.HardKey> gefolgt von der jeweiligen <Keys.HardKey>@</Keys.HardKey>-Taste (bei dem  
+entsprechenden Rad). Damit lassen sich z.B. versehentlich gesetzte Werte aus dem Programmer entfernen oder beim Busking
+etwas revidieren.
+
+### Einen Master releasen
+
+Ein Masterregler lässt sich auf seinen Ausgangswert zurücksetzen, indem man die <Keys.HardKey>Release</Keys.HardKey>-Taste
+drückt gefolgt von der **Auswahltaste** des Masters. Um alle Master auf einmal zu releasen, drücken 
+Sie <Keys.HardKey>Release</Keys.HardKey> und wählen aus dem Menü <Keys.SoftKey>Release all Masters</Keys.SoftKey>. 
+Damit werden alle Master zurückgesetzt (100% bei Intensity-Mastern, 100% bei Speed-Mastern etc.)
+
+## Werte für Release / Power On programmieren
+
+Der Status, auf den die Lampen/Geräte beim Einschalten des Pultes gesetzt werden bzw. zu dem sie nach dem Releasen aller
+Playbacks zurückkehren, lässt sich getrennt programmieren. So kann es sinnvoll sein, dafür ein Grundlicht auf der Bühne
+einzustellen.
+
+Es lassen sich sowohl shared (gemeinsam genutzte) als auch individuelle Werte pro Gerät einstellen. Werden shared Werte
+gespeichert, so muss das - wie bei Paletten - nur für ein Gerät gemacht werden und gilt dann für alle Lampen dieses
+Gerätetyps. Individuelle Werte dagegen gelten jeweils nur für das einzelne Gerät.
+
+1.  Nehmen Sie die gewünschten Einstellungen vor.
+2.  Drücken Sie <Keys.HardKey>Record</Keys.HardKey>, dann <Keys.HardKey>Release</Keys.HardKey>.
+3.  Wählen Sie <Keys.SoftKey>Shared values</Keys.SoftKey> oder <Keys.SoftKey>Individual values</Keys.SoftKey>.
+4.  Klicken Sie die Funktionstaste <Keys.SoftKey>Record</Keys.SoftKey>.
+5.  Damit werden die Release-Werte gespeichert.
+
+>   Zum Testen starten Sie ein oder mehrere Playbacks und releasen diese
+    (<Keys.HardKey>Release</Keys.HardKey> sowie die jeweiligen Playbacks). Die Geräte sollten auf
+    die programmierten Release-Werte zurückkehren.
+
+## Deaktivieren einzelner Geräte mit Off
+
+Einzelne Geräte und Attribute können über das **Off**-Menü deaktiviert werden.
+Damit bleiben die Werte zwar im Playback enthalten, werden aber nicht abgerufen.
+Die programmierten Werte verbleiben dabei im Playback und können in der 
+Playback-Ansicht wieder auf On geschaltet, also aktiviert werden.
+
+Dazu drücken Sie die Taste <Keys.HardKey>Off</Keys.HardKey>, dann die **Select-Taste** des Playbacks. 
+Wählen Sie die betreffenden Geräte aus, stellen Sie im Menü die Attributmaske
+ein, und klicken Sie auf <Keys.SoftKey>Off</Keys.SoftKey>, um wie gewünscht Attribute/Geräte/Shapes 
+Off zu schalten.
+
+Auf Titan-Pulten mit **Release** und **Off** auf der gleichen Taste würde
+dies zum Releasen führen. Drücken Sie stattdessen <Keys.HardKey>Release/Off</Keys.HardKey>, dann 
+aus dem Menü <Keys.SoftKey>Off Playback Values</Keys.SoftKey>, und wählen Sie nun das Playback aus.
+
+## Playback-Gruppen
+
+Playbacks können zu Gruppen zugeordnet werden, innerhalb deren sie sich gegenseitig deaktivieren. So kann man z.B. 
+Farb-Playbacks auf verschiedenen Tasten programmieren, von denen nur die zuletzt angewählte aktiv ist. Auch beim Busking 
+kann das sinnvoll sein, so dass man nicht mit vielen aktiven Playbacks endet, die sich gegenseitig überschreiben.
+
+Das ist genauer beschrieben im Kapitel Steuern der Show, siehe [Playback-Gruppen](../running-the-show/playback-controls.md#playback-gruppen).
+
+![Playback groups window](/docs/images/Playback-groups-display-mode-1.png)

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues/cue-timing.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues/cue-timing.md
@@ -1,0 +1,234 @@
+---
+id: cue-timing
+title: Zeiten für Cues
+sidebar_label: Zeiten für Cues
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Es lassen sich viele verschiedene Zeiteinstellungen für Cues vornehmen.
+
+## Einstellen von Überblendzeiten und Geräteversatz
+
+Beim Programmieren von Cues lassen sich Verzögerung, Ein- und
+Ausblendzeit für den Cue insgesamt oder aber für einzelne Attribute und
+Geräte getrennt einstellen. Sind in dem Cue auch Shapes vorhanden, so
+werden diese, abhängig vom [Fade Mode](#fade-modes), davon auch beeinflusst.
+
+> Gibt man längere Zeiten als 60 Sekunden ein, so wird die Eingabe von der Software 
+automatisch in Minuten und Sekunden aufgeteilt. Gibt man z.B. **115** ein, so wird das 
+als **1:15** (also 1 Min 15 Sek) gewertet. Gibt man noch mehr Stellen ein, so werden 
+diese als Stunden:Minuten:Sekunden interpretiert.
+
+Die Überblendzeiten lassen sich zwischen den einzelnen Geräten
+verzögern, so dass der Cue nacheinander auf die einzelnen Geräte
+eingeblendet wird. Dies bezeichnet man als **Fixture Overlap**
+(Geräteversatz), und es gestattet, vielfältige Effekte ohne großen
+Programmieraufwand zu realisieren.
+
+Im nachfolgenden Schema zeigt das obere Bild den Wechsel eines
+LTP-Kanals unter Berücksichtigung von Verzögerungs- und Überblendzeiten.
+Das zweite Diagramm zeigt den entsprechenden Wechsel eines HTP-Kanals.
+In den beiden letzten Bildern sind 'Fixture Overlap' sowie das separate
+Faden einzelner Attribute dargestellt.
+
+![Fade time, delay time, fixture overlap and attribute fade time diagram](/docs/images/Fade-time-delay-time-fixture-overlap-and-attribute-fade-time-diagram.png)
+
+Alle beim Programmieren des Cues eingestellten Zeiten werden in den Cue
+gespeichert.
+
+Gespeicherte Zeiten lassen sich wie folgt ändern:
+
+1. Drücken Sie <Keys.SoftKey>Edit Times</Keys.SoftKey> im Hauptmenü.
+2. Drücken Sie die **Auswahltaste** des Cues.
+3. Drücken Sie <Keys.SoftKey>Fade Mode x</Keys.SoftKey>, um den 'Fade Mode' (Überblendmodus)
+einzustellen. &nbsp;*Das bestimmt, wie die Zeiten verwendet werden, [siehe unten](#fade-modes).*
+4. Drücken Sie <Keys.SoftKey>Delay time</Keys.SoftKey>, um die Verzögerungszeit vor Beginn des
+Cues einzugeben, <Keys.SoftKey>Fade time</Keys.SoftKey> für die Einblendzeit, sowie <Keys.SoftKey>Fade out time</Keys.SoftKey> für die Eingabe der Ausblendzeit.
+5. Geben Sie die jeweilige Zeit mit den Zifferntasten (in Sekunden)
+ein, und schließen Sie die Eingabe mit <Keys.HardKey>Enter</Keys.HardKey> ab.
+6. Drücken Sie <Keys.SoftKey>Fixture Overlap</Keys.SoftKey> zur Einstellung des Geräteversatzes,
+gefolgt von einem Wert **0...100** auf den Zifferntasten.<br/>
+ **100%** bedeutet: alle Geräte blenden gemeinsam über.<br/>
+ **0%** bedeutet: das vorherige Gerät muss die Überblendung abgeschlossen haben, bevor das nächste damit beginnt.<br/>
+ **50%** bedeutet: das nächste Gerät beginnt mit der Überblendung, wenn das vorherige seine Überblendung zur Hälfte
+abgeschlossen hat.<br/>
+ Die Reihenfolge der Geräte wird bestimmt durch die Reihenfolge beim Anwählen der Geräte *(kann aber später geändert
+ werden, siehe [Ändern der Geräte-Reihenfolge](#ändern-der-reihenfolge-der-geräte))*.
+7. Drücken Sie <Keys.HardKey>Exit</Keys.HardKey> zum Verlassen des Menüs.
+
+-   Ebenso lassen sich sowohl für die **IPCGBES**-Attributgruppen als auch für jedes Attribut einzeln gesonderte Zeiten
+vergeben, siehe     [Ändern der Attribut-Fadezeit](#eingeben-von-überblendzeiten-für-einzelne-attribute).
+
+-   Mit der Taste <Keys.HardKey>TIME</Keys.HardKey> lassen sich Zeiten sehr komfortabel mit dem
+    Ziffernblock eingeben, z.B. ergibt <Keys.HardKey>TIME</Keys.HardKey> <Keys.HardKey>5</Keys.HardKey> <Keys.HardKey>AND</Keys.HardKey> <Keys.HardKey>2</Keys.HardKey> 5s Ein- und
+    2s Ausfadezeit *(auf früheren Pulten liegt die Times-Funktion auf der
+    Taste <Keys.HardKey>SET</Keys.HardKey> (Titan Mobile/Sapphire Touch) bzw. <Keys.HardKey>NEXT TIME</Keys.HardKey>
+    (Tiger Touch/Pearl Expert))*.
+
+### Fade Modes
+
+Die eingegebenen Zeiten werden abhängig vom 'Fade Mode' (Überblendmodus) wie folgt interpretiert (auch erreichbar 
+über <Keys.SoftKey>Options</Keys.SoftKey> auf dem Reiter <Keys.SoftKey>Fader</Keys.SoftKey>):
+
+-   <Keys.SoftKey>Mode 0</Keys.SoftKey> - die Kanäle blenden in der vorgegebenen Zeit über, die
+    Ausblendzeit wird dabei ignoriert. Stehen die Zeiten auf '0', so
+    werden HTP-Kanäle direkt mit dem Fader eingeblendet, während
+    LTP-Kanäle 'hart' umschalten.
+
+-   <Keys.SoftKey>Mode 1</Keys.SoftKey> - die Kanäle blenden in der vorgegebenen Zeit ein, HTP Kanäle
+    blenden in der vorgegebenen Ausblendzeit aus (LTP-Kanäle behalten
+    ihre Werte). Stehen die Zeiten auf '0', so werden HTP-Kanäle direkt
+    mit dem Fader eingeblendet, während LTP-Kanäle 'hart' umschalten.
+
+-   <Keys.SoftKey>Mode 2</Keys.SoftKey> - die Kanäle blenden in der vorgegebenen Zeit ein, die
+    Ausblendzeit wird ignoriert. Das Überblenden stoppt, sobald die
+    Position des Fader erreicht ist; steht dieser etwa auf 50%, so
+    erfolgt das Überblenden nur zur Hälfte. Bringt man den Fader wieder
+    auf '0', so kehren die Kanäle zu den vorherigen Werten zurück.
+    Stehen die Zeiten auf '0', so werden HTP- und LTP-Kanäle direkt mit
+    dem Fader gesteuert.
+	
+    In diesem Modus kehren LTP-Kanäle generell zu den vorherigen Werten zurück, sobald der Cue deaktiviert wird.
+
+    *Mit Mode 2 lässt sich z.B. auch eine manuelle Verfolgersteuerung etwa für einen Laufsteg realisieren, 
+	indem der Cue nur Pan/Tilt enthält und dann auf Mode 2 gestellt wird. Dieser Modus bietet sich auch für die 
+	Steuerung der einzelnen Farben bei RGB-Lampen an*.
+
+-   <Keys.SoftKey>Mode 3</Keys.SoftKey> - Crossfade (Überblendung). Sämtliche Kanäle, einschließlich
+    der Helligkeit, blenden zu den Einstellungen des neuen Cues über,
+    alle anderen noch aktiven Cues werden ausgeblendet und deaktiviert.
+    Wird ein anderer Cue wieder benötigt, so bringen Sie dessen Regler
+    auf '0' und dann wieder auf den gewünschten Wert.
+
+>   Enthält der Cue Shapes, so ändern sich diese mit den eingestellten
+    Überblendzeiten. Im <Keys.SoftKey>Mode 1</Keys.SoftKey> ändern sich die Shapes abhängig von den
+    Zeiten, in <Keys.SoftKey>Mode 2</Keys.SoftKey> abhängig von der Faderstellung. Damit lassen sich
+    etwa Shapes realisieren, die abhängig vom Fader schneller oder
+    größer werden.
+
+## Ändern der Reihenfolge der Geräte
+
+Die Reihenfolge der Geräte in einem Cue lässt sich nachträglich ändern.
+Normalerweise wird diese mit der Reihenfolge der Auswahl der Geräte beim
+Erstellen des Cues oder der Gruppe, sofern eine angewählt wurde, festgelegt, 
+aber ggf. möchte man diese später ändern *(etwa, um Geräte bei der Nutzung von [Fixture Overlap](#einstellen-von-überblendzeiten-und-geräteversatz) 
+paarweise zusammenzufassen)*.
+
+1. Drücken Sie <Keys.SoftKey>Edit Times</Keys.SoftKey> im Hauptmenü.
+2. Drücken Sie die **Auswahltaste** des zu ändernden Cues.
+3. Drücken Sie <Keys.SoftKey>Fixture Order</Keys.SoftKey>.
+4. Wählen Sie die Schrittnummer, ab der Sie beginnen möchten, mit der
+Menütaste <Keys.SoftKey>Step Number</Keys.SoftKey>.
+5. Soll die Schrittnummer automatisch erhöht werden, so stellen Sie
+<Keys.SoftKey>Autoincrement</Keys.SoftKey> auf **On**. Sollen mehrere Geräte die gleiche
+Schrittnummer bekommen, stellen Sie diese Option auf **Off**.
+6. Betätigen Sie die Schaltfläche des Gerätes, das Sie an dieser Stelle
+in der Sequenz haben möchten. Die Schrittnummer wird (in grün) jeweils oben rechts
+in den Geräte-Schaltflächen angezeigt.<br/>
+ ![Fixtures Window setting Fixture Order](/docs/images/Fixtures-Window-showing-fixture-order.png)
+7. Drücken Sie <Keys.HardKey>Exit</Keys.HardKey>, um das Menü zu beenden.
+
+-   Ebenso kann man mehreren Geräten die gleichen Schrittnummern geben.
+    Damit lässt sich erreichen, dass bei Verwendung des Geräteversatzes
+	([Fixture Overlap](#einstellen-von-überblendzeiten-und-geräteversatz)) 
+    mehrere Geräte gleichzeitig beeinflusst werden.
+
+-   Einzelne Geräte kann man auch komplett aus der Folge entfernen;
+    schalten Sie dazu <Keys.SoftKey>Autoincrement</Keys.SoftKey> auf 'Off' und klicken Sie die
+    Geräteschaltfläche zweimal (daraufhin wird statt der Schrittnummer ein 'X'
+    angezeigt). Betätigen Sie die Geräte-Schaltfläche nochmals, um das
+    Gerät wieder in die Folge aufzunehmen.
+
+## Eingeben von Überblendzeiten für einzelne Attribute
+
+Es lassen sich spezifische Überblendzeiten für die einzelnen
+Attributgruppen vergeben (etwa für 'Position'). Wird eine solche Zeit
+eingegeben, so überschreibt diese die allgemein vergebenen Zeiten.
+
+Zur Eingabe der Überblendzeit für Attributgruppen gehen Sie wie folgt
+vor:
+
+1. Drücken Sie <Keys.SoftKey>Edit Times</Keys.SoftKey> im Hauptmenü.
+2. Drücken Sie die **Auswahltaste** des jeweiligen Cues.
+3. Drücken Sie die Taste der Attributgruppe (IPCGBES Buttons, oder 
+rechts auf dem Pult bei älteren Pulten) des Attributes, das Sie ändern möchten.
+4. Drücken Sie <Keys.SoftKey>Delay = </Keys.SoftKey> zur Eingabe einer Verzögerung oder <Keys.SoftKey>Fade = </Keys.SoftKey> 
+zur Eingabe einer Überblendzeit.
+5. Geben Sie die gewünschte Zeit mit den Zifferntasten, gefolgt von
+<Keys.HardKey>Enter</Keys.HardKey>, ein, oder drücken Sie <Keys.HardKey>Back</Keys.HardKey>, um die eingegebenen
+Attributzeiten zu löschen und die allgemeinen Zeiten des Cues zu
+verwenden.
+6. Drücken Sie <Keys.HardKey>Enter</Keys.HardKey> zum Speichern der Änderungen.
+
+Dies lässt sich weiter verfeinern, indem man etwa jedem einzelnen Gerät
+unterschiedliche Zeiten gibt. Sobald Sie einen Cue zum Ändern auswählen,
+sehen Sie, dass automatisch alle Geräte des Cues angewählt sind. Um nur
+die Zeiten einzelner Geräte zu ändern, ändern Sie die Geräteauswahl mit den
+entsprechenden Auswahl-Schaltflächen.
+
+Das [Fenster Cue View](editing-cues.md#cue-view) erscheint, sobald die Zeiten
+editiert werden. Innerhalb dieses Fensters kann man direkt Geräte und
+Attribute zum Editieren auswählen.
+
+Betätigen Sie die Taste <Keys.HardKey>ALL</Keys.HardKey>, um wieder alle Geräte in dem Cue
+auszuwählen.
+
+Innerhalb des Menüs 'Set Attribute Times' lassen sich nur Geräte
+auswählen, die bereits in dem Cue enthalten sind.
+
+## Editieren der Zeiten im Programmer
+
+Die Zeiten im Programmierspeicher lassen sich vor dem Speichern eines
+Cues überprüfen und ändern. Ebenso lassen sich Zeiten einstellen und in
+bestehende Cues verschmelzen ([mergen](editing-cues.md#editieren-eines-cues-durch-verschmelzen-merge)), genau wie man Attribut-Werte verschmilzt.
+
+Drücken Sie die Taste <Keys.HardKey>TIME</Keys.HardKey>, um in dieses Menü zu gelangen,
+oder die Menütaste <Keys.SoftKey>Edit Times</Keys.SoftKey> im Hauptmenü.
+
+>   Auf dem Titan Mobile und dem Sapphire Touch liegt diese Funktion auf
+    der Taste oberhalb der <Keys.HardKey>Clear</Keys.HardKey>-Taste (Taste <Keys.HardKey>SET</Keys.HardKey>). Auf dem Tiger
+    Touch und dem Pearl Expert ist es die Taste <Keys.HardKey>NEXT TIME</Keys.HardKey>.
+
+Es lassen sich Zeiten für den gesamten Cue, für einzelne Geräte, für
+Attributgruppen oder einzelne Attribute einstellen.
+
+![Edit Programmer Cue Times in the Titan Go interface](/docs/images/Edit-Programmer-Cue-Times-in-the-Titan-Go-interface.png)
+
+Unter Verwendung der Taste <Keys.HardKey>TIME</Keys.HardKey> gibt es folgende Tastatur-Syntax:
+
+-   <Keys.HardKey>Time</Keys.HardKey> <Keys.HardKey>5</Keys.HardKey> = 5 s Einfadezeit.
+
+-   <Keys.HardKey>CUE</Keys.HardKey> <Keys.HardKey>3</Keys.HardKey> <Keys.HardKey>Time</Keys.HardKey> <Keys.HardKey>5</Keys.HardKey> = 5 s Einfadezeit für Cue 3 der verbundenen
+    Cueliste.
+
+-   <Keys.HardKey>Time</Keys.HardKey> <Keys.HardKey>FIXTURE</Keys.HardKey> <Keys.HardKey>5</Keys.HardKey> = 5 s Einfadezeit für alle Attribute der
+    gewählten Geräte.
+
+-   <Keys.HardKey>Time</Keys.HardKey> <Keys.HardKey>FIXTURE</Keys.HardKey> <Keys.HardKey>G</Keys.HardKey> <Keys.HardKey>5</Keys.HardKey> = 5 s Einfadezeit für die Gobo-Kanäle der
+    gewählten Geräte.
+
+-   <Keys.HardKey>Time</Keys.HardKey> <Keys.HardKey>FIXTURE</Keys.HardKey> <Keys.HardKey>\@B</Keys.HardKey> <Keys.HardKey>5</Keys.HardKey> = 5 s Einfadezeit für das momentan
+    auf Rad B liegende Attribut der gewählten Geräte.
+
+-   <Keys.HardKey>5</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>3</Keys.HardKey> = 5 s Einfadezeit, 3 s Delay.
+
+-   <Keys.HardKey>5</Keys.HardKey> <Keys.HardKey>AND</Keys.HardKey> <Keys.HardKey>2</Keys.HardKey> = 5 s Ein-, 2 s Ausfadezeit.
+
+-   <Keys.HardKey>1</Keys.HardKey> <Keys.HardKey>THRO</Keys.HardKey> <Keys.HardKey>10</Keys.HardKey> = Auffächern der Zeit zwischen den gewählten Geräten
+    in der Reihenfolge deren Auswahl.
+
+<Video videoId="GHq9b3PT8U0" title="Timing Syntax" />
+
+Zeiten für einzelne Attribute lassen sich auch mit den Encodern
+einstellen; wählen Sie dazu mit der Funktionstaste <Keys.SoftKey>Wheels</Keys.SoftKey> im
+Hauptmenü die gewünschte Arbeitsweise der Räder.
+
+Mit der Taste <Keys.HardKey>Options</Keys.HardKey> lassen sich, während die Zeiten angezeigt
+werden, die Parameter **Speed**, **Effect Multiplier**, **Speed Multiplier** und
+&nbsp;**Speed Source** im Programmer, so dass sie einfach direkt in die nächsten
+Playbacks gespeichert werden können. Speed und Speed Multiplier haben nur
+Auswirkungen auf [Chaser](../chases.md), nicht auf einzelne Cues.
+
+![Edit Programmer Rate Settings Menu, found by pressing Options](/docs/images/Edit-Programmer-Rate-Settings-Menu-found-by-pressing-Options.png)

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues/editing-cues.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues/editing-cues.md
@@ -1,0 +1,247 @@
+---
+id: editing-cues
+title: Editieren von Cues
+sidebar_label: Editieren von Cues
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Editieren eines Cues durch Verschmelzen (Merge)
+
+Jeder Cue lässt sich ganz einfach ändern, indem man die Änderungen
+vornimmt, und die neuen Einstellungen mit in den gleichen Cue speichert.
+
+1. Drücken Sie <Keys.HardKey>Clear</Keys.HardKey>, um den Programmierspeicher zu leeren.
+2. Rufen Sie den zu ändernden Cue auf, um die Änderungen sehen zu können; *deaktivieren Sie dazu andere Cues*.
+3. Wählen Sie die zu ändernden Geräte, und nehmen Sie die gewünschten Änderungen vor.
+4. Drücken Sie <Keys.HardKey>Record</Keys.HardKey>.
+5. Drücken Sie die **Auswahltaste** des zu ändernden Cues.
+6. Drücken Sie <Keys.SoftKey>Merge</Keys.SoftKey> *(dabei wird der aktuell zu ändernde Cue am
+Bildschirm hervorgehoben)*.
+7. Das Pult fügt daraufhin die vorgenommenen Änderungen in den Cue ein; unveränderte Werte bleiben erhalten.
+
+-   Um den Cue komplett zu überschreiben, wählen Sie bei Schritt 6 die Option <Keys.SoftKey>Replace</Keys.SoftKey>
+(Ersetzen). Bitte berücksichtigen: damit werden Geräte, die nicht aktuell verändert wurden (und damit auch nicht im
+Programmierspeicher sind), nicht in dem Cue gespeichert!
+
+-   Um die Arbeit zu beschleunigen, können Sie die Option 'Always Merge' (immer Verschmelzen) aktivieren. Diese befindet
+sich auf dem [Tab 'Handles'](../system-settings/user-settings.md#handles) der Benutzereinstellungen (drücken Sie die Taste <Keys.HardKey>AVO</Keys.HardKey>
+und wählen im Menü <Keys.SoftKey>User Settings</Keys.SoftKey>).
+
+-   Sie können auch die **Auswahltaste** des zu bearbeitenden Cues ein zweites Mal betätigen, um die
+Option **Merge** anzuwenden (schneller als die Schaltfläche <Keys.SoftKey>Merge</Keys.SoftKey>)
+
+## Aktualisieren gespeicherter Werte und Paletten
+
+Muss ein Cue oder eine im Cue verwendete Palette während der Show
+verändert werden *(wenn z.B. der Grün-Ton nicht exakt die gewünschte
+Farbe trifft)*, so lässt sich das einfach per <Keys.HardKey>Update</Keys.HardKey> realisieren; dabei
+kann entweder der Cue oder die enthaltene Palette aktualisiert werden.
+
+Um den Cue zu aktualisieren, nehmen Sie die erforderlichen Änderungen
+vor und drücken zweimal <Keys.HardKey>Update</Keys.HardKey>.
+
+1. Während der Cue gestartet ist, wählen Sie die betreffenden Geräte aus und stellen die gewünschten Werte ein.
+2. Drücken Sie <Keys.HardKey>Update</Keys.HardKey> *(auf älteren Pulten: <Keys.HardKey>Record Cue</Keys.HardKey>, 
+   dann <Keys.SoftKey>Update</Keys.SoftKey>)*.
+3. Drücken Sie <Keys.HardKey>Enter</Keys.HardKey>, um sofort die neuen Werte im Cue zu speichern.
+
+Alternativ werden die [Paletten](../palettes.md) und Cues, die upgedatet werden
+können, im Bildschirm angezeigt; wählen Sie die gewünschten aus.
+
+In diesem Fall bestätigen Sie die Auswahl mit <Keys.HardKey>Enter</Keys.HardKey>.
+
+-   Sie können auch die Paletten durch zweimaliges Betätigen
+    der jeweiligen Schaltfläche updaten.
+
+-   Soll der vormalige Wert einer Palette mit einem manuellen Wert
+    überschrieben werden, so drücken Sie <Keys.HardKey>Update</Keys.HardKey>-<Keys.HardKey>Update</Keys.HardKey>. Soll
+    hingegen die Palette aktualisiert werden, so nutzen Sie die
+    Menütasten oder drücken die <Keys.HardKey>Palette</Keys.HardKey>-Taste.
+
+-   Wird ein Attribut durch eine andere Palette überschrieben, wird
+    stattdessen die neue Palette gespeichert.
+
+## Anzeige der Cues: Playback View und Cue View
+
+Zum Anzeigen der Zeiteinstellungen des Cues klicken Sie auf das Display
+oberhalb der Regler, oder Sie drücken <Keys.HardKey>Open / View</Keys.HardKey> und dann
+die **Auswahltaste** des Cues. Im Bildschirm erscheinen daraufhin Details
+zu Verzögerungs- und Überblendzeit, Geräteüberblenden, und Einstellung
+der Reglerkurve. Jeder Wert lässt sich durch Anklicken zum Ändern
+auswählen.
+
+Ist in dem Cue ein [Shape oder Effekt](../effects.md) gespeichert, so gibt es in der
+entsprechenden Spalte extra einen Button, nach dessen Anklicken man den
+Effekt editieren kann.
+
+In der Spalte **Effect Speed** lässt sich ein Speed-Faktor für den Effekt
+in diesem Cue eintragen.
+
+Klickt man Links auf den Button **Times**, so werden einige Spalten
+ausgeblendet, so dass man nur noch die Timing-Werte angezeigt bekommt.
+
+![Playback View for cue](/docs/images/Playback-View-for-cue.png)
+
+### Filtern -- Nur einzelne Spalten anzeigen
+
+Mittels der Kontext-Funktion <Keys.SoftKey>Edit Columns</Keys.SoftKey> lässt sich noch genauer
+einstellen, welche Spalten in der Playback-Ansicht angezeigt werden. Hat man seine Auswahl getroffen, lässt 
+sich diese links als Filter abspeichern.
+
+1. Klicken Sie auf <Keys.SoftKey>Edit Columns</Keys.SoftKey> im Kontext-Bereich.
+2. Mit den Menütasten aktivieren/deaktivieren Sie die gewünschten Spalten.
+3. Drücken Sie auf die Taste <Keys.HardKey>Record</Keys.HardKey>. Daraufhin wird am unteren Rand
+des Playback-View-Fensters ein <Keys.SoftKey>Add</Keys.SoftKey>-Button eingeblendet.
+4. Klicken Sie auf <Keys.SoftKey>Add</Keys.SoftKey>, um einen Filter für Ihre Ansicht zu speichern.
+5. Sie können Ihren Filter wie gewohnt mittels Set Legend umbenennen sowie mit einem Halo versehen.
+6. Zum Löschen Ihrer Filter drücken Sie <Keys.HardKey>Delete</Keys.HardKey> und klicken auf den zu löschenden
+Filter-Button.
+
+### Cue View
+
+Betätigen Sie die Schaltfläche <Keys.SoftKey>View</Keys.SoftKey> am rechten Zeilenende oder die
+<Keys.SoftKey>View Cue</Keys.SoftKey>-Kontext-Schaltfläche, so erscheint das Fenster 'Cue View'
+mit sämtlichen Details der Einstellungen zu allen einzelnen Geräten in dem gewählten Cue.
+
+Das Fenster 'Cue View' bietet vier unterschiedliche Anzeigen: **Levels**
+(Werte), **Palettes** (Paletten), **Times** (Zeiten) und **Shapes**. Die
+einzelnen Anzeigen lassen sich mit den Schaltflächen links der
+Menütasten umschalten.
+
+-   Die Anzeige **Levels** zeigt die Werte der einzelnen Attribute für jedes Gerät.
+
+-   Die Anzeige **Palettes** zeigt die in dem Cue verwendeten Paletten mit ihren Namen. Ist statt einer Palette ein
+  absoluter Wert verwendet worden, so wird dieser angezeigt. Auch hier lassen sich die Werte ändern oder löschen.
+
+-   Die Anzeige **Times** zeigt die Zeiteinstellungen für die einzelnen Attribute der Geräte an. Werden globale Zeiten
+ verwendet, so werden in dieser Anzeige keine Zeiten dargestellt.
+
+-   In der Anzeige **Shapes** wird dargestellt, welche Shapes auf einzelnen Attributen zur Anwendung kommen.
+
+![Cue View](/docs/images/Cue-View-2.png)
+
+Mit den Buttons All/IPCGBES oben links können die anzuzeigenden **Attribute** ausgewählt werden.
+
+Mit den Gerätetyp-Buttons links unterhalb der Attribut-Buttons kann man die anzuzeigenden **Geräte** auswählen.
+
+### Editieren von Werten im Cue View
+
+Es lassen sich die Werte einzelner oder mehrerer Kanäle **ändern** oder **löschen**:
+
+1.  Klicken Sie den entsprechenden Wert an, oder fahren Sie über den gewünschten Bereich: *die ausgewählten Werte 
+ werden in blau	hervorgehoben*.
+2.  Auf den Menütasten erscheinen daraufhin die für das gewählte Attribut verfügbaren Optionen, ferner lässt sich mit 
+ den Zifferntasten direkt ein numerischer Wert eingeben und mit <Keys.HardKey>Enter</Keys.HardKey> bestätigen.
+3.  Einzelne Attribute lassen sich mit der Taste <Keys.HardKey>Off</Keys.HardKey> sowie den Menütasten
+ <Keys.SoftKey>Off</Keys.SoftKey> und <Keys.SoftKey>On</Keys.SoftKey> temporär deaktivieren und wieder aktivieren, 
+ ohne sie komplett aus dem Cue zu löschen. 
+4.  Um ein Gerät komplett aus einem Cue zu entfernen, wählen Sie dieses aus	und klicken 
+ auf <Keys.SoftKey>Remove Fixtures</Keys.SoftKey>.
+
+Sämtliche Änderungen werden sofort wirksam.
+
+## Cues wiederverwenden - die 'Include'-Funktion
+
+Mit der 'Include'-Funktion lassen sich ausgewählte Teile eines Cues
+zurück in den Programmierspeicher laden (normalerweise werden nur
+manuelle Änderungen in den Programmierspeicher geschrieben). Diese
+lassen sich dann etwa zum Anlegen eines neuen Cues verwenden. Dies ist
+sinnvoll z.B. beim Anlegen eines Cues, der einem bereits vorhandenen
+ähnlich ist, oder um einen neuen Cue aus verschiedenen Teilen mehrerer
+anderer Cues zusammenzustellen. Auch zum Editieren von Shapes in Cues
+ist Include erforderlich,
+
+Es gibt zwei Arbeitsweisen: 'Quick' (Schnell) Include, und 'Advanced'
+(mit weitergehenden Optionen) Include. **Quick Include** lädt einfach den
+kompletten Cue, während bei **Advanced Include** die zu ladenden Geräte
+und Attribute einzeln ausgewählt werden können. Hat man etwa einen Cue
+mit Positions-, Farb- und Goboinformationen für 8 Geräte, so lassen sich
+mit dieser Funktion z.B. nur die Farben von vier Geräten in den
+Programmierspeicher laden. Daraufhin kann man etwa die
+Positions-Information aus einem anderen Cue laden, und so nach und nach
+einen neuen Cue aus mehreren bestehenden zusammenstellen.
+
+Wird 'Include' auf einen [Chaser](../chases.md) oder eine [Cueliste](../cue-lists.md)
+angewendet, so zeigt das Display eine Liste der darin enthaltenen 
+einzelnen Cues, um den gewünschten auswählen zu können (mit Encoder A, 
+oder ganz einfach durch Anklicken). Ebenso kann man die Nummer des 
+gewünschten Schrittes mit den Zifferntasten eingeben.
+
+1.  Drücken Sie <Keys.HardKey>Include</Keys.HardKey>.
+2.  Drücken Sie <Keys.SoftKey>Quick Include</Keys.SoftKey> oder <Keys.SoftKey>Advanced Include</Keys.SoftKey>, um den 
+ Modus zu wechseln.
+3.  Drücken Sie die **Auswahltaste** des Cues, den Sie in den Speicher laden möchten. Haben Sie den 
+ Modus **Quick Include** gewählt, so wird damit der Cue in den Speicher geladen, und der Vorgang ist abgeschlossen.
+4.  Befinden Sie sich im Modus **Advanced Include**, so werden alle in dem Cue
+	enthaltenen Geräte ausgewählt. Werden nicht alle gewünscht, so wählen
+	Sie die übrigen nun ab. Die ausgewählten Geräte werden auf den
+	Geräte-Schaltflächen und -Tasten hervorgehoben.
+5.  Verwenden Sie <Keys.SoftKey>Set Mask</Keys.SoftKey> oder die Attribut-Auswahltasten, um die
+	zu ladenden Attribute auszuwählen *(standardmäßig sind alle ausgewählt;
+	Taste <Keys.HardKey>C</Keys.HardKey> wählt alle ab, Taste <Keys.HardKey>D</Keys.HardKey> wählt alle wieder an)*. Taste
+	<Keys.HardKey>E</Keys.HardKey> aktiviert oder deaktiviert das Laden von Shapes aus dem Cue.
+6.  Drücken Sie <Keys.HardKey>Enter</Keys.HardKey>. Die ausgewählten Attribute der ausgewählten
+	Geräte werden in den Programmierspeicher geladen.
+7.  Wiederholen Sie die Schritte 2 bis 6 zum Includen weiterer Attribute
+	der gleichen Geräte oder ab Schritt 1 für weitere Geräte.
+
+>   Im Modus **Quick Include** lässt sich eine Maske der zu wählenden
+    Attribute erstellen; betätigen Sie dazu eine oder mehrere
+    Attributtasten vor der Anwahl des gewünschten Cues.
+
+## Deaktivieren von Attributen in Cues mit "Off"
+
+<Video videoId="p7Ffz4e4tws" title="Off" />
+
+Mit der <Keys.HardKey>Off</Keys.HardKey>-Taste lässt sich ein Attribut in einem Cue deaktivieren,
+als ob es nie in diesem gespeichert gewesen wäre - es kann später wieder
+aktiviert werden.
+
+Angenommen, Sie haben einen Cue programmiert, in dem etwa ein paar
+Scanner auf einer bestimmten Position mit grün als Farbe abgespeichert
+sind. Wollen Sie nun die Farbe aus diesem Cue deaktivieren, so dass die
+Lampen die Einstellung aus dem vorher abgerufenen Cue zeigen, so setzen
+Sie die Farbwerte auf 'Off' und speichern den Cue wie gewohnt. Die 
+"Off"-Funktion lässt sich ebenso nutzen, um ganze Geräte in einem Cue 
+zu deaktivieren, indem man sämtliche Attribute auf "Off" setzt.
+
+Ein Attribut auf **"Off"** zu setzen ist nicht gleichzusetzen mit dem Setzen
+des Attributes auf "0", denn das würde einen Wert für das Attribut
+bedeuten, der beim Aufruf des Cue abgerufen würde. "Off" ist vielmehr
+gleichbedeutend mit dem Deaktivieren des Attributs in diesem Cue, so dass 
+das Attribut beim Aufruf des Cues unbeeinflusst bleibt.
+
+1. Drücken Sie <Keys.HardKey>Off</Keys.HardKey>, dann <Keys.SoftKey>Off Playback Values</Keys.SoftKey>, gefolgt von der
+	**Auswahltaste** des zu ändernden Cues.
+2. Alle Geräte in dem Cue sind nun ausgewählt. Wählen sie ggf. Geräte ab, die Sie nicht Off schalten wollen.
+3. In der Attributmaske sind alle Attribute angewählt. Wählen Sie ggf.
+per <Keys.SoftKey>Set Mask</Keys.SoftKey> einzelne Attribute ab, die nicht Off geschaltet werden sollen.
+4. Klicken Sie auf <Keys.SoftKey>Off</Keys.SoftKey>.
+
+Werte lassen sich auch unter Verwendung der <Keys.HardKey>Include</Keys.HardKey>-Funktion auf Off
+setzen:
+
+1. Verwenden Sie **Quick Include** (siehe [voriger
+Abschnitt](./editing-cues.md#cues-wiederverwenden---die-include-funktion)), um den Cue in den Programmierspeicher zu laden.
+2. Betätigen Sie die <Keys.HardKey>Off</Keys.HardKey>-Taste, um das 'Off'-Menü anzuzeigen.
+3. Alle Geräte in dem Cue werden ausgewählt. Wollen Sie nicht alle
+verändern, so entfernen Sie die Geräte einzeln aus der Auswahl.
+4. Wählen Sie mit den Attributbank-Buttons die Off zu schaltenden
+Attributbänke und drücken Sie <Keys.SoftKey>Attributes Off</Keys.SoftKey>. Außerdem kann man mit
+den Menütasten auch einzelne Attribute Off schalten, z.B. <Keys.SoftKey>Dimmer Off</Keys.SoftKey>.
+5. Drücken Sie <Keys.HardKey>Record</Keys.HardKey>, dann die **Auswahltaste** des Cues, und schließlich 
+<Keys.SoftKey>Replace</Keys.SoftKey> zum Speichern der Änderungen.
+
+-   Um alle Attribute aller angewählten Geräte Off zu schalten, drücken
+    Sie <Keys.HardKey>Off</Keys.HardKey> gefolgt von <Keys.SoftKey>Selected Fixtures Off</Keys.SoftKey>.
+
+-   "Off"-Einstellungen lassen sich auch ohne vorheriges Includen in einen Cue übernehmen (**Merge**).
+
+-   Ebenso lassen sich mit der Off-Funktion einzelne Attribute aus gespeicherten Paletten entfernen.
+
+-   Eine weitere Möglichkeit zum Entfernen von Attributen ist das [Cue View-Fenster](#cue-view).
+
+-   Mittels **Off** deaktivierte Attribute lassen sich wieder aktivieren. Stellen Sie dazu das Attribut 
+auf **On**, und **verschmelzen (mergen)** Sie das in den bestehenden Cue.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues/playback-options.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/cues/playback-options.md
@@ -1,0 +1,236 @@
+---
+id: playback-options
+title: Playback-Optionen
+sidebar_label: Playback-Optionen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+<Video videoId="Dz_lWDHukxo" title="Playback Options" />
+
+Zum Einstellen der Optionen eines Cues, einer Cueliste oder eines
+Chasers drücken Sie <Keys.SoftKey>Options</Keys.SoftKey> im Hauptmenü oder die Taste <Keys.HardKey>Options</Keys.HardKey> und anschließend die **Auswahltaste** der entsprechenden Playbacks. Darauf werden 
+alle verfügbaren Optionen übersichtlich in einem Fenster dargestellt(die Optionen können außerdem wie früher mit den Menütasten bearbeitet werden). 
+
+Auch die Zeiten lassen sich hier einstellen (auf dem Reiter <Keys.SoftKey>Times</Keys.SoftKey> oder mit der Taste <Keys.HardKey>Times</Keys.HardKey>).
+
+Alle verfügbaren Optionen sind auf verschiedene Reiter aufgeteilt. 
+Ein Klick auf den Button <Keys.SoftKey>i</Keys.SoftKey> zeigt einen kurzen Hilfetext zu der jeweiligen
+Option.
+
+> Sollen die Optionen für mehrere Playbacks auf einmal angezeigt/geändert werden, so kann man einfach mehrere Playbacks auswählen. Dabei werden Optionen als aktiv angezeigt, sofern sie auf allen Playbacks gleich aktiviert sind; anderenfalls wird ein Sternchen angezeigt.
+
+## Tab "Handle"
+
+![Playback Options window for cue showing handle tab](/docs/images/Playback-Options-Handle-Tab.png)
+
+### Handle Paging
+Mit dieser Option lässt sich ein Playback 'fixieren',
+so dass es unabhängig vom Wechsel der Seiten stets verfügbar bleibt.
+Dies bietet sich an, wenn man ein paar allgemeine Cues hat, die auf
+jeder Seite benötigt werden, ohne dass man diese extra kopieren muss.
+
+Einstellung | Ergebnis
+------|------
+Unlocked | Voreinstellung, das Playback wird normal umgeschaltet.
+Transparent Lock | Das Playback wird auf alle Seiten eingeblendet, auf denen nicht schon etwas anderes auf dem entsprechenden Regler programmiert ist.
+Locked | Das Playback wird auf allen Seiten auf den gleichen Regler eingeblendet. Etwa dort bereits programmierte Cues etc. sind nicht erreichbar.
+
+### Key Profile
+Auswahl des [Tastenprofils/Key Profiles](../system-settings/key-profiles.md) 
+für das Playback. 'Global' stellt etwa vorhandene einzelne Einstellungen auf 
+den global gültigen Wert zurück.
+
+## Tab "Playback"
+
+![Playback Options showing playback tab](/docs/images/Playback-Options-Playback-Tab.png)
+
+### Blind
+Schaltet das jeweilige Playback in den **Blind**-Modus. Damit
+erfolgt die Ausgabe nicht an die 'Live'-DMX-Ausgänge, sondern an den
+Visualiser, *um Änderungen vornehmen zu können, ohne das aktuelle Bild zu
+stören*.
+
+### Cross Fade HTP
+Sofern aktiviert, überschreiben HTP-Kanäle (Dimmer)
+in diesem Playback die Informationen für diese Kanäle aus anderen
+Playbacks, wobei die [Priorität](#priority) der Playbacks beachtet wird.
+Normalerweise folgen Dimmerkanäle ja der HTP-Regel, d.h. der höhere Wert
+wird ausgegeben. Doch mit dieser Option lassen sich Playbacks erstellen,
+bei denen der zuletzt gesendete - auch niedrigere - Wert
+berücksichtigt wird.
+
+### Priority
+Damit lässt sich das Verhalten bestimmen, wenn mehrere
+aktive Cues gleichzeitig dieselben Geräte beeinflussen. Die Priorität
+lässt sich zwischen **Low** (niedrig), **Normal** (normal), **High** (hoch),
+&nbsp;**Programmer** (Programmierspeicher) und **Very High** (sehr hoch)
+umschalten *('Programmer' ist gleichwertig mit der Priorität des
+Programmierspeichers)*. Wird ein Gerät aktuell von einem Cues gesteuert,
+und dann ein Cue mit gleicher oder höherer Priorität gestartet, so
+übernimmt der neue Cue die Kontrolle. Hat hingegen der neue Cue eine
+niedrigere Priorität, so erfolgt keine Änderung am Gerät.
+
+Ein Anwendungsfall wäre etwa, wenn man mit sämtlichen Geräten ein
+bestimmtes Bild programmiert hat und später entscheidet, ein paar Geräte
+davon z.B. als Spot auf den Sänger zu verwenden. Setzt man nun die
+Priorität des 'Spot'-Cues höher, so werden die dafür verwendeten Geräte
+von den anderen Cues nicht beeinflusst.
+
+
+> Priorisierung ist etwa hilfreich, wenn mit **Swop**-Tasten ein Strobe programmiert werden soll, das solange alle anderen Cues ausblendet. Wenn z.B. ein Positions-Shape läuft, so soll der natürlich nicht stoppen, da sonst ggf. alles ‚durcheinander' aussieht. Entsprechend empfiehlt es sich, das Playback mit dem Shape auf eine höhere Priorität zu setzen, so dass es vom Swop nicht ausgeblendet wird.
+
+Wird manuell eine Palette aufgerufen, so haben deren Werte eine
+höhere Priorität als Werte in Cues, außer in solchen mit der Priorität 'Very High'.
+
+### Run On Startup
+Ist dies eingeschaltet, so wird das Playback beim
+Start des Pultes bzw. Laden der Show aktiviert. Dazu gehört die
+Benutzereinstellung [Run Startup Playbacks](../system-settings/user-settings.md#general-allgemein) *(Vorgabewert: ein)*.
+
+Sinnvoll z.B. für Festinstallationen, wenn beim Starten des Pultes direkt 
+ein Grundlicht aktiviert werden soll.
+
+Playbacks, die beim Start der Software automatisch starten, zeigen dies durch 
+ein Einschalt-Symbol an. Im [Show-Verzeichnis](../titan-basics/show-library.md) 
+gibt es einen Kontext-Button, um die automatisch aktivierten Playbacks anzuzeigen.
+
+![Power On Playback](/docs/images/Power-On-Playback.png)
+
+Außerdem kann es sinnvoll sein, eine Standard-Show zu festzulegen, die immer beim Start geladen wird. 
+Damit wird vermieden, versehentlich eine falsche Show zu starten. Dafür gibt es im Disk-Menü den Punkt 
+**Start Up Show**, siehe [Eine Show zum automatischen Starten festlegen](../titan-basics/loading-and-saving-shows.md#eine-show-zum-automatischen-starten-festlegen).
+
+## Tab "Times"
+
+![Playback Options showing times tab](/docs/images/Playback-Options-Times-Tab.png)
+
+### Delay In/Fade In/Fade Out 
+Hier können die jeweiligen Zeiten
+eingestellt werden. Das kann auch mit der <Keys.HardKey>Time</Keys.HardKey>-Taste erfolgen.
+
+### Fixture Overlap
+Mit Fixture Overlap - Geräte-Überlappung - werden Änderungen von einem 
+Cue zum nächsten auf die einzelnen Fixtures nacheinander statt gleichzeitig 
+angewendet. Genauer ist dies in [Einstellen von Überblendzeiten und Geräteversatz](../cues/cue-timing.md#einstellen-von-überblendzeiten-und-geräteversatz) erläutert.
+
+### Flash Fade In / Flash Fade Out
+Ein- und Ausfadezeit beim Flashen
+per Flash-Taste. Vorgabewerte sind *'AsIn'* und *'AsOut'*, also die normalen
+Ein-/Ausfadezeiten für den Cue. Hiermit lassen sich wenn gewünscht
+andere Flash-Fadezeiten als Fadezeiten für den Fader einstellen.
+*Voraussetzung dafür ist das [Tastenprofil/Key Profile](../system-settings/key-profiles.md) **Timed
+Flash** &nbsp;*.
+
+### Speed
+Vorgabe-Tempo für Effekte in diesem Cue. Kann durch
+entsprechende [Master](../running-the-show/playback-controls.md#speed--und-size-master) 
+überschrieben werden.
+
+## Tab "Fader"
+
+![Playback Options showing fader tab](/docs/images/Playback-Options-Fader-Tab.png)
+
+### Fader Mode
+
+Bestimmt die genaue Arbeitsweise des Faders.
+
+Einstellung | Ergebnis
+------: | ------
+**Mode 0** | die Kanäle blenden in der vorgegebenen Zeit über, die Ausblendzeit wird dabei ignoriert. Stehen die Zeiten auf '0', so werden HTP-Kanäle direkt mit dem Fader eingeblendet, während LTP-Kanäle 'hart' umschalten.
+Mode 1 | die Kanäle blenden in der vorgegebenen Zeit ein, HTP Kanäle blenden in der vorgegebenen Ausblendzeit aus (LTP-Kanäle behalten ihre Werte). Stehen die Zeiten auf '0', so werden HTP-Kanäle direkt mit dem Fader eingeblendet, während LTP-Kanäle 'hart' umschalten..
+Mode 2 | sowohl HTP- als auch LTP-Werte folgen dem Faderwert. *Sinnvoll z.B. zur Anwendung mit Pan und Tilt etwa auf einem Catwalk oder zur manuellen Steuerung der Farben bei RGB-Lampen.*
+Mode 3 | Crossfade (Überblendung). Sämtliche Kanäle, einschließlich der Helligkeit, blenden zu den Einstellungen des neuen Cues über, alle anderen noch aktiven Cues werden ausgeblendet und deaktiviert. Wird eine anderer Cue wieder benötigt, so bringen Sie dessen Regler auf '0' und dann wieder auf den gewünschten Wert. *Sinnvoll z.B. für eine Präsentationsstimmung, mit der alle anderen Playbacks ausgefadet werden.*
+
+Die gleiche Einstellung wie im [<Keys.SoftKey>Edit Times</Keys.SoftKey>](./cue-timing.md#fade-modes)-Menu.
+
+<Video videoId="2fwM5S8nX3k" title="Playback Modes" />
+
+### Curve
+Bestimmt den Verlauf der Änderungen der Attribute, wenn der
+Cue eingeblendet wird. Die verschiedenen Kurven sind [Curves](../system-settings/curves.md) näher beschrieben.
+
+### Kill Point
+Legt fest, wann der Cue released wird und die LTP-Attribute zum vorigen Wert zurückkehren. Normalerweise erfolgt das, 
+wenn alle Fadezeiten abgelaufen sind, so dass keine Änderung erfolgt, bevor der Dimmer aus ist.
+
+Einstellung | Ergebnis
+------: | ------
+**Fade Out Complete** | Cue wird deaktiviert, sobald alle Fadezeiten vorbei sind.
+Fader at 0 | Cue wird deaktiviert, sobald der Fader auf 0 ist.
+
+## Tab "Effects"
+
+![Playback Options showing effects tab](/docs/images/Playback-Options-Effects-Tab.png)
+
+### Effect Speed Multiplier
+Damit lässt sich die Geschwindigkeit vervielfachen/teilen. Das bietet sich 
+besonders an, wenn man mehrere Chaser/Effekte gleichzeitig anwendet.
+
+### Shape & Effect Speed
+Bestimmt, ob der Fader Einfluss auf das Tempo
+von Shapes auf diesem Playback hat. Steht dies auf <Keys.SoftKey>On Fader</Keys.SoftKey>, so kann
+das Tempo von 0 bis zur programmierten Geschwindigkeit stufenlos
+verändert werden. Mit dem Multiplier (s.o.) lassen sich auch höhere
+Geschwindigkeiten erzielen.
+
+> Haben Sie einen Cue, der nur Shapes enthält, um diese zu anderen Cues dazuzumischen, so empfiehlt es sich, für diesen die Einstellung <Keys.SoftKey>Size on Fader</Keys.SoftKey> vorzunehmen sowie einen [Speed Master](../running-the-show/playback-controls.md#speed--und-size-master) zu verwenden. Damit lässt sich dann flexibel und unabhängig die Größe und die Geschwindigkeit des Shapes live verändern.
+
+### Shape Behaviour
+Steuert das Verhalten von Shapes und Keyframe-Shapes in diesem Playback:
+
+Einstellung | Ergebnis
+------: | ------
+Global | Es gelten die globalen [Benutzereinstellungen](../system-settings/user-settings.md#shape-behaviour)
+Overlay | der Shape läuft unabhängig von etwaigen Attribut-Änderungen
+LTP | Attributänderungen beenden den Shape auf den jeweiligen Attributen
+
+### Shape Size
+Bestimmt, ob der Fader Einfluss auf die Größe von Shapes
+auf diesem Playback hat:
+
+Einstellung | Ergebnis
+------: | ------
+Fixed | keine Auswirkung, nur fest programmierte Werte
+Fader | die Größe aller hier programmierten Shapes wird vom Fader gesteuert
+HTP Fader | nur die Größe von Dimmer-Shapes wird durch den Fader gesteuert
+
+### Size Source
+Zuordnung eines [Size Masters](../running-the-show/playback-controls.md#speed--und-size-master)
+für enthaltene Shapes.
+
+### Speed Source
+Bestimmt einen [Speed Master](../running-the-show/playback-controls.md#speed--und-size-master), 
+der enthaltene Shapes steuert.
+
+## Tab "Release"
+
+![Playback Options showing release tab](/docs/images/Playback-Options-Release-Tab.png)
+
+### Release Mask
+Bestimmt die freizugebenden Attribute, die damit auf
+den Status vor Abruf des Cues zurückgesetzt werden, sobald der aktuelle
+beendet/ausgeblendet wird (Fader auf 0). Ebenso lassen sich dazu die
+Attribut-Tasten benutzen.
+
+Normalerweise bleiben Werte von LTP-Kanälen erhalten, auch wenn der Cue
+deaktiviert wird. Mitunter ist dies aber nicht gewünscht, z.B. bei einem
+Strobe-Cue.
+
+Klicken Sie auf den <Keys.ContextKey>Global</Keys.ContextKey> Button, um auf <Keys.ContextKey>Local</Keys.ContextKey> 
+umzuschalten, und wählen Sie dann die gewünschten Attribute aus (mit den Menütasten oder den Buttons der 
+Attributgruppen).
+
+'Global' verwendet die [Globale Release-Maske](../cues/cue-playback.md#global-release-mask).
+
+> Mit der Release-Maske lässt sich z.B. ein temporärer ('flashbarer') Strobe-Effekt programmieren. Stellen Sie **Mask** auf **Local** und **Intensity** auf **Include**. Wird nun das Playback deaktiviert, kehrt der Shutter zum vorigen Wert zurück, und das Strobe stoppt. 
+
+Per [Tastenprofil/Key Profile](../system-settings/key-profiles.md) lässt sich eine der Tasten mit der Funktion ‚Release' belegen.
+
+### Release Time
+Zum Einstellen der Zeit für das Releasen; in dieser
+Zeit werden die Attribute zum vorherigen Wert übergeblendet. Wird die
+Zeit komplett gelöscht, so wechselt der Eintrag auf *Global* (die in den
+[Benutzereinstellungen](../system-settings/user-settings.md) eingestellte [globale Release-Zeit](../system-settings/user-settings.md#master-release-time)).
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects.md
@@ -1,0 +1,24 @@
+---
+id: effects
+title: Shapes und Effekte
+sidebar_label: Shapes und Effekte
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Der **Shape-Generator** (auf Pulten anderer Hersteller wird das oft als
+Effekt-Generator bezeichnet) gestattet es, schnell beeindruckende Shows
+mit vielen Bewegungen und Wechseln bei minimalem Programmieraufwand
+erstellen. Diese lassen sich während der Wiedergabe über verschiedene 
+Steuerelemente für Größe und Geschwindigkeit detailliert beeinflussen, 
+so dass man schon mit wenigen [Cues](cues.md) beeindruckende Ergebnisse 
+erzielen kann.
+
+Titan enthält sowohl den gewohnten [Shape-Generator](effects/shape-generator.md) mit
+vorgefertigten Mustern und Abläufen, als auch den
+[Keyframe-Shapegenerator](effects/key-frame-shapes.md), mit dem sich Muster, Abläufe und Effekte selbst
+erstellen lassen.
+
+Die [Matrixsteuerung/Pixelmapper](effects/pixel-mapper.md) ermöglicht 
+es, auf im passenden Raster angeordneten Geräten (etwa LED-Strahler oder Bars, Sternvorhänge o.ä.) abstrakte 2D-Animationen zu realisieren.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects/advanced-options.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects/advanced-options.md
@@ -1,0 +1,39 @@
+---
+id: advanced-options
+title: Spezielle Optionen
+sidebar_label: Spezielle Optionen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Shapes im Fadermodus
+
+Ist ein Shape [in einem Cue gespeichert](shape-generator.md#verwenden-von-shapes-in-cues), 
+so lässt sich die Art und Weise, wie der Shape eingeblendet wird, mit <Keys.SoftKey>Edit Times</Keys.SoftKey> 
+sowie den [Optionen](../cues/playback-options.md) einstellen.
+
+Um die Größe/Geschwindigkeit abhängig vom Fader zu machen, drücken Sie
+im Hauptmenü <Keys.HardKey>Options</Keys.HardKey> (oder die Menütaste <Keys.SoftKey>Options</Keys.SoftKey>) und wählen dann 
+den Speicherplatz (Cue) aus, in dem der Shape enthalten ist.
+
+Mit den Funktionstasten <Keys.SoftKey>Fader</Keys.SoftKey> <Keys.SoftKey>Shape Size</Keys.SoftKey> 
+und <Keys.SoftKey>Fader</Keys.SoftKey> <Keys.SoftKey>Shape Speed</Keys.SoftKey> 
+können Sie Größe bzw. Geschwindigkeit auf 'fixed' (fest) oder
+'on fader' (faderabhängig) stellen. Ebenso lässt sich ein Speed Master
+oder Size Master zuweisen, siehe
+[Speed- und Size-Master](../running-the-show/playback-controls.md#speed--und-size-master).
+
+Um eine feste Einfadezeit einzustellen, drücken Sie <Keys.SoftKey>Edit Times</Keys.SoftKey>,
+wählen das Playback aus, und geben die gewünschte Fade/Delay-Zeit ein.
+
+Der [Fader-Modus](../cues/playback-options.md#fader-mode) für Playbacks 
+kann auf 0 (einfaden), 1 (ein- und ausfaden) oder 3 (crossfade) gestellt 
+werden. Bei Mode 2 hängt die Fadezeit von der Reglerstellung ab; es 
+empfiehlt sich also, wenn Shapes reglerabhängig sind, das Playback nicht 
+im Mode 2 zu verwenden.
+
+Wird eine neuer Cue aufgerufen, der die gleichen Attribute steuert (etwa
+ein zweiter Shape auf den gleichen Geräten, die in dem vorherigen Cue
+bereits mit einem Shape gesteuert werden), so wird vom bereits laufenden
+auf den neuen Shape übergeblendet.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects/editing-shapes-and-effects.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects/editing-shapes-and-effects.md
@@ -1,0 +1,145 @@
+---
+id: editing-shapes-and-effects
+title: Ändern von Shapes und Effekten
+sidebar_label: Ändern von Shapes und Effekten
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Ändern eines gerade laufenden Shapes
+
+Geschwindigkeit, Größe und Aufteilung (Spread) eines gerade laufenden
+Shapes lassen sich ändern, indem man auf <Keys.HardKey>Connect / Cue</Keys.HardKey>, gefolgt von
+<Keys.HardKey>Shape</Keys.HardKey> drückt (<Keys.HardKey>Shape</Keys.HardKey> blinkt, sofern Shapes gerade aktiv sind).
+Die Menütasten zeigen die gerade laufenden Shapes an sowie, aus welchem
+Cue oder ob sie aus dem Programmer kommen.
+
+>   Verfügt das Pult nicht über eine <Keys.HardKey>Shape</Keys.HardKey>-Taste, so erreichen Sie
+    diese Funktion über <Keys.SoftKey>Shapes and Effects</Keys.SoftKey>
+    , <Keys.SoftKey>Shape Generator</Keys.SoftKey>, <Keys.SoftKey>Edit</Keys.SoftKey>.
+
+![Shape Generator - Selecting a Shape to Edit](/docs/images/Shape-Generator-Selecting-a-Shape-to-Edit.png)
+
+Zunächst sind alle aktiven Shapes angewählt. Ändern Sie dies ggf. und
+drücken Sie <Keys.HardKey>Enter</Keys.HardKey> oder nochmals <Keys.HardKey>Shape</Keys.HardKey>, um die Shapes mit der
+Steuerung per Rad zu verbinden. Sind mehr als drei Parameter zu steuern,
+so können Sie mit Menütaste G umschalten.
+
+-   Stammen die Shapes aus einem Cue, so werden Änderungen direkt in den
+    Cue übertragen (genauso wie z.B. [Geschwindigkeit und Überblendung einstellen](../chases/chase-playback.md#geschwindigkeit-und-überblendung-einstellen)).
+
+-   Um währenddessen ein anderes Attribut zu steuern, betätigen Sie die
+    entsprechende Attribut-Taste/Button. Um wieder zur Shape-Steuerung
+    zurückzukehren, klicken Sie wieder <Keys.HardKey>Shape</Keys.HardKey> oder <Keys.SoftKey>FX</Keys.SoftKey>.
+
+## Ändern gespeicherter Shapes und Effekte
+
+Shapes und Pixelmapper-Effekte, die bereits in Cues gespeichert sind,
+lassen sich über das Fenster 'Cue View' aufrufen und editieren.
+
+![Playback View for Cue with Shape](/docs/images/Playback-View-for-Cue-with-Shape.png)
+
+Um die Parameter eines Shapes/Effektes anzuzeigen oder zu editieren,
+klicken Sie auf <Keys.SoftKey>View Shape</Keys.SoftKey> oder <Keys.SoftKey>View Pixel Effect</Keys.SoftKey>. Ist mehr als
+ein Shape/Effekt in dem Cue gespeichert, wird auf der Schaltfläche
+<Keys.SoftKey>\...</Keys.SoftKey> angezeigt. Nach dem Anklicken öffnet sich ein entsprechendes
+Fenster (**Shape View** oder **Pixelmapper Effect View**), in dem alle
+enthaltenen Shapes/Effekte aufgeführt sind. Dort können Sie die
+gewünschten Änderungen vornehmen.
+
+In den Fenstern 'Shape View' oder 'Effect View' lässt sich ferner mit
+<Keys.SoftKey>View Fixtures</Keys.SoftKey> eine Liste der enthaltenen Geräte anzeigen, die in dem
+Shape/Effekt enthalten sind.
+
+## Ändern von Shapes mit Include
+
+Es lassen sich nur Shapes verändern, die sich im Programmierspeicher
+befinden - wird ein Shape einfach mit einem Cue gestartet, so erscheint
+er nicht in der Liste zu ändernder Shapes. Um einen Shape in einem Cue zu
+ändern, laden Sie also zunächst den Cue [per Include in den
+Programmierspeicher](../cues/editing-cues.md#cues-wiederverwenden---die-include-funktion)).
+
+Wurde ein Cue mittels Include geladen und sind mehrere Shapes
+gleichzeitig im Programmierspeicher, so lässt sich der mit den Encodern zu
+steuernde mit Taste <Keys.SoftKey>Edit</Keys.SoftKey> auswählen.
+
+1. Wenn das Shape-Menü noch nicht aktiv ist, so öffnen Sie es 
+mit <Keys.SoftKey>Shapes and Effects</Keys.SoftKey>, dann <Keys.SoftKey>Shape Generator</Keys.SoftKey> aus dem Hauptmenü.
+2. Drücken Sie <Keys.SoftKey>Edit</Keys.SoftKey>.
+3. Drücken Sie <Keys.SoftKey>Select shape</Keys.SoftKey>.
+4. Bei den Menütasten erscheint eine Liste der laufenden Shapes.
+5. Betätigen Sie eine Taste, um den jeweiligen Shape auszuwählen. Der
+ausgewählte Shape wird hervorgehoben.
+6. Drücken Sie <Keys.HardKey>Enter</Keys.HardKey>, um zum Shape Generator-Menü zurückzukehren.
+
+>   Läuft ein Shape mehrfach auf verschiedenen Geräten, so lässt sich
+    jede laufende Kopie einzeln steuern.
+
+## Shapes neu synchronisieren
+
+Mit der Option <Keys.SoftKey>Restart Shapes</Keys.SoftKey> im Shape-Editor werden alle gerade
+laufenden Shapes neu gestartet. Das ist sinnvoll, wenn mehrere Shapes
+miteinander synchronisiert werden sollen.
+
+## Ändern der Gerätereihenfolge eines Shapes
+
+Die Art und Weise, wie ein Shape arbeitet, wird durch die Reihenfolge
+der Auswahl der Geräte bestimmt. Diese lässt sich später mit der
+Funktion <Keys.SoftKey>Fixture Order</Keys.SoftKey> im Menü <Keys.SoftKey>Edit</Keys.SoftKey> ändern. Die aktuelle
+Gerätereihenfolge wird auf den Geräte-Schaltflächen mit großen grünen
+Zahlen angezeigt. Siehe
+[Gerätereihenfolge und -anordnung](../controlling-fixtures/fixture-groups.md#gerätereihenfolge-und--anordnung-in-den-gruppen)
+für weitere Details.
+
+## Shapes mit Gruppen verknüpft
+
+Shapes und Keyframe-Shapes, die unter Verwendung von Gruppen erstellt
+wurden, verwenden die [Gerätereihenfolge der Gruppe](../controlling-fixtures/fixture-groups.md#gerätereihenfolge-und--anordnung-in-den-gruppen) und enthalten eine
+Verknüpfung mit der/den jeweiligen Gruppe(n). Damit werden Änderungen
+etwa am Layout bzw. der Geräte-Reihenfolge sofort in den betreffenden
+Shapes wirksam und müssen nicht manuell übernommen werden.
+
+Um Geräte zu einer Gruppe hinzuzufügen, ohne die Verknüpfung des Shapes
+aufzuheben, wählen Sie die Geräte aus, drücken <Keys.HardKey>Record</Keys.HardKey>, gefolgt von
+der Gruppenschaltfläche/Taste, und betätigen diese nochmals oder wählen
+<Keys.SoftKey>Merge</Keys.SoftKey> mit den Menütasten. Ebenso kann der Inhalt einer Gruppe (die
+enthaltenen Geräte) unter Erhaltung der Verknüpfungen zu Shapes und
+Effekten ersetzt werden, indem man die Geräte auswählt, <Keys.HardKey>Record</Keys.HardKey> und
+die Gruppenschaltfläche betätigt und dann <Keys.SoftKey>Replace</Keys.SoftKey> wählt. Geräte
+lassen sich schließlich auch durch das Ein- und Ausschalten der
+Geräteschaltflächen im Menü 'Edit Groups' zu Gruppen hinzufügen oder
+daraus entfernen: <Keys.HardKey>Group</Keys.HardKey> <Keys.SoftKey>Edit Groups</Keys.SoftKey> <Keys.SoftKey>Gruppen-Schaltfläche</Keys.SoftKey>.
+
+Soll die Reihenfolge für einen bestimmten Shape geändert werden, ohne
+dies in der Gruppe zu tun und damit ggf. andere Shapes zu verändern, so
+lösen Sie die Gruppenverknüpfung mit <Keys.SoftKey>Break Group References</Keys.SoftKey> im Menü
+<Keys.SoftKey>Edit</Keys.SoftKey> <Keys.SoftKey>Edit Fixtures/Groups</Keys.SoftKey> <Keys.SoftKey>Fixture Order</Keys.SoftKey>.
+
+Siehe [Gerätereihenfolge und -anordnung](../controlling-fixtures/fixture-groups.md#gerätereihenfolge-und--anordnung-in-den-gruppen) für Details zum Editieren von Reihenfolge und Layout.
+
+## Entfernen oder Hinzufügen von Geräten
+
+Mit der Funktion <Keys.SoftKey>Add/Remove Fixtures</Keys.SoftKey> aus dem Menü <Keys.SoftKey>Edit</Keys.SoftKey> lassen
+Geräte aus einem Shape entfernen oder weitere Geräte hinzufügen; ebenso
+können Sie dazu die entsprechende Kontextfunktion aus dem Menü „Shapes
+Fixture View" verwenden. Sämtliche bereits im Shape vorhandenen Geräte
+werden als Vorauswahl angeboten, und können dann einzeln ab- oder
+angewählt werden.
+
+Ist ein Shape mit einer Gruppe verknüpft (s.o.), so wird durch das
+Entfernen von Fixtures aus dem Shape die Verknüpfung gelöst.
+Entsprechend wird eine Meldung ausgegeben, und man muss das mit <Keys.SoftKey>Remove Fixtures</Keys.SoftKey> bestätigen.
+
+## Einen Shape umkehren
+
+Die Richtung eines Shapes lässt sich umkehren; dazu drückt man im
+'Shape'-Menü auf <Keys.SoftKey>Reverse Selected Fixtures</Keys.SoftKey>. Dadurch wird der Shape
+für die ausgewählten Geräte umgekehrt; damit lassen sich Abläufe gezielt
+nur für einzelne - oder aber für alle - Geräte umkehren.
+
+## Löschen von Shapes
+
+Ein laufender Shape lässt sich ganz einfach löschen: dazu drücken Sie
+<Keys.SoftKey>Delete</Keys.SoftKey> aus dem 'Shape'-Menü, und wählen den zu löschenden Shape mit
+der entsprechenden Menütaste.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects/key-frame-shapes.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects/key-frame-shapes.md
@@ -1,0 +1,218 @@
+---
+id: key-frame-shapes
+title: Keyframe-Shapes
+sidebar_label: Keyframe-Shapes
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Keyframe-Shapes gestatten es, eigene Sequenzen als Effekte zu nutzen.
+Dazu werden mehrere Attribut-Einstellungen gespeichert, zwischen denen
+dann gewechselt und übergeblendet wird.
+
+## Einen Keyframe-Shape erzeugen
+
+<Video videoId="1nvLaipivhM" title="Key Frame Shapes" />
+
+Ein Keyframe-Shape wird so ähnlich wie ein [Chaser](../chases.md) erstellt, ist aber
+wesentlich flexibler, den es lässt sich sowohl der Überblend-Verlauf
+bestimmen als auch die Art der Aufteilung auf mehrere Geräte. Ferner
+lassen sich Keyframe-Shapes auch sehr einfach z.B. in [Cuelisten](../cue-lists/creating-a-cue-list.md#tracking-von-shapes-in-cuelisten)
+einbinden.
+
+Die einzelnen Keyframes baut man entweder im **Channel (Kanal-) Modus**, indem man die
+Geräte entsprechend einstellt und auf <Keys.SoftKey>Add Frame</Keys.SoftKey> klickt, oder im
+&nbsp;**Quick Build**-Modus, bei dem automatisch ein neuer Frame angefügt wird,
+sobald man eine [Palette](../palettes.md) oder einen
+[Cue](../cues.md) anklickt. Mit der Schaltfläche <Keys.SoftKey>Record Mode</Keys.SoftKey>
+kann man zwischen beiden Modi umschalten.
+
+In diesem Beispiel bauen wir einen Keyframe-Shape für Farben. Man kann
+aber Keyframe-Shapes für andere und auch für mehrere verschiedene
+Attribute programmieren. Verwendet man dabei [Paletten](../palettes.md), 
+so werden diese auch hier als Referenz gespeichert: ändert man später 
+die Palette, so ändert sich auch der Shape.
+
+
+1. Im Hauptmenü drücken Sie <Keys.SoftKey>Shapes and Effects</Keys.SoftKey>, dann <Keys.SoftKey>Key Frame Shapes</Keys.SoftKey>.
+2. Klicken Sie auf <Keys.SoftKey>Create</Keys.SoftKey>, um einen neuen Keyframe-Shape zu
+beginnen.
+3. [Wählen Sie die gewünschten Geräte](../controlling-fixtures.md#dimmer-und-geräte-zum-steuern-auswählen) und stellen Sie die Farben für den ersten
+Keyframe ein.
+4. Klicken Sie auf <Keys.SoftKey>Add Frame</Keys.SoftKey>. Über dem ersten Playback-Fader wird
+eine entsprechende Legende angezeigt *(schalten Sie dies mit <Keys.SoftKey>Playbacks
+Display Visible/Hidden</Keys.SoftKey> ab, falls Sie das nicht wünschen oder z.B. im
+Quick Build-Modus ein Playback auswählen möchten)*.<br/>
+![Key Frame Shape - creating an effect with colour key frames](/docs/images/Key-Frame-Shape-creating-an-effect-with-colour-key-frames.png)
+5. Fügen Sie Schritte mit anderen Farben hinzu (jeweils mit <Keys.SoftKey>Add Frame</Keys.SoftKey>, 
+bis alle gewünschten Schritte erstellt wurden.
+6. Wenn Sie fertig sind, klicken Sie auf <Keys.SoftKey>Finish Recording Frames</Keys.SoftKey>.
+7. Im Effekt-Editor können Sie die Übergänge, die Überlappung und die
+Verteilung auf mehrere Geräte (Spread) einstellen, siehe nachfolgendes
+Bild.
+8. [Speichern Sie den Shape in einen Cue](#einen-keyframe-shape-in-einen-cue-speichern), um ihn später zu verwenden.
+
+-   Auch mit der <Keys.HardKey>Unfold</Keys.HardKey>-Taste können die Playbacks zwischen normaler
+    Anzeige und Anzeige der Keyframes umgeschaltet werden.
+
+-   Gibt man mit <Keys.SoftKey>Frame Number</Keys.SoftKey> die Nummer eines bereits bestehenden
+    Frames ein, oder wählt man diesen über die Auswahltaste des
+    Playbacks, so lässt sich der Frame mit <Keys.SoftKey>Replace</Keys.SoftKey> ersetzen sowie
+    mit <Keys.SoftKey>Delete</Keys.SoftKey> löschen.
+
+-   Ist der Shape nicht erkennbar, weil die Geräte dunkel sind, so
+    lassen sich die Dimmerkanäle der verwendeten Geräte mit der
+    Schaltfläche <Keys.ContextKey>Sonne</Keys.ContextKey> locaten.
+	
+## Ändern von Shape-Parametern im Effekt-Editor
+Siegen
+Ist ein Keyframe-Shape komplett erstellt, so wird er im Effekt-Editor
+angezeigt.
+
+![Effect Editor Window with colour key frame shape](/docs/images/Effect-Editor-Window-with-colour-key-frame-shape.png)
+
+Die Steuerelemente oben im linken Bereich beeinflussen den gesamten
+Shape: Speed (Geschwindigkeit), Direction (Richtung unter Verwendung des [Gruppen-Layouts](../controlling-fixtures/fixture-groups.md#gerätereihenfolge-und--anordnung-in-den-gruppen)), [Phase/Spread](shape-generator.md#ändern-der-verteilung-eines-shapes-mehrere-geräte)
+(Verteilung auf mehrere Geräte) und [Overlap](../cues/cue-timing.md#setting-fade-times-and-overlap-for-a-cue) (Überlappen benachbarter
+Geräte).
+
+Mit dem **Auge** oben links werden alle gerade angezeigten Shapes
+*eingeklappt*, so dass man sich nur einzelne Shapes zum Bearbeiten
+ausklappen kann, wenn mehrere Shapes laufen. Mit dem **Button mit dem
+Movinglight** lässt sich die Auswahl der Geräte, auf denen der 
+Keyframe-Shape läuft, verändern.
+
+Im Hauptbereich rechts werden die Übergänge zwischen den einzelnen
+Schritten dargestellt. Dies kann man einfach anklicken und ziehen, um
+den Verlauf zu ändern. Der gelbe Pfeil ist der Phasenversatz
+(Startposition) des gesamten Layers, den man ebenfalls einfach anklicken
+und ziehen kann, um den Start relativ zu anderen Layern zu verschieben 
+*(gleiches Ergebnis wie der Fader 'Phase Offset' unten)*.
+
+### Steuerelemente für Shape und Layer
+
+Zu Beginn *(oder sobald man links auf einen Layer klickt)* steuern die
+Fader rechts unten jeweils einen einzelnen Layer.
+
+![Effect Editor key frame controls for layer/effect](/docs/images/Effect-Editor-key-frame-controls-for-layer-effect.png)
+
+Man kann auf die Schaltflächen rechts neben den Fadern klicken, um
+direkt einen bestimmten Wert einzugeben oder den Wert mit den Wheels des
+Pultes einzustellen. Zum Zurücksetzen dient jeweils ein Doppelklick auf
+den Button oder die Funktion <Keys.SoftKey>Reset to default value</Keys.SoftKey> (erscheint,
+sobald ein Button angeklickt wird).
+
+Die Einstellung **Beats Per Cycle**, die genauso wie für normale Shapes
+arbeitet (s.o.), stellt das Verhältnis von Beats (BPM) und der
+Geschwindigkeit des Keyframe-Shapes ein. Vorgabewert ist auch hier 1:
+jeder Beat entspricht einem kompletten Durchlauf des Effektes. Stellt 
+man das z.B. auf 4, so dauert jeder Durchlauf vier Beats, der Shape 
+läuft also langsamer. Damit lassen sich z.B. mehrere Shapes im passenden 
+Verhältnis zueinander steuern. 
+
+<Keys.SoftKey>Custom</Keys.SoftKey> erlaubt es, beliebige Werte einzugeben. Klickt man auf 
+den numerischen Wert, so kann man entweder einen anderen 
+Wert eingeben oder mit <Keys.SoftKey>Reset to default value</Keys.SoftKey> auf den Vorgabewert 
+zurückschalten. Außerdem wird dabei der 'Beats per Cycle'-Wert mit dem
+Encoder A verknüpft, so dass man diesen schnell ändern kann.
+
+Wählt man die Option <Keys.SoftKey>Spread</Keys.SoftKey>, so wird der Beats-per-Cycle-Wert
+an den Spread gebunden. Das ist oft bei Dimmer- und Bewegungs-Shapes 
+gewünscht.<br/>
+Mit <Keys.SoftKey>Keyframes</Keys.SoftKey> schließlich wird pro Beat ein Keyframe weitergeschaltet.
+Jeder einzelne Keyframe-Shape und jeder einzelne Layer hat seine 
+individuellen **Beats per Cycle**-Einstellungen. 
+
+Mit **Cycles** (Durchläufe) stellt man ein, wie oft der Shape laufen soll.
+Vorgabewert ist 0, womit der Shape läuft, bis er wieder gestoppt wird.
+Ändert man dies auf eine andere Zahl (entweder für einen einzelnen Layer
+oder für den ganzen Keyframe-Shape bzw. alle Layer in diesem), so läuft
+der Shape nur die vorgegebene Anzahl von Zyklen und hält dann an. *So
+kann man also für jeden Layer einzeln einstellen, wie oft der Effekt
+laufen soll*.
+
+Keyframe-Shape können auf **Subfixtures** (Zellen) laufen. Dies ist normalerweise <Keys.SoftKey>Off</Keys.SoftKey>
+(abgeschaltet), man kann es aktivieren mit <Keys.SoftKey>On (Group)</Keys.SoftKey>, wobei das [Layout der Gruppe](../controlling-fixtures/fixture-groups.md#fixture-order-and-fixture-layout-in-groups) berücksichtigt wird, oder mit <Keys.SoftKey>On (Linear)</Keys.SoftKey>, wobei das Layout ignoriert wird und die Zellen einfach in numerischer Reihenfolge angesteuert werden.
+
+
+Mit der Einstellung <Keys.SoftKey>Phase Master</Keys.SoftKey> kann die Phase eines Shapes durch
+die Intensität eines Videolayers (eines Ai-Servers) gesteuert werden,
+siehe [Synchronisieren eines Keyframe-Shapes zu Ai](../synergy/operating-synergy.md#phasensteuerung-von-keyframe-shapes-durch-ai).
+
+### Parameter für einzelne Frames
+
+Klickt man links auf einen einzelnen Keyframe, so lassen sich dessen
+Parameter einstellen.
+
+![Effect Editor key frame controls for individual key frame step](/docs/images/Effect-Editor-key-frame-controls-for-individual-key-frame-step.png)
+
+-   Mit dem Regler „Start Time" lässt sich das **Timing** verändern (genauso
+    wie durch Ziehen in der oberen Ablauf-Darstellung).
+
+-   **Frame A Min** / **Frame B Max**: Limitierung des Effektes. *Hat man z.B.
+    einen 100% Flash programmiert, lässt sich dieser etwa auf 80% reduzieren.*
+
+-   **Mid point**: wo ist die Mitte des Überblend-Weges
+
+-   **Width**: ähnlich der Einstellung Crossfade bei Chasern. Stellt man
+    Width auf 20%, so wird in nur 20% der Zeit übergeblendet, und bei
+    80% der Zeit ändert sich nichts.
+
+Der Kurvenverlauf des Überblendens lässt sich mit der
+Kurven-Schaltfläche rechts neben jedem einzelnen Schritt einstellen. Die
+neue Kurve wird entsprechend grafisch dargestellt.
+
+![Effect Editor key frame shape changing curves for individual key frame steps](/docs/images/Effect-Editor-key-frame-shape-changing-curves-for-individual-key-frame-steps.png)
+
+### Editieren von Frames
+
+Auch die Reihenfolge der Keyframes lässt sich im Effekt-Editor ändern:
+
+![Effect Editor key frame shape layer with colour steps](/docs/images/Effect-Editor-key-frame-shape-layer-with-colour-steps.png)
+
+-   Um Frames **hinzuzufügen**, klicken Sie auf den <Keys.ContextKey>Stift</Keys.ContextKey> rechts neben dem
+    **Namen des Layers**.
+
+-   Um einen Frame zu **editieren**, klicken Sie auf den <Keys.ContextKey>Stift</Keys.ContextKey> rechts neben
+    dem **Namen des Frames**.
+
+-   Um einen Frame zu **löschen**, wählen Sie diesen aus und klicken unten
+    auf den <Keys.ContextKey>Papierkorb</Keys.ContextKey>.
+
+-   Um die **Reihenfolge zu ändern**, wählen Sie einen Frame aus und
+    verschieben ihn mit den **Pfeiltasten**.
+
+-   Um **mehrere Frames** gleichzeitig zu **ändern**, klicken Sie unten auf die
+    **Mehrfachauswahl**-Schaltfläche, oder sie ziehen um die gewünschten
+    Frames im Display einen Rahmen.
+
+### Komplexe Effekte
+
+Keyframe-Shapes können jeweils mehrere Layer (Ebenen) enthalten, so dass
+verschiedene Effekte gleichzeitig laufen können. Um einen neuen Layer
+hinzuzufügen, klicken Sie unten auf das <Keys.ContextKey>+</Keys.ContextKey> und wählen nun
+&nbsp;**Layers**. Damit erscheint der neue Layer in der Liste auf der linken
+Seite.
+
+![Effect Editor adding an extra effect](/docs/images/Effect-Editor-adding-an-extra-effect.png)
+
+Ebenso können Sie einen komplett anderen Keyframe-Shape oder
+[Pixelmapper-Effekt](pixel-mapper.md) hinzufügen. Pixelmapper-Effekte 
+werden immer ganz oben in der Liste angezeigt und lassen sich mit dem **Auge**
+ausblenden, wenn man nur mit den Keyframe-Shapes arbeiten will.
+
+## Einen Keyframe-Shape in einen Cue speichern
+
+Normalerweise wird Keyframe-Shapes, die in einem Cue gespeichert sind,
+durch den zugehörigen Fader die Größe (Size) gesteuert; ist in den jeweiligen
+Playback-Optionen die Option [Speed on Fader](../cues/playback-options.md#shape--effect-speed)
+gewählt, so wird die Geschwindigkeit des Effekts mit dem Fader geregelt.
+
+Zum Verhalten von Keyframe-Shapes in Cuelisten siehe
+[Shape-Tracking in Cuelisten](../cue-lists/creating-a-cue-list.md#tracking-von-shapes-in-cuelisten).
+
+-   Wird mittels [Mask FX](shape-generator.md#masking-shapes-using-mask-fx)
+    ein Mask Shape erzeugt, so stoppt dieser auch Keyframe-Shapes.
+
+-   Shapes und Keyframe-Shapes, die in Playbacks gespeichert sind, können entweder als Overlay arbeiten, also andere programmierte Attribute überlagern, oder wie gewohnt als LTP-Werte, werden also ihrerseits von später gestarteten Playbacks überlagert/überschrieben. Siehe [Shape-Verhalten: Overlay oder LTP](./shape-generator.md#shape-verhalten-overlay-oder-ltp).

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects/pixel-mapper-examples.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects/pixel-mapper-examples.md
@@ -1,0 +1,534 @@
+---
+id: pixel-mapper-examples
+title: Pixelmapper - Beispiele
+sidebar_label: Pixelmapper - Beispiele
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Zufallseffekte
+
+In diesem Beispiel wird die Matrixengine genutzt, um auf mehreren
+Dimmern einen Zufallseffekt zu erzeugen. Dieser Effekt überlagert
+anderweitig für die Dimmer eingestellte Pegel.
+
+1. Zunächst müssen die betreffenden Dimmer in einer Gruppe
+zusammengefasst werden, wenn das nicht schon der Fall ist.
+2. Als nächstes muss das Layout der Geräte in dieser Gruppe
+entsprechend eingestellt werden (mit <Keys.SoftKey>Shapes And Effects</Keys.SoftKey>, <Keys.SoftKey>Pixel Mapper</Keys.SoftKey>, <Keys.SoftKey>Edit Group Layout</Keys.SoftKey>, Gruppe auswählen).
+3. Erstellen Sie nun einen Effekt: wählen Sie die Gruppe aus und
+klicken Sie <Keys.SoftKey>Shapes And Effects</Keys.SoftKey>, <Keys.SoftKey>Pixel Mapper</Keys.SoftKey>, <Keys.SoftKey>Create Effect</Keys.SoftKey>.
+4. Im Effekt-Editor schalten Sie die Option <Keys.SoftKey>Fixture Overlay</Keys.SoftKey> auf <Keys.SoftKey>Fixture Overlay 50/50</Keys.SoftKey>. 
+ *Damit sieht man das Ergebnis direkt beim Erstellen des Effekts.*
+ ![Effect Editor - Pixel Mapper - Fixture Overlay 50/50](/docs/images/Effect-Editor-Pixel-Mapper-Fixture-Overlay-50-50.png)
+5. Wählen Sie links <Keys.SoftKey>Effect</Keys.SoftKey> und stellen den Fader **Background Opacity** 
+auf **0%**. *(Damit überlagert der Effekt alle anderen Werte.)*
+![Effect Editor - Pixel Mapper - Setting Background Opacity of Effect](/docs/images/Effect-Editor-Pixel-Mapper-Setting-Background-Opacity-of-Effect.png)
+6. Wählen Sie <Keys.SoftKey>Layer 1</Keys.SoftKey>, klicken auf <Keys.ContextKey>+</Keys.ContextKey> am unteren Rand des
+Bildschirms, und wählen Sie als Form den **Kreis**.
+![Effect Editor - Pixel Mapper - Adding a Circle to Layer 1](/docs/images/Effect-Editor-Pixel-Mapper-Adding-a-Circle-to-Layer-1.png)
+7. Stellen Sie **Zoom** so ein, dass etwa eine Zelle vom Kreis bedeckt
+wird. Ebenso kann man dies mit **Width** und **Height** erreichen.
+ Schieben Sie den Kreis dann mit **X** und **Y** etwa in die Mitte der Fläche.
+ ![Effect Editor - Pixel Mapper - Transforming a Circle Element](/docs/images/Effect-Editor-Pixel-Mapper-Transforming-a-Circle-Element.png)
+8. Klicken Sie wieder auf <Keys.ContextKey>+</Keys.ContextKey> und wählen Sie als Animation **zufällige
+Position** (dargestellt durch mehrere kleine Blöcke).
+![Effect Editor - Pixel Mapper - ](/docs/images/Effect-Editor-Pixel-Mapper.png)  
+(Achtung: bis jetzt ist noch kein Effekt zu sehen.)
+9. Klicken Sie <Keys.ContextKey>+</Keys.ContextKey> und wählen Sie diesmal **Opacity** als Effekt (dargestellt als teilweise sichtbarer Block).
+10. Variieren Sie nun den Effekt:
+
+ Die Zufalls-Animation wird mit der Opacity-Animation kombiniert, so dass jeder neue Kreis an einer zufälligen Stelle erscheint.
+ 
+ Stellen Sie **In Time** und **Out Time** auf 0%, um nicht jeweils ein- und auszublenden, sondern hart zu schalten.
+
+ Machen Sie den Effekt nun mit **Speed** schneller, und verändern Sie die Häufigkeit mit **Spawn Rate** (für Effekte mit solch kleinen Elementen bieten sich hohe Spawn Rates an.)
+
+ ![Effect Editor - Pixel Mapper - Modify an Opacity Animation](/docs/images/Effect-Editor-Pixel-Mapper-Modify-an-Opacity-Animation.png)
+
+11. Speichern Sie mittels <Keys.HardKey>Record</Keys.HardKey> das Ergebnis als Cue.
+
+
+
+## Effekte und Layer kombinieren
+
+In diesem Beispiel wird ein diagonaler Wisch-Effekt mit einem
+rotierenden roten 'Propeller' erstellt.
+
+1.  Erstellen Sie ein Gruppe von Geräten und legen Sie das Layout wie im
+[vorigen Beispiel](#zufallseffekte) beschrieben fest.
+2.  Starten Sie den Effekt-Editor mit <Keys.SoftKey>Shapes And Effects</Keys.SoftKey>, <Keys.SoftKey>Pixel Mapper</Keys.SoftKey>, <Keys.SoftKey>Create Effect</Keys.SoftKey>.
+3.  Wählen Sie <Keys.SoftKey>Layer 1</Keys.SoftKey>, klicken auf das <Keys.ContextKey>+</Keys.ContextKey> unten links und wählen den Block als grafisches Element.
+
+ Stellen Sie die **Rotation** auf ca. 25° nach rechts ein.
+
+ Machen Sie den Block mit **Width** schmaler.
+
+ Verändern Sie die Höhe (**Height**) so, dass der Block das gesamte Fenster	von unten bis oben füllt.
+
+ Ziehen Sie den Regler **X** (für horizontale Position) soweit nach rechts,	dass der Block gerade nicht mehr im Bild erscheint.
+
+ ![Effect Editor - Pixel Mapper - Transforming a Block](/docs/images/Effect-Editor-Pixel-Mapper-Transforming-a-Block.png)
+
+4.  Klicken Sie wieder auf <Keys.ContextKey>+</Keys.ContextKey> und wählen Sie als Animation **Lineare Bewegung** (dargestellt als von links nach rechts sich bewegender Block).
+
+ Rechts neben dem Regler **Direction** (Richtung) befindet sich ein kleiner
+ Kompass. Klicken Sie 4x darauf und stellen damit die Richtung auf 270°
+ ein (die Grundeinstellung ist 90°, also *von links nach rechts*; da wir den
+ Block aber rechts aus dem Bild geschoben haben, muss die Richtung
+ diesmal 270° sein. Der Kompass schaltet in 45°-Schritten um).
+
+ Verringern Sie die **Spawn Rate**, bis nur noch ein Streifen auf der Fläche zu sehen ist. Für solche Effekte ist eine typische Spawn Rate etwa 0,2.
+
+ Ebenso möchten Sie vielleicht die Geschwindigkeit (**Speed**) etwas reduzieren - zum Einstellen der Spawn Rate wiederum ist vorübergehend eine höhere Geschwindigkeit sinnvoll.
+
+ ![Effect Editor - Pixel Mapper - Modify a Linear Movement Animation](/docs/images/Effect-Editor-Pixel-Mapper-Modify-a-Linear-Movement-Animation.png)
+
+5.  Klicken Sie auf <Keys.SoftKey>Layer 2</Keys.SoftKey>, dann auf <Keys.ContextKey>+</Keys.ContextKey>, und wählen Sie den stilisierten Propeller.
+
+ Stellen Sie den **Zoom** so ein, dass die Grafik die gesamte Fläche füllt.
+
+ Stellen Sie **Bend** auf 0%, so dass die Flügel gerade sind.
+
+ Stellen Sie **Points** auf 3 (das ist der Minimalwert) -- so erhalten Sie einen 3-flügeligen Propeller.
+
+ Stellen Sie **Thickness** auf 50% - so erhalten Sie gleichmäßig breite Segmente und Lücken.
+
+ Stellen Sie **Border Width** auf einen kleinen Wert, so dass nur schmale Kanten gezeigt werden.
+
+ ![Effect Editor - Pixel Mapper - Modifying Swirl](/docs/images/Effect-Editor-Pixel-Mapper-Modifying-Swirl.png)
+
+6.  Klicken Sie auf <Keys.ContextKey>+</Keys.ContextKey> und fügen Sie eine Rotations-Animation hinzu.
+
+ Verringern Sie die Geschwindigkeit.
+
+7.  Klicken Sie auf die Titelleiste des Layers ('Layer 2'), um die Layer-Steuerung einzublenden.
+
+ Klicken Sie nun auf den Farbbalken, um den Colourpicker zu öffnen.
+
+ Im Colourpicker klicken Sie oben links für ein kräftiges Rot.
+
+ ![Effect Editor - Pixel Mapper - Changing Colour of Swirl to Red](/docs/images/Effect-Editor-Pixel-Mapper-Changing-Colour-of-Swirl-to-Red.png)
+
+8.  Klicken Sie auf <Keys.SoftKey>Effect</Keys.SoftKey> ganz oben links für die Globalsteuerung.
+
+ Stellen Sie **Pre Spool** auf 0s (ganz links) *(damit beginnt der Wischeffekt außerhalb, wie gewünscht)*.
+
+9.  Speichern Sie dies mit <Keys.HardKey>Record</Keys.HardKey> als Cue.
+
+>   Diese Beispiel verdeutlicht, wie mehrere Layer miteinander
+ kombiniert werden: ein Layer mit einer höheren Nummer ist dabei im
+ Vordergrund. Daher erscheint der ‚rote Propeller' auf/vor dem weißen ‚Wischeffekt'.
+>    
+>   ![Pixel Mapper Preview Window - Overlayed Layers](/docs/images/Pixel-Mapper-Preview-Window-Overlayed-Layers.png)
+
+## Kreative Gruppenlayouts
+
+Da jede Gerätegruppe ein anderes Geräte-Layout haben kann, ist es auch sehr
+einfach möglich, die gleichen Geräte in mehreren Gruppen mit
+unterschiedlicher Anordnung zu arrangieren.
+
+Damit lassen sich schnell und einfach interessante Effekte erzielen.
+
+### Beispiel 1: Gerade/ungerade
+
+1. Wählen Sie die betreffenden Geräte aus.
+2. Drücken Sie <Keys.HardKey>All</Keys.HardKey>, um nach Muster auszuwählen.
+3. Wählen Sie mit <Keys.SoftKey>Odd</Keys.SoftKey> alle ungeraden Geräte aus.
+4. Speichern Sie die Auswahl in eine Gruppe.
+5. Drücken Sie <Keys.HardKey>Fix+1</Keys.HardKey> (oder <Keys.HardKey>Next</Keys.HardKey>). *(Damit werden alle geraden Geräte angewählt.)*
+6. Speichern Sie die Auswahl mittels 'Merge' (Kombinieren/Verschmelzen) in die gleiche Gruppe.
+7. Öffnen Sie den Layout-Editor (<Keys.SoftKey>Shapes And Effects</Keys.SoftKey>, <Keys.SoftKey>Pixel Mapper</Keys.SoftKey>, <Keys.SoftKey>Edit Group Layout</Keys.SoftKey>) und **wählen Sie die Gruppe**.
+
+Durch die beschriebene Vorgehensweise wurde mit wenigen Klicks ein
+Layout erstellt, bei dem alle ungeraden Geräte links und alle geraden
+Geräte rechts angeordnet sind.
+
+Diese Anordnung kann bereits ohne weitere Änderungen für schöne Effekte
+verwendet werden. So wird z.B. ein Block mit Bewegung links-rechts
+nacheinander erst über die ungeraden und dann über die geraden Geräte
+geblendet.
+
+Eine weitere - ähnliche - Anwendung wäre das Erstellen eines **Kaskadier-Effektes**:
+
+1. Verändern Sie mit **'Resize' (unterer Rand)** die Größe des Gitters, so
+dass es mindestens doppelt so hoch ist.<br/>
+  ![Layout Editor - Expanding Layout Grid](/docs/images/Layout-Editor-Expanding-Layout-Grid.jpeg)
+2. Markieren Sie mit der Maus die **geraden Geräte**.<br/>
+  ![Layout Editor - Selecting Fixtures](/docs/images/Layout-Editor-Selecting-Fixtures.jpeg)
+3. Ziehen Sie die Geräte so, dass Sie direkt unter den ungeraden (der linken Gruppe) positioniert werden.<br/>
+  ![Layout Editor - Moving Fixtures](/docs/images/Layout-Editor-Moving-Fixtures.jpeg)
+4. Wählen Sie **Crop Grid** aus dem Kontextmenü, um die nicht verwendete Fläche zu entfernen.
+
+Erstellt man nun ein Block-Element, welches senkrecht von oben nach
+unten läuft, so wird dieses vertikal erst auf die ungeraden und danach
+auf die geraden Geräte abgebildet.
+
+### Beispiel 2 -- Pseudo-Zufallsfolge
+
+1.  Wählen Sie die betreffenden Geräte aus und erstellen Sie eine Gruppe.
+2.  Öffnen Sie den Layout-Editor.
+3.  Bringen Sie mit dem Anfasser am unteren Rand das Gitter auf	mindestens die doppelte Höhe. 
+  Mittels der Zoomfunktion am linken Rand wird das exakte Anordnen
+  deutlich vereinfacht. Klicken Sie auf die stilisierte Lupe, um schnell
+  hinein- und herauszuzoomen.
+4.  Wählen Sie die Gruppe nochmals an; damit werden sämtliche enthaltenen Geräte angewählt.
+5.  Drücken Sie auf <Keys.HardKey>Fix+1</Keys.HardKey>, um das erste Gerät anzuwählen.
+6.  Verschieben Sie das Gerät mit den Encodern auf eine neue vertikale Position.
+7.  **Wiederholen Sie Schritt 5 und 6**, bis alle Geräte auf unterschiedlichen Positionen - insbesondere Höhen - sind.
+
+![Layout Editor - Randomly Arranged Fixtures](/docs/images/Layout-Editor-Randomly-Arranged-Fixtures.jpeg)
+
+*Erstellen Sie nun einen Effekt auf dieser Gruppe, so erscheint das
+Ergebnis zufällig. Dabei lassen sich Details jederzeit durch Ändern des
+Layouts anpassen.*
+
+### Beispiel 3 -- Winkel (oder 'wenn einfach grade einfach langweilig ist')
+
+Mitunter werden Geräte absichtlich schräg oder aufgehängt. Die Software
+startet zwar mit der Annahme einer rechtwinkligen Anordnung, kann aber
+auch gewinkelte Aufbauten passend darstellen.
+
+1.  Wählen Sie die Geräte aus und erstellen Sie eine Gruppe.
+2.  Öffnen Sie den **Layout-Editor**.
+3.  Wählen Sie das/die Gerät(e), die Sie drehen möchten, und ändern Sie
+	den Winkel mit dem betreffenden Encoder.<br/>
+	*Die Zuordnung der Räder lässt sich mit der Option **Wheel Control** 
+	einstellen; beim Pearl Expert kann darüber hinaus zwischen **Adjust Angle**
+	und **Adjust X, Y** umgeschaltet werden.*
+	
+![Layout Editor - Adjusting Angle](/docs/images/Layout-Editor-Adjusting-Angle.jpg)
+
+Hinter den nun gedrehten Zellen wird die ursprüngliche Anordnung
+hellgrau eingeblendet.
+
+Wurde versehentlich ein Gerät komplett außerhalb des Bereiches
+verschoben, so lässt sich mit der Kontext-Option **Crop Grid** das Gitter
+anpassen, so dass man wieder Zugriff auf alle Geräte hat.
+
+Bei der Verwendung der Räder zum Positionieren kann man im
+Anzeigebereich der Räder auf die Buttons für Up und Down klicken, womit
+sich der Wert um +/-1px bzw. +/-45° ändert. Klickt man auf den Wert im Display
+bzw. die entsprechende <Keys.HardKey>@</Keys.HardKey>-Taste, so lässt sich der gewünschte Wert
+numerisch eingeben.
+
+## Weitere Werkzeuge des Layout-Editors
+
+Im Layout-Editor gibt es einige Werkzeuge, die das Arbeiten deutlich vereinfachen.
+
+**Arrange Fixtures:** Damit lassen sich sehr schnell viele Geräte
+definiert anordnen. Um z.B. 20 RGB-Geräte in 4 Säulen à 5 Geräte
+anzuordnen, gehen Sie wie folgt vor:
+
+1.  Wählen Sie die Geräte aus und erstellen Sie eine Gruppe.
+2.  Öffnen Sie den **Layout-Editor**.
+3.  Wählen Sie **Arrange Fixtures** aus dem Kontext-Menü.
+4.  Wählen Sie die Option <Keys.SoftKey>Height</Keys.SoftKey> und geben Sie <Keys.HardKey>5</Keys.HardKey> ein *(die Breite wird automatisch berechnet)*.
+5.  Aktivieren Sie <Keys.SoftKey>Crop Grid to fixtures</Keys.SoftKey> *(damit wird die Größe der gesamten Darstellung automatisch angepasst)*.
+6.  Schalten Sie <Keys.SoftKey>Arrange in..</Keys.SoftKey> je nach Adressierung auf **Columns**	(Spalten) oder **Rows** (Zeilen). *('Rows' ordnet die Geräte horizontal (links-rechts) an, 'Columns' ordnet sie vertikal an (von oben nach unten))*.
+7.  Mit der Option <Keys.SoftKey>Shape</Keys.SoftKey> (Umriss) können die Zellen/Geräte in einem Rechteck, Oval oder Dreieck angeordnet werden.
+8.  Bestätigen Sie die Einstellungen mit <Keys.SoftKey>OK</Keys.SoftKey>.
+
+**Highlight:** Mit dieser Option werden gerade angewählte Geräte
+hervorgehoben. Damit sieht man, welches Gerät man gerade im Layout
+bearbeitet.
+
+**Position & Angle/Cell Scale:** Steht dies auf 'Position & Angle', so
+bewegen/rotieren die wheels die gesamten Geräte. Im Modus 'Cell Scale'
+dagegen lassen sich die Zellen auseinanderfächern bzw. zusammenschieben,
+um die Zellenabstände verschiedener Gerätetypen anzugleichen.
+
+**Arrange/Select Only:** Ist diese Option auf 'Select Only' gesetzt, so
+ist das Verschieben per Drag-and-Drop deaktiviert. Damit kann man diese 
+Funktion nutzen, um Geräte auszuwählen, ohne versehentlich die Position 
+zu verändern.
+
+*Stellt man umgekehrt fest, dass sich Positionen plötzlich nicht mehr
+verändern lassen, so ist sicherlich diese Option aktiviert worden.*
+
+In jedem Fall aber lassen sich die Positionen mit den Encodern ändern.
+
+**Wheels Move Full Pixel/Sub Pixel:** Damit können Geräte mittels der
+Wheels unabhängig vom Raster positioniert werden. Mit der Option 
+**Snap** dagegen wird immer auf die nächstgelegene Zelle zentriert.
+
+**Wheels Rotate Individual Fixtures/Selection:** Hier wählt man, ob die
+komplette Auswahl um ihr Zentrum rotiert werden soll, oder jedes
+gewählte Gerät einzeln um sein Zentrum.
+
+**Media options:** Öffnet ein Untermenü für verschiedene Einstellungen
+bei Verwendung eines Ai-Servers/Synergy. Das ist ausführlich beschrieben 
+im Abschnitt [Verwendung des Layout-Editors mit Ai](../synergy/operating-synergy.md#verwendung-des-layout-editors-mit-ai).
+
+## Reihenfolge und Priorität beim Abruf
+
+Angenommen, Sie haben auf einem Speicherplatz ein pulsierendes weißes
+Oval, und auf einem anderen eine blaue Spirale erstellt. Normalerweise
+wird das Ergebnis jeweils anders sein, abhängig von der Reihenfolge, in
+der die Cues gestartet werden. Aber mit der Vergabe von Prioritäten
+lässt sich jedes Mal das gleiche Ergebnis erzielen.
+
+Zum Erstellen des ersten Effekts:
+
+1.  Wählen Sie eine Gruppe mit entsprechendem Layout, und starten Sie
+den Effekt-Editor mit <Keys.SoftKey>Create Effect</Keys.SoftKey>.
+2.  Wählen Sie links oben <Keys.SoftKey>Effect</Keys.SoftKey> für die globale Steuerung, und
+stellen Sie **Background Opacity** auf 0. *(Damit kann dieser Effekt zum Überlagern anderer Effekte verwendet werden)*.
+3.  Klicken Sie 2x auf <Keys.SoftKey>Layer 1</Keys.SoftKey> (oder klicken Sie auf <Keys.ContextKey>+</Keys.ContextKey>), und wählen Sie den **Kreis** als Element.<br/>
+  *(Der Doppelklick ruft ebenfalls Elemente und Animationen auf).*<br/>
+  Verringern Sie die Höhe, um daraus ein Oval zu machen.
+
+  ![Effect Editor - Pixel Mapper - Editing Height of Circle](/docs/images/Effect-Editor-Pixel-Mapper-Editing-Height-of-Circle.png)
+
+4.  Klicken Sie 2x auf <Keys.SoftKey>Circle</Keys.SoftKey> (oder klicken Sie auf <Keys.ContextKey>+</Keys.ContextKey>) und
+  wählen Sie die **Zoom**-Animation.
+
+  Stellen Sie **In Time** auf 0 und **Out Time** auf 100%. (Damit beginnt
+  der Effekt groß und endet klein - ein gleiches Ergebnis ließe sich
+  erzielen, wenn man **Start Zoom** größer als **End Zoom** macht).
+
+  Vergrößern Sie **End Zoom**, bis das Oval die ganze Fläche zu füllen beginnt.
+
+5.  Klicken Sie 2x auf <Keys.SoftKey>Zoom Animation</Keys.SoftKey> (oder klicken Sie auf <Keys.ContextKey>+</Keys.ContextKey>) und wählen Sie die Animation **Opacity**.
+
+  Reduzieren Sie **Spawn Rate** auf 0. (Damit wirkt Opacity nur auf die	Zoom-Animation.)
+
+  Stellen Sie **In Time** auf 0 und **Out Time** auf 100. (Damit beginnt
+  der Effekt schlagartig und blendet beim Verkleinern aus. Wie beim Zoom
+  beschrieben lässt sich ein ähnliches Ergebnis durch Invertieren der
+  Werte für Start/End Opacity erzielen. Stellt man diese Werte auf mehr
+  als 100%, so ergibt sich ein Delay vor dem Ausblenden).
+
+  ![Effect Editor - Pixel Mapper - Opacity Animation Settings](/docs/images/Effect-Editor-Pixel-Mapper-Opacity-Animation-Settings.png)
+
+6.  Klicken Sie wieder auf <Keys.SoftKey>Effect</Keys.SoftKey> und stellen **Master Speed** nach
+  Belieben ein. (Durch Verwenden der globalen Geschwindigkeit werden beide
+  Animationen gleichermaßen beeinflusst, so dass man sie nicht manuell synchronisieren muss).
+  
+  ![Effect Editor - Pixel Mapper - Effect Master Speed](/docs/images/Effect-Editor-Pixel-Mapper-Effect-Master-Speed.png)
+
+7.  Speichern Sie mit <Keys.HardKey>Record</Keys.HardKey> den Effekt als Cue.
+
+Erstellen des zweiten Effektes:
+
+1.  Wählen Sie die gleiche Gruppe wie vorher und starten Sie den
+  Effekt-Editor mit <Keys.SoftKey>Create Effect</Keys.SoftKey>.
+2.  Klicken Sie auf <Keys.SoftKey>Effect</Keys.SoftKey> und stellen Sie **Background Opacity** auf 0.
+3.  Klicken Sie auf <Keys.SoftKey>Layer 1</Keys.SoftKey> und fügen diesmal ein Spiral-Element hinzu.
+
+  Vergrößern Sie mit **Zoom** die Darstellung.
+
+  Stellen Sie **Thinning** auf **0%**. (Damit bleibt die Spirallinie von innen
+  bis außen gleich dick. Negative Werte machen die Linie innen dicker und
+  außen dünner, positive Werte arbeiten umgekehrt).
+
+  Verändern Sie **Turns**, so dass es ein kräftigerer Effekt wird. Eine
+  Einstellung von etwa 3 sollte ein gutes Ergebnis liefern.
+
+  Stellen Sie **Thickness** auf **50%**, um stärkere Linien zu erhalten.
+
+  Stellen Sie **Exponent** auf etwa **25%**. (Damit **öffnet** sich die Spirale schneller).
+    
+  ![Effect Editor - Pixel Mapper - Modifying a Spiral](/docs/images/Effect-Editor-Pixel-Mapper-Modifying-a-Spiral.png)
+
+4.  Fügen Sie eine Drehung als Animation hinzu (**Spin**).
+  Für wirklich psychedelische Effekte erhöhen Sie die Geschwindigkeit...
+
+5.  Klicken Sie nun auf <Keys.SoftKey>Layer 1</Keys.SoftKey> und wählen Sie ein kräftiges Blau als Farbe.<br/>
+![Effect Editor - Pixel Mapper - Changing Colour of Spiral Layer to Blue](/docs/images/Effect-Editor-Pixel-Mapper-Changing-Colour-of-Spiral-Layer-to-Blue.png)
+
+6.  Speichern Sie das mit <Keys.HardKey>Record</Keys.HardKey> als Cue.
+
+Probieren Sie nun aus, wie sich beide Cues miteinander kombinieren lassen:
+
+-   Starten Sie als erstes die blaue Spirale.
+
+-   Starten Sie nun dazu das weiße Oval.
+
+Sie werden feststellen, dass das weiße Oval eine höhere Priorität als
+die Spirale hat; diese erscheint nur, sobald das Oval kleiner wird bzw.
+ausblendet.
+
+-   Blenden Sie beide Cues aus.
+
+-   Starten Sie nun als erstes das weiße Oval.
+
+-   Starten Sie dazu die blaue Spirale.
+
+Diesmal hat die blaue Spirale eine höhere Priorität und ist folglich im
+Vordergrund. Das liegt daran, dass die Effekte der **LTP-Regel** folgen,
+d.h. der zuletzt gestartete Effekt hat Priorität.
+
+Um sicherzustellen, dass die blaue Spirale immer im Vordergrund
+erscheint, vergeben Sie dieser eine höhere Priorität:
+
+1.  Beenden Sie beide Cues.
+2.  Drücken Sie auf <Keys.HardKey>Options</Keys.HardKey> (oder im Hauptmenü auf die Menütaste <Keys.SoftKey>Options</Keys.SoftKey>, siehe [Playback Options](../cues/playback-options.md)).
+3.  Wählen den Speicherplatz mit der blauen Spirale.
+4.  Klicken Sie auf <Keys.SoftKey>Previous</Keys.SoftKey> oder <Keys.SoftKey>Next</Keys.SoftKey>, bis der Eintrag
+  <Keys.SoftKey>Priority Normal</Keys.SoftKey> bei den Kontext-Tasten erscheint. Ändern Sie
+  diesen Eintrag mit der betreffenden Taste auf <Keys.SoftKey>Priority High</Keys.SoftKey>.
+5.  Starten Sie nun testweise erst die blaue Spirale, gefolgt vom weißen
+  Oval.
+
+Obwohl die Cues in der gleichen Reihenfolge wie im ersten Versuch
+gestartet wurden, erscheint nun die blaue Spirale immer im Vordergrund.
+
+## Verlagerung und Layer-Eigenschaften
+
+In diesem Beispiel erstellen wir zufällig blinkende Streifen und nutzen
+die globale Steuerung, um Einstellungen für den gesamten Effekt
+vorzunehmen.
+
+1.  Erstellen Sie eine Gruppe und passen Sie das Gruppenlayout der Geräte wie vorstehend
+	beschrieben an.
+	
+2.  Wählen Sie die Gruppe, und beginnen Sie einen Effekt zu erstellen.
+
+3.  Wählen Sie <Keys.SoftKey>Layer 1</Keys.SoftKey> und fügen ein **Block**-Element hinzu.
+
+4.  Stellen Sie Breite und Höhe (**Width**, **Height**) so ein, dass sich
+ein Streifen ergibt, der horizontal über das gesamte Gitter reicht und mindestens eine Zelle hoch ist.
+
+  ![Effect Editor - Pixel Mapper - Adjusting Width and Height of a Block](/docs/images/Effect-Editor-Pixel-Mapper-Adjusting-Width-and-Height-of-a-Block.png)
+
+5.  Stellen Sie nun **Y** so ein, dass der Streifen gerade oben aus dem Bild
+verschwindet (zur Vorbereitung auf den Verlagerungs-Effekt).
+
+6.  Fügen Sie nun eine Verlagerungs-Animation (**Displacement**) hinzu. Mit
+den Vorgabewerten ergibt sich daraus eine zufällige Verlagerung um bis
+zu 30% der Ausgangsposition, denn der Vorgabewert für **Distance** ist
+30%, und der für **Distance Random** sowie **Direction Random** ist 100% 
+(es ergeben sich zufällige Werte für den Bereich zwischen 0 und 30% in 
+jeder Richtung).
+
+  Zum Ausprobieren stellen Sie z.B. einfach mal **Distance Random** auf 0, um zu sehen, was passiert.
+
+  Stellen Sie **Direction Random** auf 0. (Für den hier beschriebenen
+  Effekt benötigen wir ohnehin diese Einstellung, da eine zufällige 
+  Richtung nicht erforderlich ist. Der Streifen wird nun verschwinden,
+  da die Verlagerung in der Grundeinstellung nach oben erfolgt.)
+
+  Stellen Sie nun **Direction** auf 180°. Dazu können Sie auch einfach 4x
+  auf den kleinen Kompass klicken. Nun erscheint der Streifen wieder, da
+  nun die zufällige Verlagerung um 30% nach unten von unserer
+  Ausgangsposition erfolgt.
+
+  Vergrößern Sie nun **Distance**, bis der Streifen etwa in der Mitte erscheint.
+
+  ![Effect Editor - Pixel Mapper - Displacement Animation Settings](/docs/images/Effect-Editor-Pixel-Mapper-Displacement-Animation-Settings.png)
+
+7.  Fügen Sie die Animation **Opacity** hinzu.
+
+  Verringern Sie **In Time** und **Out Time**, so dass nicht ein-/ausgeblendet, sondern hart geschaltet wird.
+  
+  ![Effect Editor - Pixel Mapper - Opacity Animation Settings](/docs/images/Effect-Editor-Pixel-Mapper-Opacity-Animation-Settings-2.png)
+
+8.  Klicken Sie in Layer 1 auf **Displacement**, um wieder diese Animation zu steuern.
+
+  Stellen Sie nun **Distance Random** auf 100%. (Damit wird der Balken um
+  zufällige Beträge vom Ausgangspunkt versetzt, erscheint also zufällig
+  irgendwo innerhalb des mit **Distance** vorgegebenen Wertes).
+
+  ![Effect Editor - Pixel Mapper - Displacement Animation Direction Random Setting](/docs/images/Effect-Editor-Pixel-Mapper-Displacement-Animation-Direction-Random-Setting.png)
+
+9.  Wählen Sie nun zum Steuern wieder die Animation **Opacity** aus und
+  erhöhen Sie die Geschwindigkeit nach Belieben. 
+
+  Vielleicht hätten Sie den Streifen nun doch lieber senkrecht. Um
+  das möglichst zu vereinfachen, wählen Sie einfach die Steuerelemente des
+  Layers, um nicht die ganzen einzelnen Elemente und Animationen editieren zu müssen:
+
+10. Klicken Sie auf <Keys.SoftKey>Layer 1</Keys.SoftKey>, um die Steuerung dieses Layers anzuzeigen.
+
+11. Ändern Sie 'Rotation' auf 90° (einfach 2x auf den Kompass klicken). 
+
+  ![Effect Editor - Pixel Mapper - Changing Layer Rotation](/docs/images/Effect-Editor-Pixel-Mapper-Changing-Layer-Rotation.png)
+
+Damit ist sowohl der Streifen gedreht als auch die damit verknüpfte
+Animation. Ebenso kann man mit den Steuerungen für **X**, **Y** und **Zoom**,
+wahlweise für den <Keys.SoftKey>Layer</Keys.SoftKey> oder den gesamten <Keys.SoftKey>Effekt</Keys.SoftKey>, schnell Anpassungen
+vornehmen.
+
+## Spawn und Pre-Spool -- 'Aufspreizen' und 'Vorspulen'
+
+Der Regisseur hätte gern viele sich drehende kleine Ungeheuer auf dem
+LED-Backdrop, die noch dazu pulsieren. Sie haben vielleicht keine
+Ahnung, wozu das gebraucht wird - aber so sind Regisseure nun mal.
+
+1.  Wählen Sie eine Gruppe mit den entsprechenden Geräten.
+
+2.  Fügen Sie als Element einen **Stern** hinzu.
+
+  Stellen Sie **Points** auf 4.
+
+  Verringern Sie den **Zoom**, so dass viele 'Mini-Ungeheuer' auf die Fläche passen.
+
+  ![Effect Editor - Pixel Mapper - Modifying a Star Element](/docs/images/Effect-Editor-Pixel-Mapper-Modifying-a-Star-Element.png)
+
+3.  Fügen Sie eine Drehungs(**Spin**)-Animation hinzu.
+
+  Setzen Sie die Geschwindigkeit (**Speed**) herab, so dass sie harmlos sind.
+
+4.  Fügen Sie eine **lineare Bewegung** hinzu.
+
+  Stellen Sie die Geschwindigkeit so ein, dass es aussieht, als ob sie herumrollen.
+
+5.  Wählen Sie wieder das Stern-Element und ändern Sie **X** so, dass die
+Sterne ganz links starten und über die ganze Breite rollen.
+
+  ![Effect Editor - Pixel Mapper - Transforming Star Element](/docs/images/Effect-Editor-Pixel-Mapper-Transforming-Star-Element.png)
+
+6.  Fügen Sie eine Verlagerungs (**Displacement**)-Animation hinzu. 
+
+  Jetzt rollt jedes Ungeheuer auf einer anderen Höhe herum.
+
+7.  Gehen Sie nun wieder zur linearen Bewegung und ändern Sie **Spawn Rate**
+so, dass mehr Ungeheuer gleichzeitig sichtbar sind (Häufigkeit neuer Elemente).
+
+  Ändern Sie **Direction Random** langsam. (Das ergibt leicht zufällige
+  Richtungen, basierend auf dem Wert für **Direction**).
+
+  ![Effect Editor - Pixel Mapper - Linear Movement Settings](/docs/images/Effect-Editor-Pixel-Mapper-Linear-Movement-Settings.png)
+
+8.  Fügen Sie nun eine **Zoom**-Animation hinzu.
+
+  Stellen Sie **Spawn Rate** auf 0. (Das ist eine spezielle Einstellung:
+  die Zoom-Animation läuft damit für jedes Element jeweils, solange es auf
+  dem Gitter sichtbar ist. Stellt man den Wert hingegen auf 1, so läuft
+  die Animation immer nur einmal, und die Gebilde verschwinden sehr rasch wieder).
+
+  Stellen Sie **Out Time** auf 100%. (Damit pulsieren die Ungeheuer von
+  ganz klein bis ganz groß -- keine Ahnung, warum sie das machen).
+
+  Verlangsamen Sie den Zoom etwas.
+
+  ![Effect Editor - Pixel Mapper - Zoom Animation Settings](/docs/images/Effect-Editor-Pixel-Mapper-Zoom-Animation-Settings.png)
+
+9.  Klicken Sie auf <Keys.SoftKey>Effect</Keys.SoftKey> und stellen Sie **Pre-Spool** auf 0.
+*(Dies dient zunächst zum Testen dieser Eigenschaft.)*
+
+  ![Effect Editor - Pixel Mapper - Zoom Animation Settings](/docs/images/Effect-Editor-Pixel-Mapper-Zoom-Animation-Settings-2.png)
+
+10. Speichern Sie mit <Keys.HardKey>Record</Keys.HardKey> den Cue. 
+
+11. Drücken Sie <Keys.HardKey>Clear</Keys.HardKey>, öffnen Sie die Matrix-Vorschau (**Pixel Mapper 
+Preview**), und starten Sie den Cue.
+
+  Damit ist die Fläche zunächst leer, und nur nach und nach erscheinen
+  die seltsamen Gebilde, um allmählich die Fläche zu bevölkern. Um das
+  zu ändern, nutzen wir nun **Pre-Spool**.
+
+12. Laden Sie den Cue mit <Keys.HardKey>Include</Keys.HardKey> wieder in den Programmierspeicher
+und öffnen Sie wieder den **Effekt-Editor**.
+
+13. Klicken Sie auf <Keys.SoftKey>Effect</Keys.SoftKey> und stellen Sie **Pre-Spool** auf etwa
+20s. Damit startet der Effekt mit einem Status, als ob er schon 20s	gelaufen wäre.
+
+14. Speichern Sie den Cue mit <Keys.HardKey>Record</Keys.HardKey>, drücken Sie <Keys.HardKey>Clear</Keys.HardKey>, 
+starten Sie den Cue und überprüfen Sie das Ergebnis wieder in der Vorschau.
+
+  Diesmal sollten direkt von Anfang an eine Menge ‚Ungeheuer' auf dem
+  Raster erscheinen. Pre-Spool ist besonders nützlich bei Animationen, die
+  bei geringer Geschwindigkeit und großer Aufspreizung (Spawn Rate)	arbeiten.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects/pixel-mapper.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects/pixel-mapper.md
@@ -1,0 +1,245 @@
+---
+id: pixel-mapper
+title: Der Pixelmapper
+sidebar_label: Der Pixelmapper
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Matrix-Effekte mit dem Pixelmapper erstellen
+
+<Video videoId="UchvGw2vvU8" title="Pixel Mapping" />
+
+Der Pixelmapper funktioniert mit Gruppen von Geräten, die mit dem
+[Gruppenlayout-Editor](../controlling-fixtures/fixture-groups.md#gerätereihenfolge-und--anordnung-in-den-gruppen) angeordnet wurden. Damit wird dem Pult mitgeteilt, wo sich
+die einzelnen Geräte tatsächlich auf der Bühne befinden. Daraufhin
+werden die einzelnen Pixel der Effekte passend auf die Geräte
+abgebildet, so dass der 2D-Effekt sichtbar wird. 
+
+> Am Ende dieses Abschnitts sind einige [Anwendungsbeispiele](pixel-mapper-examples.md) für das Arbeiten mit dem Pixelmapper aufgeführt. Das Vorgehen ist mit konkreten Beispielen deutlich einfacher zu verstehen. 
+
+Ist das Layout entsprechend eingerichtet, können Sie mit dem Pixelmapper
+wie folgt arbeiten:
+
+1. Wählen Sie die gewünschte Gerätegruppe aus.
+2. Im Hauptmenü wählen Sie <Keys.SoftKey>Shapes and Effects</Keys.SoftKey> und darauf <Keys.SoftKey>Pixel Mapper</Keys.SoftKey>.
+3. Wählen Sie <Keys.SoftKey>Create effect</Keys.SoftKey>. Damit öffnet sich der Pixel Mapper
+Editor mit einem schwarzen Hintergrund. Wahlweise kann das Gerätelayout
+mit angezeigt werden, um genauer arbeiten zu können. Klicken Sie dazu im
+Kontext-Bereich auf <Keys.SoftKey>Fixture Overlay 50/50</Keys.SoftKey>.
+
+![Effect Editor - Pixel Mapper - New Effect](/docs/images/Effect-Editor-Pixel-Mapper-New-Effect.png)
+
+### Elemente
+
+Klicken Sie unten auf die Schaltfläche <Keys.ContextKey>+</Keys.ContextKey>, um einen Effekt zu
+erzeugen, und wählen Sie eine der verfügbaren Formen aus. Zum **Entfernen**
+bereits erzeugter Elemente wählen Sie diese aus und klicken auf den <Keys.ContextKey>Papierkorb</Keys.ContextKey>,
+Es stehen folgende Elemente zur Verfügung:
+
+-   Quadrat
+-   Kreis
+-   Dreieck
+-   Stern
+-   Propeller (Fan)
+-   Spirale
+-   Text
+-   Zeichnen *(man kann auf dem Touchscreen zeichnen)*
+-   Bild aus Datei *(von der Festplatte oder einem USB-Stick)*
+-   [Synergy-Content](../synergy/operating-synergy.md#lightmap-pixelmapping-mit-ai) von einem Ai-Medienserver oder von Prism Zero
+
+![Effect Editor - Pixel Mapper - Adding an Element](/docs/images/Effect-Editor-Pixel-Mapper-Adding-an-Element.png)
+
+Nach der Auswahl wird das gewünschte Element oben rechts angezeigt und
+zu den verwendeten Geräten ausgegeben. Das Element lässt sich mit den
+Fadern unterhalb der Darstellung genauer einstellen (je nach
+Element-Typ):
+
+- Opacity (Sichtbarkeit)
+- X/Y-Position
+- Width, height (Breite, Höhe)
+- Zoom
+- Rotation
+- Border width (Randstärke)
+> Zum **Ändern der Farbe** klicken Sie links auf den **Namen des Layers**.
+
+![Effect Editor - Pixel Mapper - Circle on Layer](/docs/images/Effect-Editor-Pixel-Mapper-Circle-on-Layer.png)
+
+### Animationen
+
+Bei noch ausgewähltem Grafikelement (links in der Layer-Darstellung)
+klicken Sie nochmals auf <Keys.ContextKey>+</Keys.ContextKey> und wählen eine **Animation** (Bewegung)
+oder einen **visuellen Effekt** (etwa das Aufzoomen oder Einblenden).
+Damit wird der Effekt auf dem schwarzen Hintergrund und den Geräten
+animiert. Es lassen sich mehrere Animationen miteinander kombinieren, um
+komplexe Effekte zu erzielen.
+
+![Effect Editor - Pixel Mapper - Adding an Animation](/docs/images/Effect-Editor-Pixel-Mapper-Adding-an-Animation.png)
+
+Available animations are:
+
+Folgende Animationen stehen zur Verfügung:
+
+-   Rotation
+-   Verschieben (lineare Bewegung)
+-   Zoom
+-   Einblenden/Fade (Opacity)
+-   Zufall/Random
+-   Grid Fit *(genaues Einpassen der Elemente in das Raster)*
+-   Linearer Verlauf
+-   Radialer Verlauf
+-   Motion Blur *(Bewegungsunschärfe)*
+
+Eine Animation kann das jeweilige Element verschieben oder anderweitig
+verändern. Ebenso kann sie mehrere Kopien des Elements in
+unterschiedlichen Animationsstadien erzeugen (Spawn).
+
+Sie können die Parameter der einzelnen Animation ändern, indem Sie links
+auf deren Namen klicken. Abhängig vom Effekt werden verschiedene
+Schieberegler eingeblendet:
+
+- Speed *(Geschwindigkeit)*
+- Speed Random *(Zufälligkeit der Bewegung)*
+- Spawn Rate *(Häufigkeit neuer Kopien des Elements)*
+- Spawn Random *(Zufälligkeit neuer Kopien)*
+- Spawn For *(Maximalwert neuer Kopien des Elements)*
+- Run For / And Then *(Anzahl der Effekt-Durchläufe und bestimmen, ob
+danach gestoppt oder auch der Effekt deaktiviert werden soll - freeze
+oder kill)*
+- Direction / Direction Random *(Richtung und Zufälligkeit der Richtung -
+nur bei Bewegungen)*
+- Start Angle / End Angle *(Start/Endwert, nur bei Rotation)*
+
+Ein paar Tipps zu den Animationen:
+
+-   Für das Einpassen ins Raster (**Grid Fit**) ist die Anzahl von Zeilen und Spalten anzugeben.
+
+-   Für die **Verlaufs-Animation** stellen Sie den Start- und Endwert
+    sowie den Versatz dazwischen ein. Mit Spread wählen Sie die
+    Verlaufs-Kurve: Pad ist ein einfacher, einmaliger Verlauf. Reflect
+    ist ein Verlauf, der sich immer auf- und abbaut. Repeat schließlich
+    ist eine Wiederholung in immer nur einer Richtung).
+
+-   Gibt man einen Wert für **Spawn For** oder **Run For** ein, so
+    stoppt die Animation nach der entsprechenden Anzahl von Zyklen. Um
+    sie wieder zu starten, betätigen Sie den **Reset-Knopf** oben rechts im
+    Fenster des Effekt-Editors.
+	
+    ![Effect Editor - Pixel Mapper - Reset Button](/docs/images/Effect-Editor-Pixel-Mapper-Reset-Button.png)
+
+-   Für Effekte mit **Start** und **Endpunkt** bestimmt <Keys.SoftKey>Cycles</Keys.SoftKey> die Anzahl
+    der Durchläufe. Bei Effekten ohne Endpunkt bestimmt sich die Anzahl
+    hingegen aus dem Master-Tempo und der Geschwindigkeit der Animation.
+
+### Das Fenster Pixel Mapper Preview
+
+Zur Vorschau, wie der Effekt später aussehen wird, öffnen Sie das
+Fenster 'Pixel Mapper Preview': drücken Sie zweimal auf 
+[<Keys.HardKey>Open / View</Keys.HardKey>](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster) 
+und wählen <Keys.SoftKey>Pixel Mapper Preview</Keys.SoftKey>. Eine Vorschau der laufenden Effekte
+erscheint; unten können Sie zwischen den einzelnen Animationen
+umschalten.
+
+![Pixel Mapper Preview Window](/docs/images/Pixel-Mapper-Preview-Window.png)
+
+### Allgemeine Hinweise
+
+Wenn gewünscht, können mehrere Layer (Ebenen) miteinander kombiniert
+werden. Ist das gewünschte Ergebnis erzielt, so kann es als Cue
+gespeichert werden.
+
+> Sowohl beim Einstellen der Fader auf dem Bildschirm als auch beim Klicken und Ziehen lassen sich alternativ die Werte mit den Rädern oder den Zifferntasten eingeben. Um dies für einen Wert zu aktivieren, klicken Sie auf das Feld rechts, das den jeweiligen Wert zeigt. Mit einem Doppelklick kann man den Vorgabewert wiederherstellen, und mit <Keys.SoftKey>+/-</Keys.SoftKey> lässt sich der Wert invertieren.
+
+-   Die **Reihenfolge** der Layer lässt sich verändern, indem man zuerst auf
+    den zu verschiebenden Layer klickt und dann unten die Schaltflächen
+    'Pfeil hoch'/'Pfeil runter' bedient.
+
+-   Layer, Elemente und Animationen lassen sich mit <Keys.HardKey>Copy</Keys.HardKey> und <Keys.HardKey>Move</Keys.HardKey> **kopieren** und **verschieben**: drücken Sie <Keys.HardKey>Copy</Keys.HardKey> (oder <Keys.HardKey>Move</Keys.HardKey>), dann das zu verschiebende/kopierende Element, und
+    schließlich auf das gewünschte Ziel des Kopierens.
+
+### Master-Parameter für Effekte
+
+Jeder erstellte Effekt hat auch Master-Parameter, mit denen bestimmt
+wird, wie sich dieser im Zusammenspiel mit anderen Effekten verhält. Zur
+Anzeige dieser Master-Parameter klicken Sie links oben auf den
+Effekt-Namen:
+
+![Effect Editor - Pixel Mapper - Effect Master Parameters](/docs/images/Effect-Editor-Pixel-Mapper-Effect-Master-Parameters.png)
+
+-   Der Schalter **Block Effect** erlaubt es, einen Pixelmapper-Effekt zu
+    bauen, der andere laufende Pixelmapper-Effekte stoppt (je nach
+    [Priorität](../cues/playback-options.md#priority)). Damit ähnelt 
+	die Wirkung dem Block Shape.
+
+-   **Colour** bestimmt die Hintergrundfarbe dieses Effekts (unwirksam,
+    falls **Back Opacity** auf 0 steht).
+
+-   **Back Opacity** bestimmt die Sichtbarkeit anderer Effekte durch diesen
+    hindurch. Default ist 0 -- andere Effekte werden transparent
+    hindurchgelassen.
+
+-   **Opacity** bestimmt die Sichtbarkeit anderer Effekte im Vordergrund
+    dieses Effekts.
+
+-   **X/Y/Zoom/Rotation** bestimmen Position und Größe des Effekts.
+
+-   **Master Speed** ist die generelle Geschwindigkeit des Effekts. Das
+    beeinflusst die Animationsgeschwindigkeit sowie die Anzahl der
+    Zyklen.
+
+-   **Pre-Spool** startet der Effekt 'mittendrin', so als ob er bereits
+    eine Weile gelaufen sei. Damit lassen sich langsam aufbauende
+    Effekte gleich in ihrer ganzen Pracht starten.
+
+-   **Run For** / **And Then** wie viele Zyklen der Effekt laufen und
+    was dann passieren soll (**Freeze** (Stoppen), **Kill** (Deaktivieren) 
+	oder **Stop Spawning** (keine neuen Kopien erzeugen)). Vorgabe 
+	für **Run For** ist 0, also unbegrenzt.
+
+## Masterregler für Pixelmapper-Layer
+
+Jedem der vier Layer (Ebenen) des Pixelmappers kann ein Masterregler
+zugewiesen werden. Mit diesem kann der jeweilige Layer dann live
+gesteuert werden. Das Zuweisen erfolgt im System-Menü oder per <Keys.HardKey>Record</Keys.HardKey>,
+<Keys.SoftKey>Create Master</Keys.SoftKey>, <Keys.SoftKey>Pixel Mapper</Keys.SoftKey>. Wählen Sie <Keys.SoftKey>Layer 1</Keys.SoftKey> bis <Keys.SoftKey>Layer 4</Keys.SoftKey>
+und drücken Sie die Auswahltaste eines Faders. Darauf steuert dieser Fader die
+Sichtbarkeit (Helligkeit) des jeweiligen Layers.
+
+Damit ist es möglich, Cues und Paletten zu erzeugen, die die
+Layer-Einstellungen von Effekten steuern, die in anderen Cues
+gespeichert sind.
+
+Die Masterregler für die Layer müssen im Effekt-Editor aktiviert werden
+(Schaltfläche <Keys.SoftKey>Use Master</Keys.SoftKey>).
+
+> Für Layer-Masterregler sind ggf. aktualisierte Personalities
+    erforderlich.
+
+<Video videoId="rCIIH2-DCNM" title="Advanced Pixel Mapping" />
+
+## Pixelmapper-Effekte mit Mask FX stoppen
+
+Mit der **Mask FX**-Funktion lassen sich Playbacks programmieren, durch die 
+laufende Pixelmapper-Effekte auf einigen oder allen Geräten gestoppt werden.
+
+Ein Mask-Effekt wird wie folgt erzeugt:
+
+1.  Drücken Sie <Keys.SoftKey>Shapes and Effects</Keys.SoftKey>, <Keys.SoftKey>Mask FX</Keys.SoftKey>.
+2.	Wurden vorher keine Geräte ausgewählt, so wirkt sich der Mask-Effekt 
+	auf alle Geräte aus. Wurden dagegen Geräte angewählt, so gilt der 
+	Mask FX nur für diese.
+3.	Drücken Sie <Keys.SoftKey>Create Mask Pixel Map</Keys.SoftKey>. (Der Button <Keys.SoftKey>Create Mask FX</Keys.SoftKey> 
+	wirkt sich sowohl auf Pixelmapper-Effekte als auch auf Shapes aus.)
+4.	Der Mask FX ist sofort wirksam und stoppt laufende Pixelmapper-Effekte.
+	Speichern Sie diesen auf ein Playback, um nach Bedarf andere Effekte 
+	zu stoppen.
+	
+-   Mit dem Button <Keys.SoftKey>Clear mask from programmer</Keys.SoftKey> werden sämtliche Mask Effekte und Mask Shapes für alle Geräte aus dem Programmer gelöscht.
+
+-   Diese Funktion ersetzt **Block Effect** aus früheren Versionen. Shows, 
+  die noch den Block Effect enthalten, können trotzdem geladen werden und
+  funktionieren wie gewohnt, aber der Block Effect wird bereits als "Mask"
+  angezeigt.
+  
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects/shape-generator.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/effects/shape-generator.md
@@ -1,0 +1,300 @@
+---
+id: shape-generator
+title: Der Shape-Generator
+sidebar_label: Der Shape-Generator
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+<Video videoId="oTo6FxHD02o" title="Using Shape Generator" />
+
+Ein Shape ist eine automatische Folge von Werten, die verschiedene
+Attribute eines Gerätes modulieren kann. Ein Kreis-Shape (circle) etwa,
+angewendet auf Pan und Tilt, sorgt für eine Kreisbewegung des Gerätes.
+Dabei lässt sich das Zentrum des Kreises, die Größe sowie die
+Geschwindigkeit der Bewegung beeinflussen.
+
+Shapes sind besonders eindrucksvoll, wenn die auf mehrere Geräte
+angewandt werden. Dabei kann ein Shape auf mehreren Geräte gleichzeitig
+oder aber mit einem Versatz laufen (hier **Spread** oder **Phase** genannt), womit man rasch z.B. Welleneffekte
+erstellen kann.
+
+Außer Positions-Shapes gibt es eine große Anzahl weiterer Shapes. Diese
+sind jeweils pro Attribut definiert, etwa für Farbe, Dimmer, Fokus usw.
+
+Außerdem gibt es die Funktion **Mask FX**, mittels derer sich laufende
+Shapes stoppen lassen. Läuft etwa auf einigen Geräten ein Kreis-Shape,
+und wird dann ein Cue aufgerufen, in dem auf ein paar der Geräte ein
+'Position Mask-Shape' abgespeichert ist, so beenden diese Geräte ihre
+Kreisbewegung. Das ist hilfreich etwa beim Verändern von Cues während
+des Showablaufs. Details dazu siehe [Mask FX](shape-generator.md#masking-shapes-using-mask-fx).
+
+![Capture Visualiser with a shape running across fixtures](/docs/images/Capture-Visualiser-with-a-shape-running-across-fixtures.png)
+
+## Einen Shape erstellen
+
+Wird ein Shape ausgewählt, so wird dieser auf die zuvor angewählten
+Geräte angewendet.
+
+1. [Wählen Sie die Geräte](../controlling-fixtures.md#dimmer-und-geräte-zum-steuern-auswählen), auf die der Shape angewendet werden soll.
+2. Im Hauptmenü drücken Sie <Keys.SoftKey>Shape and Effects</Keys.SoftKey>, dann <Keys.SoftKey>Shape Generator</Keys.SoftKey>.
+3. Klicken Sie <Keys.SoftKey>Create</Keys.SoftKey>, um einen neuen Shape zu starten.<br/>
+  ![Shape Generator selecting a category of new shape](/docs/images/Shape-Generator-selecting-a-category-of-new-shape.png)
+4. Betätigen Sie eine <Keys.SoftKey>Menütaste</Keys.SoftKey>, um den Shape nach Attribut
+auszuwählen, oder drücken Sie <Keys.SoftKey>All Shapes</Keys.SoftKey> für eine Gesamtliste.
+5. Klicken Sie im **Shapes-Fenster** auf den gewünschten Shape, oder
+benutzen Sie eine <Keys.SoftKey>Menütaste</Keys.SoftKey> zur Auswahl. Ebenso kann man mit
+der Tastatur einen Suchbegriff für einen bestimmten Shape eingeben, um
+die Suche einzugrenzen.
+6. Der Shape wird auf die ausgewählten Geräte angewendet.
+
+-   Wird das **Shapes-Fenster** geöffnet, so bleibt es ständig offen, und
+    man muss nicht immer wieder <Keys.SoftKey>Shape Generator</Keys.SoftKey> drücken, um einen
+    Shape abzurufen. Dieses Fenster zeigt nur Shapes, die auf die
+    gewählten Geräte anwendbar sind. Wird ein Attribut ausgewählt, so
+    wird die Liste der verfügbaren Shapes weiter verkürzt auf Shapes,
+    die für dieses Attribut verfügbar sind. Zur Anzeige aller Shapes
+    wählen Sie <Keys.HardKey>Dimmer</Keys.HardKey>.
+
+    ![Shapes Workspace Window](/docs/images/Shapes-Workspace-Window.png)
+
+-   Der Ausgangswert für einen Shape ist die jeweilige momentane
+    Einstellung des Gerätes; *so wird z.B. ein Kreis-Shape um die
+    momentane Pan/Tilt-Position zentriert*.
+
+-   Zum Ändern des Basiswerts eines Shapes (etwa das Zentrum eines
+    Kreises) ändern Sie wie gewohnt die entsprechenden Attribute mit den
+    Rädern. Ggf. stellt man dazu die Größe des Shapes auf null (siehe
+    [nächster Abschnitt](#ändern-von-größe-und-geschwindigkeit)), um den Basiswert genau einstellen zu können.
+
+-   Zum gleichzeitigen Abruf mehrerer Shapes wiederholen Sie einfach die
+    o.g. Prozedur. Ebenso lassen sich auch mehrere Shapes auf das
+    gleiche Gerät anwenden, womit weitere interessante Effekte erzielt
+    werden können.
+
+-   Zur Anzeige der momentan laufenden Shapes drücken Sie <Keys.SoftKey>Shapes and Effects</Keys.SoftKey>, 
+    dann <Keys.SoftKey>Shape Generator</Keys.SoftKey> und dann <Keys.SoftKey>Edit</Keys.SoftKey>.
+
+-   Wird der gleiche Shape auf zwei verschiedene Gruppen von Geräten
+    angewendet, so erscheint er doppelt in der Liste. Damit lassen sich
+    die beiden Gruppen getrennt voneinander beeinflussen, etwa für
+    unterschiedliche Richtungen, Geschwindigkeiten etc. ([s.u.](#ändern-von-größe-und-geschwindigkeit))
+
+-   Hat das ausgewählte Gerät Teilgeräte (Zellen, Subfixtures), so kann
+    man wählen, ob der Shape auf dem Hauptgerät laufen soll und alle
+    einzelnen Zellen synchron laufen, oder ob die Zellen einzeln
+    angesteuert werden. Es gibt folgende Optionen:
+    -   <Keys.SoftKey>Run on Super Fixtures</Keys.SoftKey> - Zellen werden ignoriert, die Geräte werden im
+    Ganzen angesteuert
+    -   <Keys.SoftKey>Run on Sub Fixtures (Linear)</Keys.SoftKey> - die Zellen werden gemäß ihrer internen
+    Nummerierung angesteuert
+    -   &nbsp;<Keys.SoftKey>Run on Sub Fixtures (Group)</Keys.SoftKey> - die Zellen werden gemäß ihrer Anordnung
+    (Layout-Editor für die jeweilige Gruppe) angesteuert.
+
+-   Jeder Shape ist für ein spezifisches Attribut konzipiert. Verfügt
+    ein Gerät nicht über dieses Attribut, so führt auch der Shape zu
+    keinem sichtbaren Effekt.
+
+-   Jeder Shape hat eine Standardgröße und -geschwindigkeit *(wird in
+    der Shape-Datei definiert)*.
+
+> Wird ein 'Rainbow'-Farbshape verwendet, so müssen die Farb-Grundwerte (CMY oder RGB) auf **50%** gestellt werden, um sämtliche Farbkombinationen zu erzielen..
+
+## Ändern von Größe und Geschwindigkeit
+
+Nachdem ein Shape gestartet ist, lassen sich schnell und einfach Größe
+und Geschwindigkeit ändern. Wenn im Display oberhalb der Encoder 'Spread'
+und 'Offset' steht, so drücken Sie Taste E <Keys.SoftKey>Adjust Speed, Size and Spread</Keys.SoftKey>.
+
+![Shape Wheel Attribute Controls for Speed, Size & Spread](/docs/images/Shape-Wheel-Attribute-Controls-for-Speed-Size-Spread.png)
+
+-   Der linke Encoder steuert die Geschwindigkeit des Shapes.
+
+-   Der mittlere Encoder steuert die Größe des Shapes.
+
+-   Größe und Geschwindigkeit werden im Display angezeigt.
+
+Weitere Dinge über Größe und Geschwindigkeit:
+
+-   Laufen mehrere Shapes, so sind die Encoder dem zuletzt geladenen
+    zugeordnet. Die Parameter jedes einzelnen laufenden Shapes lassen
+    sich mit der 'Edit Shape'-Funktion einstellen, siehe
+    [Ändern von Shapes mit Include](editing-shapes-and-effects.md#ändern-von-shapes-mit-include).
+
+-   Die Minimalgröße ist Null. Dies lässt den Shape *"verschwinden"*, und
+    das Gerät kehrt zu den vorherigen Einstellungen zurück. Dennoch ist
+    der Shape noch aktiv.
+
+-   Sobald ein Shape in einem Cue gespeichert ist, können Größe und/oder
+    Geschwindigkeit entweder mit dem Fader des Cues gesteuert werden,
+    oder man legt entsprechende [Masterfader](../running-the-show/playback-controls.md#speed--und-size-master) an und verwendet diese (Rate-Master, BPM-Master, Size-Master).
+
+## Ändern der Verteilung eines Shapes (mehrere Geräte)
+
+Shapes wirken interessanter (und eindrucksvoller), wenn sie auf mehrere
+Geräte angewendet werden. Titan erlaubt es, den Spread (Verteilung)
+eines Shapes zwischen mehreren Geräten einzustellen. Ebenso lässt sich
+die Phasenlage (Versatz) einstellen: ein anderer Ansatz für die gleiche
+Eigenschaft.
+
+Die Reihenfolge, in der der Shape auf den ausgewählten Geräten abläuft,
+hängt von der Reihenfolge ab, in der die Geräte beim Abruf des Shapes
+ausgewählt wurden. Mittels <Keys.SoftKey>Fixture Order</Keys.SoftKey> lässt sich die
+Geräte-Reihenfolge innerhalb des Shape-Menüs ändern.
+
+1. Wenn der rechte Encoder nicht gerade den Spread steuert, drücken Sie
+auf <Keys.SoftKey>Adjust Speed, Size and Spread</Keys.SoftKey>
+2. Steuern Sie den **Spread** (die Verteilung) mit dem rechten Encoder, 
+oder betätigen Sie <Keys.SoftKey>Adjust Spread, Phase and Offset</Keys.SoftKey> und benutzen das 
+mittlere Rad, um den Geräteversatz (Phase) einzustellen *(rechtes Rad 
+beim Pearl Expert)*.
+
+Spread = **12** *(Phase = 30 degrees)*:
+
+![Capture Visualiser with a shape running across fixtures with spread of 12](/docs/images/Capture-Visualiser-with-a-shape-running-across-fixtures-with-spread-of-12.png)
+
+Spread = **6** *(Phase = 60 degrees)*:
+
+![Capture Visualiser with a shape running across fixtures with spread of 6](/docs/images/Capture-Visualiser-with-a-shape-running-across-fixtures-with-spread-of-6.png)
+
+Spread = **2** *(Phase = 180 degrees)*:
+
+![Capture Visualiser with a shape running across fixtures with spread of 2](/docs/images/Capture-Visualiser-with-a-shape-running-across-fixtures-with-spread-of-2.png)
+
+Im Display wird die **Phase** in ° (Grad) angezeigt. So sorgt etwa
+Phase=180° für eine Wiederholung jedes zweiten Gerätes, 90° jedes
+vierten Gerätes, 60° jedes sechsten Gerätes usw.
+
+&nbsp;**Offset** ist der Startwert des Shapes im Vergleich zu anderen gleichzeitig
+laufenden Shapes. *Wenn beispielsweise gleichzeitig ein Shape auf Cyan
+und einer auf Magenta läuft, um einen Farbmix zu erzielen, so möchte man
+vielleicht mit Cyan auf 100% und Magenta auf 0 beginnen, um den gesamten
+Farbbereich abzudecken. Dazu stellt man einen der beiden Shapes auf
+einen ‚Phase Offset' von 180°.* Ohne diese Einstellung würden beide
+Shapes gleichzeitig 0 bzw. 100% erreichen.
+
+>   Nach dem Ändern von Offset oder Phase empfiehlt es sich, den Shape 
+	**neu zu starten**, damit alle Shapes neu synchronisiert werden. Dazu gibt 
+	es im Menü 'Edit Shape' die Menütaste <Keys.SoftKey>Restart Shapes</Keys.SoftKey>.
+
+## Shape-Richtung
+
+Die Menüfunktion <Keys.SoftKey>Direction</Keys.SoftKey> erlaubt es, die Richtung des Shapes
+zu ändern; hat man ein [2D-Layout](../controlling-fixtures/fixture-groups.md#gerätereihenfolge-und--anordnung-in-den-gruppen) erstellt, so kann man abhängig vom
+Shape eine gezielte Bewegung erreichen.
+
+Mit der Taste <Keys.HardKey>Menu Latch</Keys.HardKey> lässt sich das "Shape Direction"-Menü
+einrasten, so dass man schnell die verschiedenen Einstellungen
+durchprobieren kann.
+
+## Beat und Cycles (Durchläufe)
+
+Die Option <Keys.SoftKey>Adjust Beat and Cycles</Keys.SoftKey> steuert, wie das generelle Tempo
+des Programmers das Tempo des Shapes beeinflusst und wie oft dieser
+läuft.
+
+### Beats
+
+Vorgabewert ist <Keys.SoftKey>Beats=1</Keys.SoftKey>: jeder Beat entspricht einem kompletten
+Durchlauf des Shapes, wie in früheren Software-Versionen. Höhere Werte
+dagegen sorgen dafür, dass das Tempo des Shapes entsprechend reduziert
+wird. Mit z.B. <Keys.SoftKey>Beats=4</Keys.SoftKey> lässt sich erreichen dass für einen
+kompletten Shape-Durchlauf 4 Beats erforderlich sind -- der Shape läuft
+langsamer.
+
+Klickt man auf den Wert des **linken Encoders** im Display oder betätigt die <Keys.HardKey>@A</Keys.HardKey>-Taste, 
+so kann man die gewünschte Zahl direkt eingeben; außerdem
+werden zwei weitere Optionen angeboten: mit <Keys.SoftKey>Match to Spread</Keys.SoftKey> (an den
+Spread anpassen) wird der Beat Count auf den Spread-Wert des Shapes
+gesetzt, was vor allem bei Dimmer-Shapes sinnvoll ist. Klickt man
+dagegen auf <Keys.SoftKey>Custom</Keys.SoftKey>, so kann man einen numerischen Wert eingeben.
+
+### Cycles
+
+Mit Cycles (Durchläufe) stellt man ein, wie oft der Shape laufen soll.
+Vorgabewert ist Unendlich (∞), womit der Shape läuft, bis er wieder
+gestoppt wird. Ändert man dies auf eine andere Zahl, so läuft der Shape
+nur die vorgegebene Anzahl von Zyklen und hält dann an.
+
+Zum direkten Eingeben eines Zahlenwertes drücken Sie die Taste <Keys.HardKey>@B</Keys.HardKey> oder 
+klicken auf den Wert des **mittleren Encoder** im Bildschirm. 
+Eine Eingabe von Dezimalzahlen (z.B. 1.5) sorgt dafür, dass der letzte 
+Durchlauf nur zum Teil durchgeführt wird und dann stehenbleibt.
+
+## Verwenden von Shapes in Cues
+
+Wird ein Shape in einen Cue (auf ein Playback) gespeichert, so lässt
+sich mit den [Options](../cues/playback-options.md) des Playbacks einstellen, 
+dass der Fader z.B. die Größe und/oder Geschwindigkeit
+des Shapes steuert; ebenso lassen sich [Master (Size, Speed, BPM)](../running-the-show/playback-controls.md#speed--und-size-master) für die
+Steuerung verwenden.
+Bei Dimmershapes wird per default die Größe des Shapes mit dem Fader gesteuert.
+
+Shapes lassen sich auch in Cuelisten verwenden - in [Tracking von Shapes in Cuelisten](../cue-lists/creating-a-cue-list.md#tracking-von-shapes-in-cuelisten) ist beschrieben, wie sich die Shapes in diesem Fall verhalten.
+
+Zum Editieren aktuell laufender Shapes siehe [Ändern eines gerade laufenden Shapes](../effects/editing-shapes-and-effects#ändern-eines-gerade-laufenden-shapes).
+
+### Shape-Verhalten: Overlay oder LTP
+
+Shapes und Keyframe-Shapes, die in Playbacks gespeichert sind, können entweder als **Overlay** arbeiten (per default), also andere programmierte Attribute überlagern, oder wie gewohnt als **LTP**-Werte, werden also ihrerseits von später gestarteten Playbacks überlagert/überschrieben. Dafür gibt es die Einstellung **Shape Behavior**.
+
+Die globale Einstellung des Shape-Verhaltens erfolgt in den [Benutzereinstellungen](../system-settings/user-settings.md#shape-behaviour). Dies kann individuell für einzelne Playbacks in deren [Optionen](../cues/playback-options.md#shape-behaviour) anders eingestellt werden.
+
+-   &nbsp;<Keys.SoftKey>Overlay</Keys.SoftKey> (Voreinstellung) ist das von Shapes gewohnte 
+    Verhalten. Ein aktiver Shape oder Keyframe-Shape hat Priorität über die
+    betreffenden Geräte/Attribute und läuft, bis er beendet wird. Läuft
+    z.B. ein Keyframe-Shape, der die Farbe der Geräte verändert, und
+    startet man einen weiteren Colour-Cue, so ist dies zunächst nicht
+    sichtbar. Ebenso ist zunächst keine Änderung zu sehen, wenn man etwa
+    Paletten aufruft oder die Farbe anderweitig verändert. Erst wenn der
+    Shape beendet wird, werden die im Hintergrund vorgenommenen
+    Änderungen aktiv. Auf diesem Wege lässt sich einfach bei laufendem
+    Keyframe-Shape ein neues Bild einstellen, auf das dann nahtlos
+    übergeblendet werden kann.
+
+-   &nbsp;<Keys.SoftKey>LTP</Keys.SoftKey> funktioniert dagegen eher wie ein Chaser. Nachträglich
+    gestartete Änderungen auf der gleichen Priorität überschreiben den
+    Keyframe-Shape. Startet man also z.B. bei laufendem Colour-Keyframe-Shape
+    (Priorität normal) ein anderes Colour-Playback (ebenfalls Priorität normal), 
+    so blockiert dieses den Keyframe-Shape. Deaktiviert man das Playback, so ist 
+    wieder der Keyframe-Shape aktiv. Gleiches gilt beim Aufruf von Paletten, wobei in diesem
+    Fall der Keyframe-Shape neu gestartet werden muss. Zu beachten ist,
+    dass Quick Palettes mit 'Priority=High' funktionieren. Stellt man
+    also wiederum das Playback mit dem Keyframe-Shape auf
+    'Priority=High' oder höher, verhindert man das Überschreiben durch
+    Quick Palettes. Ebenso kann man 'Priority=Very High' wählen und
+    damit verhindern, dass der Inhalt des Programmers den Keyframe-Shape
+    überschreibt. Details zur Priorität siehe [Priority](../cues/playback-options.md#priority).
+
+## Shapes stoppen mit Mask FX
+
+Mit der Funktion **Mask FX** können Playbacks programmiert werden, die
+laufende Shapes und Keyframe-Shapes auf einzelnen oder allen Geräten
+stoppen.
+
+Um einen Mask Effekt zu erzeugen, gehen Sie wie folgt vor:
+
+1.  Drücken Sie <Keys.SoftKey>Shapes und Effekte</Keys.SoftKey>, dann <Keys.SoftKey>Mask Fx</Keys.SoftKey>
+    (Diamond 9 und Diamond 7 haben eigens eine Taste <Keys.HardKey>Mask FX</Keys.HardKey> - drücken Sie diese zweimal, um alle Attribute in der Maske zu aktivieren).
+2.  Die Attributbank-Buttons flashen (P, C etc.). Wählen Sie die
+    Attribute, für die Shapes maskiert werden sollen.
+3.  Sind keine Geräte angewählt, so wirkt sich dies auf alle Geräte aus.
+    Sind dagegen Geräte gewählt, so werden nur diese beeinflusst.
+4.  Wählen Sie <Keys.SoftKey>Create Mask Shape</Keys.SoftKey>. (Mit <Keys.SoftKey>Create Mask FX</Keys.SoftKey> lassen
+    sich sowohl Shapes als auch Pixelmaps stoppen).
+5.  Wird dies in ein Playback gespeichert, so kann man mit diesem
+    laufende Effekte stoppen.
+
+-   Mit <Keys.SoftKey>Clear Mask from Programmer</Keys.SoftKey> werden Mask FX-Effekte wieder
+	gelöscht.
+
+-   Diese Funktion ersetzt die früheren Block Shapes und Block Effekte.
+	Werden ältere Shows mit solchen Effekten geladen, so werden diese jetzt
+	als Mask Fx angezeigt.
+
+## Speichern von Shapes in Paletten
+
+Es lassen sich auch Paletten mit Shapes erstellen. Das ist z.B. sehr
+hilfreich mit verschiedenen Spread- oder Size-Einstellungen. Siehe
+[Effekt-Paletten](../palettes/creating-palettes.md#erstellen-einer-effekt-palette).

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/fixture-personalities.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/fixture-personalities.md
@@ -1,0 +1,170 @@
+---
+id: fixture-personalities
+title: Die Personalities (Gerätedateien)
+sidebar_label: Die Personalities (Gerätedateien)
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Für jeden einzelnen Gerätetyp gibt es eine *'Personality'* genannte
+Gerätedatei, welche bestimmt, wie das Gerät gesteuert wird, auf welchem
+Kanal etwa der Dimmer (HTP) liegt, und die eine Menge weiterer
+Informationen enthält. Beim Patchen wird dem Pult mitgeteilt, welche
+Personality es verwenden soll.
+
+Das Pult enthält bereits eine sehr große Auswahl solcher Gerätedateien
+im internen Speicher,aber ebenso wie ständig neue Geräte auf dem Markt
+erscheinen, aktualisiert Avolites ständig die Gerätebibliothek.
+
+Es empfiehlt sich also, gelegentlich das Pult zu aktualisieren, um neue
+Geräte 'im Pult' zu haben, um evtl. auch von Fehlerbehebungen zu
+profitieren, sowie um schließlich auch neu hinzugekommene Möglichkeiten
+wie z.B. die Teilgeräte (Zellen, Subfixtures) nutzen zu können.
+
+## Herunterladen der Personalities bei Avolites
+
+Auf der [Website von Avolites](http://personalities.avolites.com) sind 
+sämtliche Geräte aufgeführt, für die es eine Avolites-Personality gibt. 
+Hier sollte man als erstes nachsehen, wenn man ein bestimmtes Gerät sucht. 
+Die Adresse ist http://personalities.avolites.com
+
+[![Avolites Personalities Website](/docs/images/Avolites-Personalities-Website.png)](https://personalities.avolites.com/)
+
+In der Liste links sind sämtliche verfügbaren Personalities aufgeführt.
+Mit den Eingabefeldern direkt darüber lässt sich die Liste filtern, etwa
+anhand des Herstellers, des Gerätenamens, oder danach, für welches Pult
+man eine solche Datei sucht.
+
+Klicken Sie nun auf den Gerätenamen in der Liste, um im Fenster rechts
+die Details zu überprüfen. Hier werden nun sämtliche für dieses Gerät
+verfügbaren Personalities aufgeführt (wird der obige Hinweis beachtet,
+so tauchen hier nur Dateien für Ihr Pult auf).
+
+Ist die gesuchte Personality in der Standard-Bibliothek enthalten, so
+ist die entsprechende Spalte markiert.
+
+Ist eine geeignete Personality aufgeführt, so laden Sie die komplette
+Gerätebibliothek herunter und speichern Sie sie auf einem USB-Stick.
+
+## Aktualisieren des Personality-Speichers des Pultes
+
+Laden Sie wie oben beschrieben die aktuelle Personality-Library herunter
+(durch Klick auf **Titan Fixture Library** auf der Startseite der
+[Personalities-Seite](https://personalities.avolites.com), 
+oder über den **Download**-Link oben auf der Seite, und
+wählen danach **Titan Fixture Library**).
+
+Es gibt verschiedene Download-Pakete, abhängig von der jeweiligen 
+&nbsp;**Titan-Version**. Diese unterscheiden sich hinsichtlich der enthaltenen 
+Capture-Library; die Titan-Personalities sind jedoch identisch.
+
+- Das Pult speichert den Inhalt des Personality-Verzeichnisses
+(FixtureLibrary) zwischen, sobald das Patch-Menü aufgerufen wird.
+Daher muss die Software neu gestartet werden, sobald neue
+Personalities eingespielt wurden (Tools -> Restart Software. Ein
+kompletter Neustart des gesamten Pultes ist nicht erforderlich).
+
+- Sobald ein Gerät gepatcht wurde, wird die zugehörige Personality in
+die Show-Datei integriert. Deshalb werden bereits gepatchte Geräte
+durch Änderungen in der Library nicht beeinflusst. Wählen Sie ggf. <Keys.SoftKey>Update Personality</Keys.SoftKey> 
+aus dem Menü <Keys.HardKey>Patch</Keys.HardKey> <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>, um
+auch bereits gepatchte Geräte zu aktualisieren, siehe [Bereits gepatchte Personalities aktualisieren](./patching/changing-the-patch.md#bereits-gepatchte-personalities-aktualisieren).
+
+> Beim Updaten gehen sämtliche von Ihnen in der Library vorgenommenen Änderungen 
+  verloren. Um dies zu vermeiden, speichern Sie Ihre persönlichen Personalities im 
+  Ordner für Benutzer-Personalities, siehe nächster Abschnitt.
+
+### Updaten der Personalities eines Pultes
+
+1. Kopieren Sie die heruntergeladene Datei **TitanFixtureLibrary.exe** 
+   auf einen USB-Stick, und verbinden Sie diesen mit dem Pult
+2. Klicken Sie auf **Tools** oben links auf dem Bildschirm, dann auf
+   **Control Panel** und schließlich auf **Titan Installers**.
+3. Nun werden die auf dem USB-Stick gefundenen Installer angezeigt 
+   *(im Hauptverzeichnis des USB-Sticks, Dateinamen nicht verändert)*,
+   darunter auch die **TitanFixtureLibrary.exe**. Klicken Sie diese an, und
+   bestätigen Sie den Dialog mit <Keys.HardKey>OK</Keys.HardKey>.<br/>
+   Sollte die Datei nicht in diesem Menü zu finden sein, so öffnen
+   Sie mit **Tools** > **Folders** den Explorer, navigieren zum 
+   richtigen Laufwerk und Verzeichnis und starten die Datei per
+   Doppelklick.
+4. Starten Sie das Pult neu (Aus- und Einschalten, oder mit dem Befehl
+   **Restart Software** aus dem Tools-Menü).
+
+### Updaten der Personalities der Titan PC Suite (T1, T2, T3, Titan Mobile und Titan Simulator)
+
+1. Starten Sie die heruntergeladene Datei **TitanFixtureLibrary.exe** per
+   Doppelklick und bestätigen Sie den Dialog mit <Keys.SoftKey>OK</Keys.SoftKey>. Möglicherweise 
+   wird eine Windows-Warnung ausgegeben.
+2. Bestätigen Sie die Warnung der Window-Benutzerkontensteuerung mit <Keys.SoftKey>OK</Keys.SoftKey>.
+3. Sobald die Installation der Library erfolgt ist, schließen und starten Sie die Titan-Software erneut.
+
+## Selbsterstellte Gerätedateien
+
+Mit dem Programm 'Personality Builder', welches mit auf dem Pult
+installiert ist, lassen sich bestehende Personalities anpassen sowie
+neue erstellen.
+
+> Das Pult lädt neue Personalities, sobald die Software neu gestartet 
+wird. Haben Sie eine neue Personality eingefügt, so müssen Sie die 
+**Software neu starten**, um die neue Personality verwenden zu können.
+
+Sie können Ihre selbsterstellten Personalities in die normale
+Personality-Bibliothek des Pultes integrieren. Allerdings werden in 
+diesem Fall beim nächsten Aktualisieren Ihre Personalities gelöscht
+und Änderungen rückgängig gemacht werden.
+
+Um dies zu vermeiden, bietet sich ein spezielles Verzeichnis an: 
+`D:\Personalities` bzw. bei der Titan PC-Suite ist dies `\Documents\Titan\Personalities`.
+
+Beim Patchen wird dieser Ordner zuerst durchsucht; ist eine passende
+Personality vorhanden, so wird diese anstelle der allgemeinen Bibliothek
+verwendet. Dieser Ordner wird beim Updaten nicht überschrieben.
+
+## Anfordern einer neuen Gerätedatei
+
+Sollte es für ein bestimmtes Gerät noch keine Personality geben, so
+fertigt Avolites diese gern an. Klicken Sie dazu in o.g. Internetseite
+auf den Link [Request](https://personalities.avolites.com/?mainPage=Request%20Queue.asp&) auf
+der [Personalities Website](https://personalities.avolites.com/), um 
+die Einzelheiten anzugeben. Dabei sehen Sie auch eine Liste der momentan 
+offenen Anforderungen; bitte vermeiden Sie Doppel-Anfragen.
+
+Neu realisierte Personalities werden von Avolites direkt in die online
+verfügbare Library integriert: um also eine solche Personality zu
+installieren, laden Sie die Gesamtdatei und installieren diese, [wie oben
+beschrieben](#updating-the-personality-library-on-the-console.
+
+## Fehler der Personalities an Avolites berichten
+
+Sollten Sie einen Fehler in der Gerätedatei eines Gerätes finden, so
+wäre Avolites für eine Rückmeldung dankbar. Suchen Sie das entsprechende
+Gerät auf der Website und klicken Sie auf die Schaltfläche **Report Bug**
+rechts im Fenster. Ein Klick auf [Bug Reports](https://personalities.avolites.com/Bug%20Queue.asp) oben öffnet eine Liste
+mit den momentan ausstehenden Problemen, um zu überprüfen, ob vielleicht
+jemand anderes das gleiche oder ein ähnliches Problem schon gemeldet
+hat.
+
+## Im Notfall
+
+Die Pult-Software enthält auch eine Liste an 'Generic Fixtures'
+(Standardgeräten), mit denen man im Notfall auch Geräte programmieren
+kann, für die es keine Personality gibt. Dazu suchen Sie beim Patchen
+den Hersteller 'Generic'. Dort finden sich u.a. folgende Geräte:
+
+Multi-DMX: bis zu 10 DMX-Kanäle, alles LTP. Wählen Sie die Anzahl der
+DMX-Kanäle im Menü ‚Modes'. Nutzen Sie die Attributbank-Tasten sowie die
+Funktionstasten, um die einzelnen Kanäle auszuwählen.
+
+Generic RGB: Zum Steuern von RGB-Geräten, etwa LED-Leuchten. Dabei kann
+man zwischen fünf Modi wählen:
+- 1: **Dim**,  2: **R**,  3: **G**, 4: **B**
+- ***VDim***, 1: **R**, 2: **G**, 3: **B**
+- 1: **R**, 2: **G**, 3: **B**, 4: **Dim**
+- ***VDim*** + 4x **RGB**
+- 4x **RGB**
+
+> ***VDim*** ist ein vom Pult emulierter 'virtueller' Dimmer für Geräte, die
+über keinen solchen Gesamtkanal verfügen. Bei Verwendung dieses Kanals
+werden automatisch die RGB-Werte entsprechend beeinflusst.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/fixture-personalities.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/fixture-personalities.md
@@ -50,8 +50,8 @@ Gerätebibliothek herunter und speichern Sie sie auf einem USB-Stick.
 ## Aktualisieren des Personality-Speichers des Pultes
 
 Laden Sie wie oben beschrieben die aktuelle Personality-Library herunter
-(durch Klick auf **Titan Fixture Library** auf der Startseite der
-[Personalities-Seite](https://personalities.avolites.com), 
+(durch Klick auf **Titan Fixture Library** auf
+[https://personalities.avolites.com](https://personalities.avolites.com), 
 oder über den **Download**-Link oben auf der Seite, und
 wählen danach **Titan Fixture Library**).
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/glossary.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/glossary.md
@@ -1,0 +1,113 @@
+---
+id: glossary
+title: Glossar/Stichwortverzeichnis
+sidebar_label: Glossar/Stichwortverzeichnis
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Hier werden die wichtigsten Fachbegriffe aufgelistet und erklärt, die
+bei der Arbeit mit Avolites-Pulten sowie in diesem Handbuch vorkommen.
+Sollten einzelne Begriffe bei anderen Herstellern eine andere Bedeutung
+haben, so wird auch dies entsprechend erläutert.
+
+Begriff	| Bedeutung
+------------|----
+ADDRESS		| Der erste von einem Gerät verwendete DMX-Kanal. Diese sog. Startadresse wird normalerweise am Gerät eingestellt, ggf. auch per RDM.
+ALIGN  <br/>(Angleichen) | Kopieren von Attributwerten von einem auf ein oder mehrere Geräte, die dadurch den gleichen Output erzeugen.
+ART-NET		| Ethernet-basiertes System zum Übertragen mehrerer DMX-Universen über Netzwerk.
+ATTRIBUTE	| Zu steuernde Funktion eine Gerätes, z.B. 'Farbrad' oder 'Fokus'.       
+ATTRIBUTE GROUPS	| siehe IPCGBES.
+AUTOLOAD	| Playback, welches durch eine Cueliste gestartet wird. Damit können z.B. Chaser durch Cuelisten gestartet werden.                              
+BACKUPS		| Sicherungskopie einer Show, etwa auf einem USB-Stick.
+BPM			| Beats Per Minute. 60 BPM entsprechen einem Beat (Schritt) pro Sekunde.
+BLIND		| Im Blind-Modus haben Werte im Programmer keine Auswirkung auf den DMX-Ausgang. So können z.B. während der Show unbemerkt Änderungen vorgenommen werden.
+BUSKING<br/> (Improvisieren)	| Spontanes, improvisiertes 'Drücken' einer Lichtshow, die also nicht komplett durchprogrammiert ist. Wichtige Hilfsmittel sind Paletten und Effekte.
+CELL <br/> 	(Zelle, Teilgerät)  	| Teil eines größeren Gerätes, welches einzeln gesteuert werden kann. So kann z.B. ein LED-Fluter 12 Zellen haben, die einzeln gesteuert werden können. Auch als Subfixture (Teilgerät) bekannt.
+CHANNEL		| Mit der <Keys.HardKey>Channel</Keys.HardKey>-Taste auf älteren Pulten können Geräte per Tastensyntax angewählt werden. (auf neueren Pulten: Fixture)
+CHASE<br/>(Lauflicht)   		| Sequenz von mehreren Cues, die automatisch nacheinander ablaufen.
+COLOUR MIX / CMY	| System aus drei bestimmten Farbfiltern (Cyan, Magenta, Gelb), durch deren Mischung sich das gesamte Farbspektrum abbilden lässt.
+CONNECTED CHASE	| Chaser, der mit der Steuerung (Encoder und Tasten) verbunden ist.
+CUE			| Einzelne Lichtstimmung (oder Teil davon), die auf einem Fader oder einer Taste/Button programmiert ist. Kann auch Teil einer Cueliste sein. Auch bekannt als Memory, State, Szene oder Look.
+CUE LIST <br/> (Cueliste) 	| Sequenz aus mehreren Cues, die auf einen Fader oder Button programmiert ist. Jeder Cue kann individuelle Fadezeiten haben sowie auch andere Cues oder playbacks starten. Auch bekannt als Cue Stack oder einfach nur Stack. 
+CUE MODE	| Einstellung eines Playbacks zur Bestimmung der Wirkungsweise des Faders. Es gibt die Cue-Modes (Fadermodes) 0 bis 3.
+CURVE <br/>(Kurve, Kennlinie)  		| Bestimmt den Verlauf des Ausgangssignals in Abhängigkeit von der Faderstellung oder der Zeit.
+DEVICE	(Gerät) 	| Siehe FIXTURE.
+DIMMER		| Der Kanal zur Helligkeitssteuerung, oder Gerät zur Helligkeitssteuerung konventioneller Leuchten.
+DMX	DMX512(1990) | Signalstandard zur Kommunikation zwischen Lichtpulten und Leuchten/Geräten. Ursprünglich für Dimmer konzipiert, jetzt auch für  Moving Light verwendet. Bis zu 512 Kanäle werden in einem Universum zusammengefasst. Jedes Titan-Pult kann (ggf. mit TNPs) bis zu 64 Universen ausgeben.
+EXCHANGE (Auswechseln) 	| Tauschen eines bereits gepatchten und programmierten Geräts gegen einen anderen Typ unter Beibehaltung der Programmierung.
+FADE	(Überblenden)  	| Stetiger/allmählicher Wechsel von einem Pegel zu einem anderen Pegel.
+FAN			| Auffächern von Attributwerten ausgehend von einem Mittelwert, um das Programmieren zu erleichtern.
+FIXTURE	(Gerät)   	| Jedes Beleuchtungsgerät, das mit seinerPersonality gepatcht wird. Kann Moving Lights, Farbwechsler und anderes umfassen, jedoch normalerweise keine einzelnen Dimmerkanäle. Auch bekannt als Intelligent Fixture, Device, positionierbarer Scheinwerfer etc. 
+FIXTURE GROUP LAYOUT	| 2D-Anordnung der gepatchten Geräte im  Pult, zur Verwendung mit Shapes und dem Pixelmapper.
+FLASH		| Taste, mit der eine Lichtstimmung dem sonstigen Output hinzugefügt wird. Früher auch ‚ADD' genannt. Siehe hingegen SWOP.                        
+FLIP		| Funktion bei kopfbewegten Scheinwerfern, um mit einer anderen Kombination aus Pan und Tilt auf die gleiche Position zu fahren.
+FOCUS		| Frühere Bezeichnung von Paletten (einzelnen Positionen, Farben oder Gobos etc.).<br/><br/>Beschreibt auch den Fokus (Schärfe) von Moving Lights, etwa mit Gobos.
+FX			| Effekte, etwa unter Verwendung des Shape Generators.
+GENERIC		| Beschreibt reine Dimmer-Kanäle. Siehe auch FIXTURE.
+GROUP  (Gruppe)     | Zusammenstellung von gepatchten Geräten, die mit einem Klick ausgewählt werden kann. Ebenso sind Playback-Gruppen möglich, innerhalb derer jeweils nur ein Playback aktiv ist.
+HALO		| Farbiger Rand um eine Schaltfläche zur besseren Übersicht.
+HANDLE		| Speicherplatz, auf dem irgendetwas gespeichert werden kann. Kann eine Schaltfläche, ein Fader oder eine Taste sein.
+HTP			| Highest Takes Precedence, ein Mechanismus, der beschreibt, wie der Ausgangspegel durch mehrere Playbacks gesteuert wird. Üblich für Dimmer (Helligkeitswerte): der höchste Wert hat Vorrang. Siehe dagegen LTP.
+INCLUDE		| Laden eines Cues oder Chase-Schritts in den Programmer.
+IPCGBESFX	| Attributgruppen, wobei die Kanäle zusammengefasst werden, die systematisch zusammengehören. Die Buchstaben stehe für Intensity, Position, Colour, Gobo, Beam, Effect, Special, FX (Shapes). So enthält etwa die Gruppe P (Position) Pan und Tilt. 
+KEY FRAME SHAPE	| Effekt, bei dem verschiedene Status programmiert werden, zwischen denen jeweils die Geräte wechseln.
+KEY PROFILE (Tastenprofil) 	| Benutzereinstellung, die die Funktion der einzelnen Tasten auf dem Pult beeinflusst.
+LED			| Leuchtdiode. Heutzutage die Lichtquelle in vielen Geräten. Kann aber auch die kleinen Leuchten in den Tasten meinen.
+LEGEND		| Text, Bild oder Zeichnung, um zu markieren, was wo gespeichert ist.
+LINK (Verknüpfen)  	| Abfolge der einzelnen Cues in einer Cueliste oder einem Chaser. Oder Verweis auf ein anderes Playback unter Verwendung individueller Zeiten.
+LOCATE	(Home) 	| Taste, mit der die angewählten Geräte in eine definierte Startposition gebracht werden (normalerweise 100% Pegel, 50% Pan/Tilt, kein Gobo, keine Farbe, kein Shutter).                 
+LOCK	<br/>(Sperren, Verriegeln) 	| Speicherplätze können gegen die Seitenumschaltung gesperrt werden, so dass sie nicht mit umgeschaltet werden.Wählt man dabei ‚Transparent Lock', so wirkt die Sperre nur, soweit auf den anderen Seiten nicht bereits etwas auf diesem Platz programmiert ist. <br/><br/> Kann auch die Sperre des Pultes gegen unbefugte Benutzung bedeuten.
+LTP			| Latest Takes Precedence, ein Mechanismus, der beschreibt, wie der Ausgangspegel durch mehrere Playbacks gesteuert wird. Insbesondere bei allen Attributen, die nicht Dimmer (Helligkeit) sind, hat der zuletzt aufgerufene Wert Vorrang. Siehe hingegen HTP.
+MACRO		| Hat bei Titan mehrere Bedeutungen: <br/><br/>Entweder eine programmierte Sequenz von Tastendrücken, die häufig verwendet wird und durch einen Klick aufgerufen werden kann. <br/><br/> Oder Abfolge von verschiedenen Attributwerten, mit der Movinglights z.B. gezündet oder resettet werden können (abhängig vom Movinglight).
+MASTER		| Fader oder Taste, mit der bestimmte Aspekte mehrerer Playbacks gesteuert werden können. Es gibt verschiedene Arten von Mastern.
+MEMORY		| Andere Bezeichnung für Cue.
+MIDI		| Musical Instrument Digital Interface. Signalstandard für Steuersignale, ursprünglich zwischen elektronischen Instrumenten, aber inzwischen für vielfältige Anwendungen im Showbereich.
+MENU (Menü) | Die verschiedenen per Menütaste verfügbaren Funktionen.
+MENU LATCH (Einrasten)	| Behält das aktuelle Menü bei. Normalerweise wird z.B. das Lösch- oder Kopier-Menü geschlossen, wenn eine Lösch- oder Kopieraktion durchgeführt wird.
+ML MENU		| Enthält spezielle Funktionen für Movinglights.
+MOVE IN DARK (MID)	| Funktion bei Cuelisten, mit der gerade inaktive Geräte bereits auf ihren nächsten Cue vorbereitet werden (Preload). Wird auf anderen Pulten auch "Mark" genannt.
+ON und OFF	| Werden gespeicherte Werte vorübergehend nicht benötigt, so können sie OFF geschaltet werden und sind damit inaktiv. Sie können später mit ON wieder aktiviert werden.
+OVERLAP		| Bestimmt, wie neue Werte auf eine Reihe von Geräten angewendet wird. Bei 100% werden alle Geräte gleichzeitig beeinflusst, bei 0% nacheinander.
+PAGE (Seite) | Zur besseren Übersicht können Playbacks und die meisten Fenster auf mehrere Seiten umgeschaltet werden. Die Seitenumschaltung kann für einzelne Handles per Lock gesperrt werden.
+PALETTE		| Gespeicherter Zustand eines oder mehrerer Attribute eines oder mehrerer Geräte. Kann zum Programmieren und für das Busking verwendet werden. Wird auch Focus oder Preset genannt.
+PARK		| Geräte, die zwar gepatcht sind, aber keinen Output erzeugen sollen, sind geparkt. Das passiert etwa beim Patchen mit überlappenden DMX-Adressen. Um ein Gerät zu entparken, gibt man diesem eine andere - gültige - Adresse. <br/><br/> Die auf anderen Pulten bekannte Park-Funktion, bei der einzelne Geräte oder Kanäle fixiert werden, heißt dagegen Freeze.                        
+PATCH		| Vorgang, bei dem dem Pult mitgeteilt wird, welche Geräte auf welchen DMX-Adressen anzusprechend sind. Auch das Ergebnis davon wird Patch genannt.
+PERSONALITY | Datei, die bestimmt, welches Gerät wie durch das Pult zu steuern ist, d.h. welcher Kanal welche Funktion hat und wie er angezeigt werden soll.
+PIXEL MAPPER	| Erlaubt das Positionieren von Fixtures analog zu ihrer tatsächlichen Position, um verschiedene grafische Effekte zu zeigen.
+PLAYBACK 	| Handle mit programmiertem Cue, Chaser oder Cueliste. Kann Fader, Button oder Taste sein.
+PRELOAD	(Vorladen)   	| Tastenfunktion, mit der die LTP-Kanäle eines Playbacks bereits aktiviert werden (etwa Farbe oder Position), aber kein HTP-Dimmer. Damit werden die Geräte ‚vorbereitet' und können später eingefadet werden.
+PRESET FOCUS	|  Andere Bezeichnung für Paletten (bei älteren Avolites-Pulten). Siehe PALETTE.
+PROGRAMMER (Programmierspeicher)	| Speicherbereich im Pult, der die vorgenommenen Änderungen beinhaltet, die im Anschluss gespeichert werden sollen.
+QUICK PALETTE	| Wird eine Palette abgerufen, ohne dass Geräte ausgewählt sind, so wird die Palette auf sämtliche Geräte angewendet, sofern dies möglich ist. Diese Funktion kann in den Benutzereinstellungen deaktiviert werden.
+RANGE		| Wenn ein ganzer Bereich von DMX-Werten ein bestimmtes Ergebnis erzeugt, z.B. 128-191 = Gobo Rotation, dann spricht man von einer Range (Bereich).
+RDM			| Remote Device Management, Signalprotokoll, mit dem Geräte vom Pult aus konfiguriert werden und Rückmeldung geben können. Nicht von allen Movinglights unterstützt.
+RELEASE		| Zurücksetzen der Werte, wenn ein Playback deaktiviert wird. Normalerweise bleiben LTP-Attribute auf ihren Werten, bis etwas Neues gesendet wird. Mittels Release kann das geändert werden.
+RGB / RGBW... | Additive Farbmischung mit LEDs verschiedener Farben. Während sich allein aus Rot, Grün und Blau, bereits eine Vielzahl von Farben mischen lässt, sind häufig noch LEDs mit weiteren Farben vorhanden (etwa Weiß, Amber, Lime, Cyan, UV), um noch bessere Farbtöne zu erzielen. So gibt es z.B. auch RGBAL oder RGBAWUV.
+sACN		| Ethernet-basiertes Signalprotokoll zur Übertragung mehrerer DMX-Universen über Netzwerk.
+SELECT BUTTON (Auswahltaste) | Die blaue Taste bei jedem Fader dient beim Programmieren zum Anwählen.
+SELECTED (Angewählt) | Ein Gerät, das gerade angewählt ist, um gesteuert zu werden.
+SEQUENCE	| Anderer Name für Chaser.
+SHAPE 		| Vorprogrammierter Effekt, der ein bestimmtes Attribut moduliert. Kann verändert und in Cues gespeichert werden.
+SHARED PALETTE (Gemeinsam genutzt)  | Ein Palettentyp mit Informationen für einen Gerätetyp (d.h. für alle Geräte dieses Typs).
+SOFTKEY	(Menütaste)  | Die Tasten A-J rechts neben dem Bildschirm. Ihre Funktion ist vom jeweiligen Menü abhängig und wird direkt daneben im Display angezeigt. 
+SPREAD		| Aufteilung eines Effekts auf mehrere Geräte. Bei Spread=1 laufen alle Geräte synchron. Gegenwert zu Phase.
+STACK	(Stapel) 	| Andere Bezeichnung für Cueliste.
+SUBFIXTURE	| Siehe Cell.
+SWOP		| Tastenfunktion, mit der ein Playback aktiviert und alle anderen Geräte dunkelgetastet werden. Auch "Solo" genannt. Siehe dagegen FLASH.
+TIMECODE	| Signal zur Übertragung von Zeitimpulsen. Damit können z.B. Cuelisten synchron zu einem Musik-Track laufen.
+TIMES	(Zeiten) | Viele Aspekte der Programmierung können über einen bestimmten Zeitraum laufen (ein-, ausblenden, verzögern, etc.)
+TNP			|  Titan Network Processor, Zusatzgerät im Rackformat, mit dem Rechenleistung für weitere DMX-Universen realisiert werden kann. Kann auch als eigenständiges Pult verwendet werden.                      
+TRACKING	| Arbeitsweise von Cuelisten, bei der nur Änderungen gespeichert werden.
+UNFOLD	(Ausklappen)  | Funktion, bei der die einzelnen Schritte eines Chasers oder eine Cueliste auf einzelne Fader eingeblendet werden, um das Programmieren zu vereinfachen.   
+UNIVERSE (Universum)  | Gruppe von 512 DMX-Kanälen, die über ein Kabel übertragen werden. Titan-Pulte können 64 Universen steuern (16 direkt pro Pult, weitere mit TNPs).
+UPS	(USV) 	| Uninterruptible Power Supply, Unterbrechungsfreie Stromversorgung. Bei manchen Pulten als Schutz vor Stromausfall integriert.
+USER NUMBER	| Jeder Dimmer/jedes Movinglight hat eine Nummer, mittels der man auch mit den Zifferntasten Geräte auswählen kann.
+USER SETTINGS (Benutzereinstellungen)	| Einstellungen, mit denen man Titan an die eigene Arbeitsweise anpassen kann. Um sie zu ändern, drücken Sie die <Keys.HardKey>Avo</Keys.HardKey>-Taste und wählen <Keys.SoftKey>User Settings</Keys.SoftKey>.
+VIRTUAL DIMMER (virtuelle Dimmer) | Insbesondere einfache RGB-Lampen haben mitunter keinen separaten Dimmerkanal. Der virtuelle Dimmer wird dann vom Pult bereitgestellt und wirkt wie ein Master für die Farbkanäle.
+VISUALISER	| Software zur Darstellung der Bühnen- und Beleuchtungssituation in 3D, um das Vorprogrammieren zu erleichtern. 
+WING		| Separates Gerät mit weiteren Fadern und Tasten, um einem Pult weitere Bedienelemente hinzuzufügen.
+WIPEALL		| Komplettes Löschen des Pultes, um ganz neu zu beginnen. Bereits gespeicherte Shows bleiben erhalten.
+WHEELS (Räder, Encoder)  | Mit den Wheels (Räder, Encoder) lassen sich Werte eingeben sowie in Chasern und Cuelisten navigieren.
+YOKE		| Die drehbare Aufhängung des Kopfes bei kopfbewegten Movinglights.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/glossary.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/glossary.md
@@ -101,7 +101,7 @@ TIMES	(Zeiten) | Viele Aspekte der Programmierung können über einen bestimmten
 TNP			|  Titan Network Processor, Zusatzgerät im Rackformat, mit dem Rechenleistung für weitere DMX-Universen realisiert werden kann. Kann auch als eigenständiges Pult verwendet werden.                      
 TRACKING	| Arbeitsweise von Cuelisten, bei der nur Änderungen gespeichert werden.
 UNFOLD	(Ausklappen)  | Funktion, bei der die einzelnen Schritte eines Chasers oder eine Cueliste auf einzelne Fader eingeblendet werden, um das Programmieren zu vereinfachen.   
-UNIVERSE (Universum)  | Gruppe von 512 DMX-Kanälen, die über ein Kabel übertragen werden. Titan-Pulte können 64 Universen steuern (16 direkt pro Pult, weitere mit TNPs).
+UNIVERSE (Universum)  | Gruppe von 512 DMX-Kanälen, die über ein Kabel übertragen werden.
 UPS	(USV) 	| Uninterruptible Power Supply, Unterbrechungsfreie Stromversorgung. Bei manchen Pulten als Schutz vor Stromausfall integriert.
 USER NUMBER	| Jeder Dimmer/jedes Movinglight hat eine Nummer, mittels der man auch mit den Zifferntasten Geräte auswählen kann.
 USER SETTINGS (Benutzereinstellungen)	| Einstellungen, mit denen man Titan an die eigene Arbeitsweise anpassen kann. Um sie zu ändern, drücken Sie die <Keys.HardKey>Avo</Keys.HardKey>-Taste und wählen <Keys.SoftKey>User Settings</Keys.SoftKey>.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/introduction.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/introduction.md
@@ -1,0 +1,61 @@
+---
+id: introduction
+title: Einführung
+sidebar_label: Einführung
+slug: /
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Herzlich willkommen in der Welt von Avolites Titan! Dieses Handbuch soll
+Ihnen alles Wissenswerte über Ihr Titan-Pult vermitteln (was eine ganze
+Menge ist).
+
+Wenn Sie bereits mit Lichtpulten vertraut, aber neu bei Avolites sind,
+so finden Sie in der [Schnellstartanleitung](./quick-start.md) alles 
+Wichtige für die ersten Schritte.
+
+Im Anschluss daran werden alle Details erläutert, und zwar in der
+Reihenfolge, in der man sie vermutlich benötigt: beginnend mit dem
+[Anschließen des Pultes](./titan-basics.md), werden als nächstes 
+verschiedene [Geräte gepatcht](./patching.md), um diese danach auf 
+[verschiedene Weise zu steuern](./controlling-fixtures.md). Häufig
+verwendete Einstellungen werden dabei in [Paletten](./palettes.md) 
+gespeichert. Ferner verfügt Titan über verschiedene mächtige 
+[Effekt-Engines](./effects.md). Aus dem Zusammenspiel werden die 
+[Cues](./cues.md), [Chaser](./chases.md), [Cuelisten](./cue-lists.md) 
+und [Timelines](./timelines.md) 
+erstellt, die letztlich die Lichtshow ausmachen. Weitere Kapitel widmen sich dem
+[Capture Visualiser](./capture-visualiser.md) zur Visualisierung, 
+[Synergy](./synergy.md) zur Steuerung der Ai-Medienserver, weiteren 
+[besonderen Aspekten der Show](./running-the-show.md), der 
+[Fernsteuerung](./remote-control.md) sowie den verschiedenen
+[Systemeinstellungen](./system-settings.md).
+
+Am Schluss gibt es ein [Glossar und Stichwortverzeichnis](./glossary.md),
+sowie eine Übersicht über die wichtigsten Fachbegriffe und Bezeichnungen 
+auf Pulten verschiedener Hersteller.
+
+Viel Spaß beim Programmieren!
+
+## Konventionen in diesem Handbuch
+
+Wo es möglich ist, wird zu anderen Kapitel mit genaueren Beschreibungen
+[verlinkt](./introduction.md).
+
+Um die Unterscheidung zwischen den fixen, fest beschrifteten Tasten und
+den variablen Menütasten zu erleichtern, werden verschiedene Symbole benutzt:
+- 'Richtige' Tasten werden <Keys.HardKey>so</Keys.HardKey> dargestellt, z.B. <Keys.HardKey>Avo</Keys.HardKey>.
+- Menütasten/Buttons werden <Keys.SoftKey>so</Keys.SoftKey> gezeigt , etwa <Keys.SoftKey>Edit Times</Keys.SoftKey>. 
+- Kontext-Buttons sowie Schaltflächen auf dem Display werden schließlich <Keys.ContextKey>so</Keys.ContextKey> dargestellt, z.B. <Keys.ContextKey>Open Settings</Keys.ContextKey>.
+
+Schrittweise Anleitungen werden Punkt für Punkt aufgeführt, etwa so:
+
+1.  Zuerst machen Sie dies.
+2.  Danach machen Sie jenes.
+3.  Schließlich machen Sie das.
+
+Besondere Hinweise werden so hervorgehoben:
+
+> Dies ist ein besonderer Hinweis.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking.md
@@ -1,0 +1,40 @@
+---
+id: networking
+title: Netzwerkeinrichtung
+sidebar_label: Netzwerkeinrichtung
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Titan unterstützt über die üblichen DMX-Buchsen hinaus etliche
+weitere Wege der Kommunikation mit Beleuchtungs- und anderen Geräten;
+diese werden im Folgenden beschrieben.
+
+Verfügt das Pult bzw. Der Computer über mehrere Netzwerkanschlüsse, so [kann
+DMX über jeden davon ausgegeben werden](system-settings/dmx-output-mapping.md#einrichten-der-dmx-ausgänge). 
+Ganz exakt lässt sich in den DMX-Einstellungen festlegen: für jeden 
+Netzwerkport lässt sich die DMX-Ausgabe explizit aktivieren oder deaktivieren.
+
+Ebenso lassen sich Prozessor-Knoten einbinden (TitanNet), womit die
+Gesamtzahl möglicher Universen bis auf 64 gesteigert werden kann. 
+
+Außerdem können mehrere Pulte per Netzwerk im Mehrbenutzerbetrieb sowie im
+Backup-Modus betrieben werden.
+
+Am Ende des Kapitels werden in einem separaten Abschnitt die [Grundlagen
+der IP-Adressierung](networking/a-quick-guide-to-ip-addressing.md) 
+erklärt, was etwa für Art-Net eine wichtige Voraussetzung ist.
+
+> Netzwerke für Lichttechnik übertragen große Datenmengen. Um einen 
+zuverlässigen Betrieb zu gewährleisten, empfiehlt es sich, dafür ein 
+separates, physikalisch von anderen Netzwerken getrenntes Netzwerk 
+vorzusehen.
+
+Zwar kann man das Licht-Netzwerk auch mit anderen Netzwerken verbinden, 
+doch kann das zu Übertragungsproblemen sowohl bei der Licht- als auch 
+bei der anderen Peripherie führen. In einem solchen Fall sollten unbedingt 
+die [Hinweise zur IP-Adressierung](networking/a-quick-guide-to-ip-addressing.md) 
+beachtet werden. Ferner ist zu beachten, dass Managed Netzwerk-Switches 
+ggf. Art-Net und ähnliche Protokolle blockieren können.
+  

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking.md
@@ -11,13 +11,13 @@ Titan unterstützt über die üblichen DMX-Buchsen hinaus etliche
 weitere Wege der Kommunikation mit Beleuchtungs- und anderen Geräten;
 diese werden im Folgenden beschrieben.
 
-Verfügt das Pult bzw. Der Computer über mehrere Netzwerkanschlüsse, so [kann
+Verfügt das Pult bzw. der Computer über mehrere Netzwerkanschlüsse, so [kann
 DMX über jeden davon ausgegeben werden](system-settings/dmx-output-mapping.md#einrichten-der-dmx-ausgänge). 
 Ganz exakt lässt sich in den DMX-Einstellungen festlegen: für jeden 
 Netzwerkport lässt sich die DMX-Ausgabe explizit aktivieren oder deaktivieren.
 
-Ebenso lassen sich Prozessor-Knoten einbinden (TitanNet), womit die
-Gesamtzahl möglicher Universen bis auf 64 gesteigert werden kann. 
+Ebenso lassen sich [TNP (TitanNet Processor)](titan-net.md) einbinden, womit die
+Gesamtzahl möglicher Universen bis zum Limit des jeweiligen Pultes gesteigert werden kann. 
 
 Außerdem können mehrere Pulte per Netzwerk im Mehrbenutzerbetrieb sowie im
 Backup-Modus betrieben werden.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/a-quick-guide-to-ip-addressing.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/a-quick-guide-to-ip-addressing.md
@@ -1,0 +1,101 @@
+---
+id: a-quick-guide-to-ip-addressing
+title: Grundlagen der IP-Adressierung
+sidebar_label: Grundlagen der IP-Adressierung
+---
+
+Jedes Gerät in einem Netzwerk muss eine eindeutige IP-Adresse haben. 
+IP-Adressen werden üblicherweise im Format `w.x.y.z` geschrieben, wobei
+`w`, `x`, `y` und `z` für Zahlen zwischen 0 und 255 stehen; ein Beispiel wäre
+etwa die Adresse `192.168.0.1`. Die Adressen können entweder manuell eingestellt 
+(**Statische** IP-Adressen) oder automatisch vergeben werden (**DHCP**). In Licht-Netzwerken
+werden meist statische Adressen verwendet: das dauert zwar etwas länger zum Einrichten, 
+aber dann hat jedes Gerät immer die richtige Adresse.
+
+Damit sich Geräte im Netzwerk gegenseitig "sehen" können, müssen sie sich im gleichen
+**Subnetz** befinden - das ist der erste Teil der IP-Adresse. Bei jedem Gerät muss 
+die **Subnetz-Maske** so eingestellt werden, dass sie bei allen Geräten innerhalb 
+eines Netzwerks gleich ist, der restliche Teil der IP-Adresse aber muss unterschiedlich sein.
+
+Oft findet man Subnetz-Masken von `255.255.255.0`, die bedeuten, dass die `w`, `x` und `y` Teile
+der IP-Adresse gleich sind und die `z`-Adresse bei jedem Gerät anders ist. Wenn z.B. das Lichtpult 
+auf `192.168.1.1` gestellt ist, dann wäre das Subnetz `192.168.1.z`, und alle anderen Geräte
+hätten Adressen wie `192.168.1.2`, `192.168.1.3` etc.
+
+Wird die IP-Adresse automatisch per DHCP vergeben, so wird auch die Subnetz-Maske automatisch eingestellt.
+Subnetz-Masken werden gelegentlich in der Form wie z.B. `/24` oder `/8` geschrieben. Das ist jeweils die 
+Anzahl von Bits in der IP-Adresse, die auf 1 stehen. Jeder der Blöcke `w`, `x`, `y` und `z` steht jeweils für 8 Bits. 
+Eine Subnetz-Maske von `255.255.255.0` wäre also gleichbedeutend mit `/24`, eine Maske von `255.0.0.0` wäre `/8`. 
+
+## Auswahl der IP-Adresse und Subnetzmaske
+
+Dies ist der komplizierteste Teil bei der Einrichtung eines Netzwerkes,
+da hierbei zu berücksichtigen ist, welche Geräte und Protokolle im
+Netzwerk verwendet werden, und welche IP-Adressen frei vergeben werden
+oder bereits festgelegt sind. manche ältere Art-Net-Geräte sind z.B. auf Adressen im Bereich `2.x.y.z` oder `10.x.y.z` 
+festgelegt, so dass auch alle anderen Geräte in diesem Netzwerk so eingestellt werden müssen. Ist das nicht der Fall, 
+so verwendet man oft den Adressbereich `192.168.1.x`. 
+
+Im Folgenden sind einige beispielhafte
+Szenarien aufgeführt. *Für das Funktionieren kann keine Garantie
+übernommen werden, doch wählen Sie als Startwert am besten das Beispiel,
+welches Ihrem Netzwerk am nächsten kommt*.
+
+### Titan-Pult und TNP, alle Ausgänge Standard-DMX
+
+Gerät             | IP-Adresse        | Subnetzmaske
+---               | ---               | ---
+Titan-Pult        | `192.168.1.30`    | `255.255.255.0`
+TNP               | `192.168.1.31`    | `255.255.255.0`
+
+### Titan-Pult steuert Geräte über Art-Net (und ggf. über DMX)
+
+Gerät             | IP-Adresse        | Subnetzmaske
+---               | ---               | ---
+Titan-Pult        | `10.100.100.100`   | `255.0.0.0`
+Art-Net-Geräte    | `10.x.y.z` **\***  | `255.0.0.0`
+
+(der Bereich `2.x.y.z` kann ebenfalls für Art-Net verwendet werden. Siehe aber die u.g.
+Bemerkungen zu privaten Adressbereichen).
+
+**\*** *Dabei sind die Kombinationen von `x`, `y` und `z` für jedes Gerät einmalig zu
+vergeben.*
+
+### Titan-Pult und TNP, Ausgang über Art-Net (und DMX)
+
+Gerät             | IP-Adresse        | Subnetzmaske
+---               | ---               | ---
+Titan-Pult        | `2.100.100.100`   | `255.0.0.0`
+TNP               | `2.100.100.101`   | `255.0.0.0`
+Art-Net-Geräte    | `2.x.y.z` **\***  | `255.0.0.0`
+
+*Alternativ:*
+
+Gerät             | IP-Adresse        | Subnetzmaske
+---               | ---               | ---
+Titan-Pult        | `10.100.100.100`  | `255.0.0.0`
+TNP               | `10.100.100.101`  | `255.0.0.0`
+Art-Net-Geräte    | `10.x.y.z` **\*** | `255.0.0.0`
+
+**\*** *Dabei sind die Kombinationen von `x`, `y` und `z` für jedes Gerät einmalig zu
+vergeben.*
+
+> Es empfiehlt sich, nie die 255 in einer IP-Adresse zu verwenden. Ist der unmaskierte Teil der IP-Adresse 255,
+so wird dies als Broadcast-Adresse verwendet (z.B. die IP-Adresse `192.168.1.255` ist eine Broadcast-Adresse in einem 
+Netzwerk mit der Maske `255.255.255.0`, und `10.255.255.255` ist eine Broadcast-Adresse in einem 
+Netzwerk mit der Maske `255.0.0.0`.
+
+## Wenn das Netzwerk Verbindung zum Internet hat
+
+Nach Möglichkeit sollten Licht-Netzwerke eigene Netzwerke ohne Verbindung zum Internet sein. 
+Sollte einmal ihr Netzwerk doch mit dem Internet verbunden sein, so ist es wichtig, dass Sie
+einen **privaten** IP-Adressbereich verwenden. Damit wird sichergestellt, dass der Netzwerkverkehr 
+nicht ins Internet geroutet wird. Die privaten Adressbereiche sind folgende:
+
+Startadresse  | Letzte Adresse   | Subnetzmaske
+--- 		  | --- 			 | ---
+`10.0.0.0` 	  | `10.255.255.255` | `255.0.0.0` (/8)
+`172.16.0.0`  | `172.31.255.255` | `255.255.0.0` (/12)
+`192.168.0.0` | `192.168.255.255`| `255.255.255.0` (/16)
+
+> Für Art-Net muss eventuell der Bereich 10.x.y.z verwendet werden, wenn die vorhandenen Geräte das erfordern.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/connecting-the-arena-to-a-network.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/connecting-the-arena-to-a-network.md
@@ -1,0 +1,91 @@
+---
+id: connecting-the-arena-to-a-network
+title: Pulte im Netzwerk betreiben
+sidebar_label: Pulte im Netzwerk betreiben
+---
+
+Alle Lichtpulte von Avolites können per Ethernet vernetzt werden, um Geräte per Art-Net oder sACN zu steuern, für den Mehrbenutzerbetrieb und Fernsteuerung, und zum Anschluss an Visualisierungslösungen. 
+
+Das T1, T2 und T3 werden jeweils mit einem PC betrieben. Zum Vernetzen muss dieser in das jeweilige Netzwerk eingebunden werden. (WLAN ist für die Steuerung von Geräten nicht zu empfehlen, da es zu Aussetzern und Verzögerungen kommen kann).
+
+Die größeren Pulte verfügen jeweils über einen oder zwei Netzwerkanschlüsse.
+
+Das D9, D7 und das Arena verfügen anders als die anderen Titan-Pulte über einen
+integrierten Netzwerkswitch und (nur D9 und Arena) einen optischen Netzwerkschluss. **Dieser Abschnitt gilt nur für das Diamond 9, Diamond 7 und für Arena-Pulte!**
+
+> Für das genaue Einrichten des Pultes für den Netzwerkbetrieb, das korrekte Vergeben von IP-Adressen und das Patchen von Geräten im Netzwerk siehe nächstes Kapitel.
+
+## Optische Anschlüsse (D9 und Arena)
+
+Der optische Netzwerkanschluss ist ein Neutrik opticalCon mit
+Multimode Glasfaser. Das Arena ist mit einem einzelnen opticalCon DUO ausgestattet, auf Nachfrage 
+kann ein zweiter Anschluss eingebaut werden. Das Diamond 9 kommt mit einem opticalCon QUAD, bei dem 
+normalerweise ein Fasernpaar belegt ist. Mit der Zusatzoption 10GbE wird das zweite Paar Fasern belegt.
+
+Bühnenseitig empfiehlt sich ein Avolites TitanNet Switch (TNS),
+welcher wiederum RJ45, also gewohnter Netzwerkanschlüsse, bereitstellt.
+Sollen andere Glasfaserkonverter verwendet werden, halten Sie bitte mit
+Avolites Rücksprache.
+
+## RJ45-Netzwerk-Anschlüsse
+
+Beim Diamond 9 ist ein 1Gb Luminex Netzwerkswitch integriert, das Diamond 7 und das Arena verfügt über einen 
+integrierten 1Gb TitanNet Switch (TNS). Dieser ist jeweils direkt mit
+Netzwerkanschluss 1 des Motherboards verbunden. Der Switch stellt
+vier Ethernet-Ports auf der Rückseite des Pultes bereit.
+
+Netzwerkanschluss 2 des Motherboards ist auf einer separaten etherCON-Buchse auf
+der Pultrückseite herausgeführt (Secondary Ethernet). Es empfiehlt sich,
+immer über die Switch-Ports zu arbeiten, und den zweiten Port nur zu
+verwenden, wenn man parallel in verschiedenen Netzwerken arbeitet, etwa
+eins für die Show, ein anderes zur Datensicherung oder die Remote. Stellen Sie sicher, dass die IP-Adresse dieses 
+Ports nicht im Adressbereich des Switches liegt, da dies sonst zu Problemen führen kann.
+
+Das Diamond 9 kann optional für die Verwendung von 10GbE ausgestattet werden.
+
+## Ändern der Einstellungen des Luminex-Switches im D9
+
+Normalerweise müssen die Einstellungen des Luminex-Switches nicht geändert werden. Sollte dies wegen eines komplexen Netzwerks doch einmal nötig sein, so dient dazu die Araneo-Software von Luminex (externer Link):
+[https://luminex.be/products/software/araneo/](https://luminex.be/products/software/araneo/)
+
+>  Beim D9 kann der Luminex-Switch auf Werkseinstellungen zurückgesetzt werden, indem die Reset-Taste neben den
+vier etherCON-Anschlüssen für 5 Sekunden gedrückt wird. Die LEDs blinken daraufhin rot, und der Switch wird auf 
+seine ursprüngliche IP-Adresse zurückgesetzt (siehe Aufkleber innen im Pult).
+
+## Ändern der IP-Adresse des Titan Network Switch (TNS) beim D7 oder Arena
+
+Beim Arena haben Netzwerkswitch und dessen Controller zwei aufeinander folgende
+IP-Adressen: Wird der Controller auf eine Adresse gesetzt (z.B.
+`10.19.0.50`), so erhält der Switch die folgende Adresse (im Beispiel
+`10.19.0.51`).
+
+Beim D7 hat der Netzwerkswitch nur eine IP-Adresse.
+
+Normalerweise müssen die IP-Adressen des Netzwerkswitchs und Controllers 
+nicht geändert werden, es sei denn, es besteht ein Konflikt mit anderen
+Geräten im Netzwerk. Der Vorgabewert ist `10.19.aa.bb`, wobei sich `aa.bb` 
+aus der Seriennummer des Pultes ergibt *(so ist z.B. `10.19.01.124` aus der 
+Seriennummer **379** abgeleitet: 01 steht für 255, und 255+124 = 379)*.
+
+Um die IP-Adresse des Switchs zu ändern:
+
+1. Öffnen Sie im **Tools**-Menü, **Control Panel**, die **USB-Expert-Console**.
+
+2. Wählen Sie das TitanNet Switch (TNS) Panel.
+![USB Expert Tools - TNS Panel](/docs/images/USB-Expert-Tools-TNS-Panel.png)
+
+3. Im angezeigten **IP Address Dialog** geben Sie die neue IP-Adresse ein.
+![USB Expert Tools - TNS Panel - IP Address Dialog](/docs/images/USB-Expert-Tools-TNS-Panel-IP-Address-Dialog.png)
+
+## Stromversorgung und USV 
+
+Der Netzwerkswitch ist mit der gleichen unterbrechungsfreien
+Stromversorgung verbunden wie das Pult selbst. Fällt also die
+Netzspannung aus, wird der Switch weiter versorgt.
+
+Wird das Pult heruntergefahren, so erhält der Switch für etwa 5 Minuten
+weiter Versorgungsspannung, um etwa auch während eines Neustarts des
+Pultes keine Unterbrechung hervorzurufen (z.B. wenn ein Backup-Pult
+vorhanden ist).
+
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/connecting-the-arena-to-a-network.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/connecting-the-arena-to-a-network.md
@@ -4,6 +4,8 @@ title: Pulte im Netzwerk betreiben
 sidebar_label: Pulte im Netzwerk betreiben
 ---
 
+import Keys from '@site/src/components/key.ts';
+
 Alle Lichtpulte von Avolites können per Ethernet vernetzt werden, um Geräte per Art-Net oder sACN zu steuern, für den Mehrbenutzerbetrieb und Fernsteuerung, und zum Anschluss an Visualisierungslösungen. 
 
 Das T1, T2 und T3 werden jeweils mit einem PC betrieben. Zum Vernetzen muss dieser in das jeweilige Netzwerk eingebunden werden. (WLAN ist für die Steuerung von Geräten nicht zu empfehlen, da es zu Aussetzern und Verzögerungen kommen kann).
@@ -29,7 +31,7 @@ Avolites Rücksprache.
 
 ## RJ45-Netzwerk-Anschlüsse
 
-Beim Diamond 9 ist ein 1Gb Luminex Netzwerkswitch integriert, das Diamond 7 und das Arena verfügt über einen 
+Beim den Diamond 9 der ersten Serie ist ein 1Gb Luminex Netzwerkswitch integriert, das Diamond 9 (ab 2025), das Diamond 7 und das Arena verfügt über einen 
 integrierten 1Gb TitanNet Switch (TNS). Dieser ist jeweils direkt mit
 Netzwerkanschluss 1 des Motherboards verbunden. Der Switch stellt
 vier Ethernet-Ports auf der Rückseite des Pultes bereit.
@@ -43,7 +45,7 @@ Ports nicht im Adressbereich des Switches liegt, da dies sonst zu Problemen füh
 
 Das Diamond 9 kann optional für die Verwendung von 10GbE ausgestattet werden.
 
-## Ändern der Einstellungen des Luminex-Switches im D9
+## Ändern der Einstellungen des Luminex-Switches im D9 (erste Serie)
 
 Normalerweise müssen die Einstellungen des Luminex-Switches nicht geändert werden. Sollte dies wegen eines komplexen Netzwerks doch einmal nötig sein, so dient dazu die Araneo-Software von Luminex (externer Link):
 [https://luminex.be/products/software/araneo/](https://luminex.be/products/software/araneo/)
@@ -52,7 +54,7 @@ Normalerweise müssen die Einstellungen des Luminex-Switches nicht geändert wer
 vier etherCON-Anschlüssen für 5 Sekunden gedrückt wird. Die LEDs blinken daraufhin rot, und der Switch wird auf 
 seine ursprüngliche IP-Adresse zurückgesetzt (siehe Aufkleber innen im Pult).
 
-## Ändern der IP-Adresse des Titan Network Switch (TNS) beim D7 oder Arena
+## Ändern der IP-Adresse des Titan Network Switch (TNS) beim D9 (ab 2025), D7 oder Arena
 
 Beim Arena haben Netzwerkswitch und dessen Controller zwei aufeinander folgende
 IP-Adressen: Wird der Controller auf eine Adresse gesetzt (z.B.
@@ -76,6 +78,13 @@ Um die IP-Adresse des Switchs zu ändern:
 
 3. Im angezeigten **IP Address Dialog** geben Sie die neue IP-Adresse ein.
 ![USB Expert Tools - TNS Panel - IP Address Dialog](/docs/images/USB-Expert-Tools-TNS-Panel-IP-Address-Dialog.png)
+
+1. Rufen Sie das System-Menü auf (<Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>DISK</Keys.HardKey>).
+2. Wählen Sie nun <Keys.SoftKey>Network Switch</Keys.SoftKey>.
+3. Auf dem D9 mit TNS sowie dem D7 können Sie nun die IP-Adresse eingeben. Auf dem Arena wählen Sie dazu <Keys.SoftKey>TitanNet Switch Panel 1</Keys.SoftKey>.
+4. Geben Sie die IP-Adresse ein und klicken Sie auf <Keys.SoftKey>Save Settings</Keys.SoftKey>.
+
+Die Management-Oberfläche des Switchs erreicht man durch Klick auf <Keys.SoftKey>Open Web Interface</Keys.SoftKey>. Auf dem Arena erreicht man sie über <Keys.SoftKey>TitanNet Switch Panel 2</Keys.SoftKey>. Damit öffnet sich ein Webbrowser mit dem Management-Interface. Dieses ist passwortgeschützt. Auf dem Arena lautet das voreingestellte Passwort 'password', auf dem D7 und D9 ist es der User 'root' und das Passwort 'password'.
 
 ## Stromversorgung und USV 
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/controlling-fixtures-over-a-network.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/controlling-fixtures-over-a-network.md
@@ -1,0 +1,127 @@
+---
+id: controlling-fixtures-over-a-network
+title: Steuern von Geräten über Netzwerk
+sidebar_label: Steuern von Geräten über Netzwerk
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Bevor das Pult mit anderen Geräten über ein Netzwerk kommunizieren kann,
+muss es eine eindeutige Netzwerkadresse bekommen; diese wird
+'IP-Adresse' genannt.
+
+## Einstellen der IP-Adresse des Pultes
+
+Es wird empfohlen, die integrierte Adressvergabe des Pultes zu
+verwenden. Alternativ kann aber auch manuell eine Adresse vergeben werden.
+Siehe [Einstellen der IP-Adresse](a-quick-guide-to-ip-addressing.md#einstellen-der-ip-adresse) mit
+Details zur IP-Adressierung.
+
+1. Öffnen Sie das **System**-Menü (mittels <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>)
+und drücken Sie	<Keys.SoftKey>Network Settings</Keys.SoftKey>.
+2. Drücken Sie <Keys.SoftKey>Local Area Connection</Keys.SoftKey>. Manche Pult verfügen über mehrere
+Netzwerkanschlüsse - wählen Sie also hier den betreffenden aus.
+3. Überprüfen Sie, dass <Keys.SoftKey>Subnet Mask</Keys.SoftKey> auf `255.255.255.0` steht.
+4. Drücken Sie <Keys.SoftKey>Set IP `2.*.*.*`</Keys.SoftKey>.
+5. Betätigen Sie <Keys.SoftKey>Save settings</Keys.SoftKey>.
+6. Verlassen Sie das System-Menü mit <Keys.HardKey>Exit</Keys.HardKey>.
+
+- Einige Geräte haben möglicherweise feste IP-Adressen aus dem Bereich `2.*.*.*` oder `10.*.*.*` - 
+in diesem Fall muss auch die Adresse des Pultes in diesem Bereich liegen.
+
+- Benötigen Sie eine Adresse aus einem anderen Adressbereich, so drücken Sie 
+auf <Keys.SoftKey>IP Address = ... </Keys.SoftKey> und geben die Adresse mit den Zifferntasten ein.
+
+> Verfügt das Pult über mehr als einen Netzwerkanschluss, so stellen Sie sicher, dass nicht beide im gleichen 
+Adressbereich liegen (sondern z.B. ein Anschluss im Bereich `2.*.*.*` und der andere bei `10.*.*.*`). Sollten 
+beide Anschlüsse im gleichen Bereich adressiert sein, so kann das bei Art-Net und sACN zu Problemen führen.
+
+## Einrichten der DMX-Ausgänge
+
+Das Pult arbeitet intern mit max. 64 DMX-Universen (siehe [DMX-Ausgänge einrichten](../system-settings/dmx-output-mapping.md) for details); beim T1 / T2 / T3 ist die Anzahl der Universen auf 1 / 2 / 16 begrenzt. Titan Go (mit einem Editor AvoKey) kann ein Universum über Art-Net oder sACN ausgeben. Der Titan Simulator (mit einem Editor AvoKey) gibt alle 64 Universen per Art-Net oder sACN aus, allerdings mit gelegentlichen Störungen (dem "Spoiler").
+
+Die einzelnen Dimmer/Geräte werden in Titan auf eine der 64 DMX-Linien gepatcht.
+Die Zuordnung interner DMX-Linien zu Netzwerklinien erfolgt im Menü
+[DMX Settings](../system-settings/dmx-output-mapping.md#configuring-dmx-outputs).
+Oft wird man einfach Linie 1 auf Netzwerk-Universum 1, Linie 2 auf Universum 2 etc.
+zuweisen, aber mitunter - etwa auf Tour zur Anpassung an das vorhandene
+Netzwerk - sieht das auch ganz anders aus.
+
+## Beispiel für ein einfaches Art-Net-System
+
+Es gibt hauptsächlich zwei Systeme zur Übertragung von Licht-Steuersignalen
+über Netzwerk: Art-Net und sACN. Titan unterstützt beide Protokolle.
+In diesem Abschnitt wird die Einrichtung eines Art-Net-Systems erläutert.
+
+Art-Net ist kein gerätespezifisches Protokoll, sondern wird von einer
+wachsenden Anzahl von Herstellern anerkannt und in immer mehr Produkte
+integriert. Viele Geräte (etwa Dimmer oder Bewegungsscheinwerfer) können
+direkt per Art-Net verbunden werden, so dass kein separater Konverter
+erforderlich ist. Benötigt man hingegen 'normales' DMX, so kann dies
+über spezielle Art-Net-DMX-Konverter (oft als **Node** bezeichnet)
+realisiert werden.
+
+Im nachstehenden Schema ist exemplarisch ein Art-Net-fähiges Pult (wie
+etwa ein Titan-Pult) über einen Netzwerk-Switch mit einem Art-Net-fähigen
+Dimmer und einem Konverter verbunden.
+
+![Art Net Explanation general](/docs/images/Art-Net-Explanation-General.png)
+
+Sobald das System entsprechend verkabelt ist, müssen die
+Geräte (Knoten, Nodes) konfiguriert werden.
+
+-   Am Dimmer stellen Sie die Startadresse 1.001 ein (Universum 1, Adresse 1).
+
+-   Den Konverter/Node stellen Sie so ein, dass er ab Universum 2 arbeitet;
+	handelt es sich z.B. um einen Konverter mit 12 Universen, so wandelt er
+	die Universen 2 bis 13 von Art-Net zu DMX.
+
+Im Menü [DMX Settings](../system-settings/dmx-output-mapping.md#configuring-dmx-outputs)
+ordnen Sie die internen Linien den verschiedenen Art-Net-Universen (1-256) zu.
+Dabei kann jede interne Linie auf mehrere Art-Net-Universen sowie auch parallel
+auf die DMX-Ausgänge des Pultes geroutet werden.
+
+Ist alles ordnungsgemäß eingerichtet, sollten der Dimmer und der Node als
+verfügbare Ausgabegeräte auf der linken Seite des DMX-Settings-Fensters
+auftauchen. Dabei zeigen Sie auch an, welches Universum sie verarbeiten.
+
+Im Beispiel erfolgt die Zuordnung daher wie folgt:
+
+-   Klicken Sie links auf das erste Universum des Dimmers, und danach rechts
+	auf Linie 1.
+
+-   Klicken Sie links auf das erste Universum des Nodes, und danach rechts
+	auf Linie 2.
+
+-   Klicken Sie links auf das zweite Universum des Nodes, und danach rechts
+	auf Linie 3.
+
+
+![Art Net Explanation Nodes to DMX](/docs/images/Art-Net-Explanation-Nodes-to-DMX.png)
+
+Beim Patchen in Titan geben Sie nun dem Dimmer die Adresse 1.001 - 1.024. Geräten
+auf der ersten Linie des Nodes geben Sie die Adresse 2.001 - 2.512, Geräten
+auf der zweiten Linie des Nodes geben Sie die Adresse 3.001 - 3.512.
+
+-   Für weitere Art-Net-Einstellungen klicken Sie auf das kleine <Keys.ContextKey>Zahnrad</Keys.ContextKey>
+	beim Art-Net-Modul. Im Abschnitt [Art-Net-Einstellungen](../system-settings/dmx-output-mapping.md#art-net-eigenschaften)
+	werden diese genauer erklärt.
+
+Als mögliche Art-Net-Geräte werden ggf. auch "Unpolled" oder
+"Unknown" angezeigt:
+
+-   Unpolled, bzw. 'nicht abgefragt', sind zusätzliche Linien für Geräte
+    mit mehr als 4 Linien: die Art-Net-Spezifikation sieht nur 4
+    Linien vor, die jedes Gerät als verfügbar anzeigen darf, deshalb
+    lassen sich weitere Linien im Pulte eben als 'nicht abgefragt'
+    anzeigen und dann auch normal zuweisen.
+
+-   Ein unbekanntes Gerät (unknown) ist hingegen ein Gerät, welches
+    seine Art-Net-Möglichkeiten nicht bekanntmacht; das Pult weiß
+    daher nicht, ob es ein Eingangs- oder Ausgangsknoten ist.
+
+## Weiterführende Informationen zu Art-Net
+
+Für weitere Informationen zum Thema Art-Net ziehen Sie am besten den
+Art-Net-Standard, veröffentlicht von der Firma [Artistic Licence](http://www.artisticlicence.com), heran.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/controlling-fixtures-over-a-network.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/controlling-fixtures-over-a-network.md
@@ -39,14 +39,14 @@ beide Anschlüsse im gleichen Bereich adressiert sein, so kann das bei Art-Net u
 
 ## Einrichten der DMX-Ausgänge
 
-Das Pult arbeitet intern mit max. 64 DMX-Universen (siehe [DMX-Ausgänge einrichten](../system-settings/dmx-output-mapping.md) for details); beim T1 / T2 / T3 ist die Anzahl der Universen auf 1 / 2 / 16 begrenzt. Titan Go (mit einem Editor AvoKey) kann ein Universum über Art-Net oder sACN ausgeben. Der Titan Simulator (mit einem Editor AvoKey) gibt alle 64 Universen per Art-Net oder sACN aus, allerdings mit gelegentlichen Störungen (dem "Spoiler").
+Titan arbeitet intern mit max. 64 DMX-Universen (siehe [DMX-Ausgänge einrichten](../system-settings/dmx-output-mapping.md) for details); bei manchen Pulten ist die Anzahl der Universen auf weniger begrenzt. Titan Go (mit einem Editor AvoKey) kann ein Universum über Art-Net oder sACN ausgeben. Der Titan Simulator (mit einem Editor AvoKey) gibt alle 64 Universen per Art-Net oder sACN aus, allerdings mit gelegentlichen Störungen (dem "Spoiler").
 
-Die einzelnen Dimmer/Geräte werden in Titan auf eine der 64 DMX-Linien gepatcht.
+Die einzelnen Dimmer/Geräte werden in Titan auf eine der DMX-Linien gepatcht.
 Die Zuordnung interner DMX-Linien zu Netzwerklinien erfolgt im Menü
 [DMX Settings](../system-settings/dmx-output-mapping.md#configuring-dmx-outputs).
 Oft wird man einfach Linie 1 auf Netzwerk-Universum 1, Linie 2 auf Universum 2 etc.
 zuweisen, aber mitunter - etwa auf Tour zur Anpassung an das vorhandene
-Netzwerk - sieht das auch ganz anders aus.
+Netzwerk - sieht das auch ganz anders aus. Linien/Universen können von 1 bis 9999 nummeriert sein.
 
 ## Beispiel für ein einfaches Art-Net-System
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/ports-used-by-titan.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/ports-used-by-titan.md
@@ -1,0 +1,23 @@
+---
+id: ports-used-by-titan
+title: Verwendete Netzwerkports
+sidebar_label: Verwendete Netzwerkports
+---
+
+Titan verwendet die folgenden Netzwerkports. bei der Verwendung von Firewalls müssen diese entsprechend eingestellt werden.
+
+Protokoll	| Port	 	| Adresse(n)					| Bemerkungen
+------------|--------	|----------						|---------
+TitanNet	|TCP 808	| Alle verfügbaren Adapter		| Titan Remote, TNPs, multi-user and backup.
+HTTP		|TCP 4430	| Alle verfügbaren Adapter		| WebApi
+SLP			|UDP 427	| Multicast 239.255.255.253		| Discovery - zum gegenseitigen Finden von Titan-Geräten.
+Ping		|ICMP echo	| Alle aktuell genutzten Adapter	| Zur Überwachung der Netzwerkverbindung.
+Art-Net		|UDP 6454	| Default: Alle verfügbaren Adapter	| |
+sACN		|UDP 5568	| Multicast 239.255.0.0-239.255.249.255	| |
+CITP		|UDP 4809/TCP	| Multicast 224.0.0.180		| Zur Kommunikation mit dem Capture Visualiser und mit Medienservern. Discovery erfolgt per UDP, dann die Kommunikation per TCP.
+RDMNet		|UDP 5569	|								| |
+ProDJ Tap   |UDP 60000-60002, 65023-65535				| | Protokoll zur Kommunikation mit pioneer DJ-Geräten (von TC-Supply)
+LiveDMX		|UDP 5584	| Multicast 239.184.0.0-239.184.249.255 | Für den internen Visualiser	
+NTP			|UDP 1234	| Between TitanNet hosts		| nicht standardisierter NTP-Port
+NDI			|UDP 5353	| Multicast zwischen NDI-Quellen und Panels	| mDNS für NDI zum Scannen für Streams
+NDI			|UDP 49152-65535	| Zwischen NDI-Quellen und Panels | NDI Video-Streams

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/ports-used-by-titan.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/ports-used-by-titan.md
@@ -6,18 +6,25 @@ sidebar_label: Verwendete Netzwerkports
 
 Titan verwendet die folgenden Netzwerkports. bei der Verwendung von Firewalls müssen diese entsprechend eingestellt werden.
 
-Protokoll	| Port	 	| Adresse(n)					| Bemerkungen
-------------|--------	|----------						|---------
-TitanNet	|TCP 808	| Alle verfügbaren Adapter		| Titan Remote, TNPs, multi-user and backup.
-HTTP		|TCP 4430	| Alle verfügbaren Adapter		| WebApi
-SLP			|UDP 427	| Multicast 239.255.255.253		| Discovery - zum gegenseitigen Finden von Titan-Geräten.
-Ping		|ICMP echo	| Alle aktuell genutzten Adapter	| Zur Überwachung der Netzwerkverbindung.
-Art-Net		|UDP 6454	| Default: Alle verfügbaren Adapter	| |
-sACN		|UDP 5568	| Multicast 239.255.0.0-239.255.249.255	| |
-CITP		|UDP 4809/TCP	| Multicast 224.0.0.180		| Zur Kommunikation mit dem Capture Visualiser und mit Medienservern. Discovery erfolgt per UDP, dann die Kommunikation per TCP.
-RDMNet		|UDP 5569	|								| |
-ProDJ Tap   |UDP 60000-60002, 65023-65535				| | Protokoll zur Kommunikation mit pioneer DJ-Geräten (von TC-Supply)
-LiveDMX		|UDP 5584	| Multicast 239.184.0.0-239.184.249.255 | Für den internen Visualiser	
-NTP			|UDP 1234	| Between TitanNet hosts		| nicht standardisierter NTP-Port
-NDI			|UDP 5353	| Multicast zwischen NDI-Quellen und Panels	| mDNS für NDI zum Scannen für Streams
-NDI			|UDP 49152-65535	| Zwischen NDI-Quellen und Panels | NDI Video-Streams
+Anwendung	       		| Port	 	| Adresse(n)					| Bemerkungen
+------------       		|--------	|----------						|---------
+Alle (bis Titan v18)	|TCP 808	| Alle verfügbaren Adapter		| Titan Remote, TNPs, Multiuser und Backup.
+TitanNet (bis Titan v18)|TCP 50052  | Alle verfügbaren Adapter	    | Synergy, TitanNet
+Synergy  				|TCP 50051  | Alle verfügbaren Adapter    	| Synergy, TitanNet, Titan Media Node, Prism
+TitanNet*    			|TCP 4442   | Alle verfügbaren Adapter      | Verbindungen von der Titan-Engine
+Console Engine*      	|TCP 4440   | Connections from console      | Verbindungen von UI, Titan Remote, Multiuser und Backup.
+TitanNet Processor Engine |TCP 4441 | Alle verfügbaren Adapter	    | Verbindungen von UI und der Titan-Engine
+CITP Active Fixture Service* |TCP 4444 | Alle verfügbaren Adapter	| Verbindungen von UI und der Titan-Engine
+CITP    				|UDP 4809/TCP	| Multicast 224.0.0.180		| Kommunikation mit dem Capture Visualiser und Medienservern. Discovery erfolgt per UDP, dann die Kommunikation per TCP.
+WebAPI		        	|TCP 4430	| Alle verfügbaren Adapter 		| WebApi
+SLP						|UDP 427	| Multicast 239.255.255.253		| Discovery - zum gegenseitigen Finden von Titan-Geräten.
+Ping					|ICMP echo	| Alle aktuell genutzten Adapter	| Zur Überwachung der Netzwerkverbindung.
+Art-Net					|UDP 6454	| Default: Alle verfügbaren Adapter	| |
+sACN					|UDP 5568	| Multicast 239.255.0.0-239.255.249.255	| |
+RDMNet					|UDP 5569	|								| |
+ProDJ Tap   			|UDP 60000-60002, 65023-65535				| | Protokoll zur Kommunikation mit pioneer DJ-Geräten (von TC-Supply)
+LiveDMX					|UDP 5584	| Multicast 239.184.0.0-239.184.249.255 | Für den internen Visualiser	
+NTP						|UDP 1234	| Between TitanNet hosts		| nicht standardisierter NTP-Port
+
+
+ \* Neuer Port ab Titan v19. Alle anderen Angaben gelten für alle Versionen.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/using-active-fixtures.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/networking/using-active-fixtures.md
@@ -1,0 +1,54 @@
+---
+id: using-active-fixtures
+title: Verwenden von Geräten mit CITP
+sidebar_label: Verwenden von Geräten mit CITP
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+CITP ist ein Protokoll zur Kommunikation von Geräten miteinander. Es
+wird häufig benutzt, um etwa Thumbnails oder Informationen über
+vorhandene Layer von Medienservern an Lichtpulte zu übertragen. Damit
+kann man am Pult sehr einfach den gewünschten Clip identifizieren und
+anwählen.
+
+Dieser Abschnitt gilt nicht für Ai-Server, die mittels Synergy mit dem
+Pult verbunden sind.
+
+## Ein CITP-Beispiel
+
+In diesem Beispiel wird ein Hippotizer mit einem Titan-Pult verbunden.
+
+1. Verbinden Sie Pult und Hippotizer netzwerkseits (per Netzwerkswitch,
+oder ggf. mittels eines Crossover-Kabels).
+2. Stellen Sie die IP-Adressen so ein, dass beide nicht identisch, aber
+in einem Bereich sind, also z.B. `192.168.0.1` und `192.168.0.2`.
+3. Bei der Verwendung der Titan PC-Suite (Titan Mobiles oder Titan Simulator) ist ggf. die
+Firewall zu deaktivieren; gleiches gilt für den Hippotizer.
+4. Starten Sie den Hippotizer. Überprüfen Sie, dass die CITP
+Component geladen ist.
+5. Öffnen Sie das **System**-Menü (mittels <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>)
+und wählen Sie <Keys.SoftKey>DMX Settings</Keys.SoftKey>.
+6. Links im Fenster wird nun der Hippotizer mit seiner IP-Adresse als
+Art-Net-Knoten angezeigt. Klicken Sie darauf und ordnen Sie ihn einer internen DMX-Linie zu.
+7. Klicken Sie auf das kleine <Keys.ContextKey>Zahnrad</Keys.ContextKey> des zugeordneten Hippo-Knotens (rechts)
+und überprüfen Sie, dass das eingestellte Universum mit den Einstellungen des Hippotizers übereinstimmt.
+8. Schließen Sie das Fenster mit <Keys.HardKey>Exit</Keys.HardKey> und schalten Sie wieder in
+das Programmier-Menü.
+9. Starten Sie die Pult-Software neu (Schließen und neu starten, oder
+<Keys.SoftKey>Tools</Keys.SoftKey>, <Keys.SoftKey>Restart Software</Keys.SoftKey>).
+10. Zum Patchen wählen Sie nun <Keys.HardKey>Patch</Keys.HardKey>, <Keys.SoftKey>Active Fixtures</Keys.SoftKey>. Nun
+taucht der Hippotizer als zu patchendes Gerät auf.
+11. Wählen Sie diesen, und stellen Sie als DMX-Linie die in Schritt 6 gewählte ein.
+12. Klicken Sie auf eine Geräte-Schaltfläche, um den Hippotizer zu
+patchen. Das Pult legt daraufhin automatisch die vorhandenen Layer (incl. Master-Layer) als Geräte an.
+13. Wird nun eines dieser Geräte ausgewählt, so zeigt der
+Attribut-Editor die vorhandenen Clips als Thumbnails an.
+
+Stellen Sie sicher, dass beim nächsten Start zuerst der Hippotizer und
+erst dann das Pult gestartet wird.
+
+Wird die DMX-Adresse geändert, so muss der Hippotizer neu gestartet
+werden. Ebenso müssen im Pult die Art-Net-Knoten zurückgesetzt werden,
+wenn diese neuen DMX-Linien zugeordnet werden.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/palettes.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/palettes.md
@@ -1,0 +1,41 @@
+---
+id: palettes
+title: Paletten
+sidebar_label: Paletten
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Beim Programmieren einer Show wird man häufig auf gleiche Positionen,
+Farben etc. zurückgreifen. Beim Tiger Touch kann man diese
+Ein­stellungen abspei­chern, so dass sie sich mit einem einfachen Klick
+abrufen lassen, anstatt sie für jede einzelnen Cue neu einstellen zu
+müssen. Das ist nicht nur zum schnellen und effektiven Programmieren,
+sondern auch beim Improvisieren sehr praktisch.
+
+Bei der [Verwendung von Paletten in Cues](cues/creating-a-cue.md#anlegen-eines-cues) wird nicht der damit verknüpfte
+Wert, sondern der Verweis auf die Palette im Cue abgespeichert. Das
+bedeutet, dass sich etwa die Positionen der Show rasch durch Ändern der
+verwendeten Paletten ändern lassen, anstatt in sämtlichen Cues alle
+Positionen einzeln nachregeln zu müssen. Eine Anwendung dafür wäre etwa
+eine Tour, bei der man täglich andere Bühnengrößen oder Traversenhöhen
+zu berücksichtigen hat.
+
+Paletten können miteinander **[verknüpft (nested)](palettes/creating-palettes.md#nested-palettes----verknüpfte-paletten)** sein, so 
+dass sie aufeinander verweisen. Ändert man nun die Master-Palette, 
+so ändern sich die verknüpften Paletten entsprechend.
+
+Paletten werden auf die Schaltflächen in den Fenstern **'Colours'
+(Farben)**, **'Positions'** sowie **'Gobos and Beams'** gespeichert. 
+Ebenso können sie auf Macro/Exekutor-Tasten abgelegt oder numerisch 
+gespeichert und abgerufen werden. 
+
+Jede Schaltfläche lässt sich 
+[beschriften oder bemalen](palettes/creating-palettes.md#paletten-beschriften-und-bemalen), 
+so dass man die gesuchte Palette schnell wiederfindet.
+
+![Gobos and Beams Window and Colours Window](/docs/images/Gobos-and-Beams-Window-and-Colours-Window.png)
+
+Werden die Fenster **'Colours'**, **'Positions'** und **'Gobos and 
+Beams'** nicht angezeigt, so ruft man sie mit dem Workspace <Keys.SoftKey>Groups and Palettes</Keys.SoftKey> auf.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/palettes/copying-moving-and-deleting-palettes.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/palettes/copying-moving-and-deleting-palettes.md
@@ -1,0 +1,71 @@
+---
+id: copying-moving-and-deleting-palettes
+title: Paletten kopieren, verschieben oder löschen
+sidebar_label: Paletten kopieren, verschieben oder löschen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Kopieren oder verschieben einer Palette
+
+Mit der Taste <Keys.HardKey>Copy</Keys.HardKey> bzw. <Keys.HardKey>Move</Keys.HardKey> lässt sich eine Palette auf eine
+andere Schaltfläche verschieben oder kopieren. Ebenso lassen sich
+mehrere Paletten gleichzeitig verschieben oder kopieren. Verknüpfungen
+(Links) lassen sich dagegen für Paletten nicht anlegen.
+
+Das Verschieben von Paletten ist sinnvoll, um die Bedienoberfläche
+übersichtlich zu halten.
+
+1. Drücken Sie die Taste <Keys.HardKey>Copy</Keys.HardKey> bzw. <Keys.HardKey>Move</Keys.HardKey> (auf Pulten ohne 
+eine **Move**-Taste dient <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Copy</Keys.HardKey> zum Verschieben).
+2. Betätigen Sie die Schaltfläche der zu kopierenden/verschiebenden Palette; es lassen sich auch mehrere Paletten 
+auswählen. Verwenden Sie die Tasten <Keys.HardKey>Thro</Keys.HardKey> und <Keys.HardKey>And</Keys.HardKey>, um 
+weitere Paletten auszuwählen; halten Sie <Keys.HardKey>And</Keys.HardKey> gedrückt, so können Sie nacheinander
+Paletten hinzufügen.
+3. Klicken Sie auf die (freie) Schaltfläche, auf die Sie die Palette bewegen möchten.
+
+-   Die Taste <Keys.HardKey>Menu Latch</Keys.HardKey> fixiert das Menü **Copy/Move/Link**, so dass
+    man bei wiederholtem Kopieren/Verschieben die Taste <Keys.HardKey>Copy</Keys.HardKey> nicht
+    erneut betätigen muss. Zum Freigeben des Menüs drücken Sie
+    nochmals <Keys.HardKey>Latch Menu</Keys.HardKey>, zum Verlassen drücken Sie <Keys.HardKey>Exit</Keys.HardKey>.
+
+-   <Keys.SoftKey>Retain Layout</Keys.SoftKey>(Darstellung beibehalten) und <Keys.SoftKey>Bunch Up</Keys.SoftKey>
+    (zusammenfassen) sind von Bedeutung beim Kopieren von mehreren
+    Paletten mit eingeschlossenen freien Speicherplätzen: man kann
+    wählen, die Verteilung (mit freien Plätzen) beizubehalten oder nur
+    die wirklich verwendeten zusammenzufassen.
+
+-   Im Kopiermodus lässt sich die Option <Keys.SoftKey>Copy Legends</Keys.SoftKey>
+    (Bezeichnungen kopieren) umschalten zu <Keys.SoftKey>Don't copy legends</Keys.SoftKey>,
+    womit den kopierten Paletten Standard-Bezeichnungen gegeben werden.
+
+-   Im Move-(Verschieben)-Modus bietet sich ferner die Option <Keys.SoftKey>Swap Items if Required</Keys.SoftKey>. 
+    Damit werden soweit möglich andere Paletten
+    umplatziert, sofern sie beim Verschieben im Weg sind. Diese Option
+    ist hilfreich beim Umgruppieren in sehr vollen Seiten.
+
+## Löschen von Paletten
+
+Zum Löschen einer Palette drücken Sie die <Keys.HardKey>Delete</Keys.HardKey>-Taste und wählen
+danach die Schaltfläche der zu löschenden Palette. Betätigen Sie danach
+die Schaltfläche zur Bestätigung erneut. Zum Löschen mehrerer Paletten
+wählen Sie diese aus und bestätigen mit <Keys.HardKey>Enter</Keys.HardKey>. Bei Paletten auf
+Tasten halten Sie die erste gedrückt und betätigen dazu die letzte, um
+einen ganzen Bereich auszuwählen.
+
+Weitere Möglichkeiten zum Löschen:
+
+-   Verfügt das Pult über eine <Keys.HardKey>Update Palette</Keys.HardKey>-Taste (z.B. alte Pearl
+    Experts), so drücken sie diese, wählen die zu löschende Palette, und
+    wählen aus dem Menü <Keys.SoftKey>Delete</Keys.SoftKey>.
+
+-   Drücken Sie die Taste <Keys.HardKey>Palette</Keys.HardKey> oberhalb des Ziffernblocks, und
+    benutzen Sie die Option <Keys.SoftKey>Delete</Keys.SoftKey> aus dem Menü <Keys.SoftKey>Palette Utilities</Keys.SoftKey>.
+
+-   Drücken Sie <Keys.HardKey>Delete</Keys.HardKey>, dann <Keys.SoftKey>Palette</Keys.SoftKey>, tippen die Nummer mit den
+    Zifferntasten ein, und drücken <Keys.HardKey>Enter</Keys.HardKey>.
+
+>   Werden Paletten gelöscht, die in Cues verwendet wurden, so werden
+    statt der Palettenwerte die zum Zeitpunkt der Programmierung des
+    Cues aktuellen Werte aktiv.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/palettes/creating-palettes.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/palettes/creating-palettes.md
@@ -1,0 +1,314 @@
+---
+id: creating-palettes
+title: Erstellen von Paletten
+sidebar_label: Erstellen von Paletten
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Attribute zum Speichern in Paletten
+
+Obwohl ein Paletteneintrag mehrere oder alle Attribute eines Geräts
+beinhalten kann, ist es deutlich einfacher, mit getrennten Paletten zu
+arbeiten, so dass man etwa Paletten nur für Positionen und andere
+Paletten nur für Farben hat. Diese Vorgehens­weise wird durch getrennte
+Fenster für **Positions**-, **Farb**- und **Gobo**paletten unterstützt.
+
+Beim Speichern einer Palette werden nur die im Programmierspeicher
+befindlichen Attribute (die seit dem letzten <Keys.HardKey>Clear</Keys.HardKey> veränderten
+Werte) verwendet. Zum Erstellen einer Farb-Palette stellen Sie einfach
+die gewünschte Farbe ein, ohne die anderen Attribute zu verändern.
+Ebenso lassen sich Paletten mit Shapes und Pixelmapper-Effekten anlegen.
+Ferner werden auch Zeiten für Attribute und Geräte in den Paletten
+gespeichert, und es lassen sich sogar [Paletten nur mit Zeiten](#erstellen-einer-palette-mit-zeiten) - ohne Attributwerte - anlegen.
+
+Sind mehrere Attribute im Programmierspeicher, so erstellen Sie eine
+Maske, mit der die zu speichernden Attribute ausgewählt werden.
+
+Paletten können **Global**e, gemeinsame (**shared**) oder **normal**e
+(einzeln verwendete) Paletten sein:  
+
+- **Globale** Paletten funktionieren mit
+allen Gerätetypen (die diese Attribute physikalisch steuern können).
+- **Shared** Paletten speichern identische DMX-Werte für alle Geräte des
+gleichen Typs, *z.B. ‚Rot' für alle Martin MAC2000*.
+- **Normale** Paletten wiederum speichern für jedes Gerät 
+andere DMX-Werte, *etwa fast immer beim Programmieren von Positionen*.
+
+Beim Verschmelzen (merge) von Paletten können auch Paletten entstehen,
+die sowohl globale, shared als auch normale Attribute enthalten.
+
+Generell können nur Dimmer, Pan/Tilt und Colour global sein. Wird für
+ein Gerät mit Farbmischung eine globale Farb-Palette erzeugt, so werden
+Werte für CMY und für RGB sowie ein 'dynamischer' Wert für Geräte mit
+Farbrad gespeichert; mit letzterem wird dann versucht, die passendste
+Farbe auf dem Farbrad (bei Geräten mit festen Farben) auszuwählen.
+
+Mit der [Benutzereinstellung "Minimum Palette Mode"](../system-settings/user-settings.md#palettes)
+kann festgelegt werden, dass auch beim Schnellspeichern Paletten immer 
+als **Shared** oder **Normal** erstellt werden, auch wenn das Pult sie 
+sonst als globale Palette speichern würde.
+
+## Speichern einer Palette
+
+<Video videoId="Hs-xzpD5x8k" title="Recording Palettes" />
+
+Zum Speichern einer Palette in eines der Palettenfenster gehen Sie wie folgt vor 
+*(werden die Palettenfenster nicht angezeigt, so klicken Sie auf den 
+Workspace-Button <Keys.SoftKey>Groups and Palettes</Keys.SoftKey>)*:
+
+1. Drücken Sie <Keys.HardKey>Clear</Keys.HardKey>, um den Programmierspeicher zu löschen.
+2. Wählen Sie die Geräte, für die eine Palette gespeichert werden soll.
+3. Mit den Attribut-Tasten und Rädern stellen Sie nun die gewünschten
+Werte ein.*Es lassen sich einzelne oder alle Attribute in einer Palette speichern.*
+4. Drücken Sie <Keys.HardKey>Record</Keys.HardKey> und dann <Keys.HardKey>Palette</Keys.HardKey> oder drücken Sie
+<Keys.HardKey>Palette</Keys.HardKey> und wählen <Keys.SoftKey>Record Palette</Keys.SoftKey>.
+5. Erstellen Sie die Palettenmaske; diese bestimmt, welche Attribute
+in der Palette gespeichert werden. Wählen Sie die zu speichernden
+Attribute mit den Attribut-Tasten: jedes mit einer leuchtenden LED
+gekennzeichnete Attribut ist zum Speichern vorgesehen. <Keys.SoftKey>Set Mask</Keys.SoftKey> und
+<Keys.SoftKey>Record by</Keys.SoftKey> dienen ebenfalls zum Einstellen der Maskierung (s.u.).
+6. Klicken Sie auf eine freie Paletten-Schaltfläche zum Speichern 
+(wählen Sie stattdessen einen bereits mit einer Palette belegten Button, 
+so gibt es weitere Optionen), oder vergeben Sie eine Nummer und drücken Sie <Keys.SoftKey>Store</Keys.SoftKey>.
+
+- Beim [Schnellspeichern von Paletten](#schnellspeichern) sind Schritt 4 und 5 nicht erforderlich - doppelklicken Sie
+einfach auf eine freie Schaltfläche in einem der Palettenfenster. Dabei wird die Palettenmaske anhand des Fensters
+festgelegt: Positionspaletten enthalten nur P, Farbpaletten nur C, und Paletten im Fenster Gobos&Beams enhalten IGBES.
+
+Möchten Sie Paletten auf die Tasten des Pultes speichern, so drücken Sie ebenfalls <Keys.HardKey>Record</Keys.HardKey>
+und dann <Keys.HardKey>Palette</Keys.HardKey>: daraufhin leuchten alle noch freien Tasten auf, und zum Speichern muss 
+einfach eine davon betätigt werden.
+
+![Recording a Palette menu](/docs/images/Recording-a-Palette-menu.png)
+
+-   Das Pult legt die Palette automatisch als global, shared (gemeinsam
+    genutzt) oder normal an (dazu wird überprüft, ob alle Geräte
+    gleichen Typs die gleichen Attributwerte haben). Diese Einstellung
+    kann mit <Keys.SoftKey>Menütaste C</Keys.SoftKey> geändert werden. Die Automatik ist weiter
+    unten näher beschrieben.
+
+-   Mit <Keys.SoftKey>Set Mask</Keys.SoftKey> lassen sich die in der Palette zu speichernden
+    Attribute auswählen. Ebenso können dazu die Attribut-Tasten bei den Encodern genutzt werden.
+    
+	Ist eine Attribut-Gruppe zum Speichern vorgesehen, so erscheint die
+    entsprechende Funktionstaste invertiert (wie für 'Colour' in 
+    Bild), und die LED der entsprechenden Attribut-Taste leuchtet. Beim
+    Verwenden der **[Schnellspeicherfunktion](#schnellspeichern)**
+    wird die Maske automatisch erstellt, abhängig vom Fenster, in dem
+    die Palette gespeichert wird: Paletten im Fenster 'Positions'
+    enthalten nur P, im Fenster 'Colours' nur C und im Fenster 'Gobos
+    and Beams' nur IGBES. Wird die Palette hingegen mit <Keys.HardKey>Record</Keys.HardKey> gespeichert, muss die Maske manuell eingestellt werden.
+
+-   Mit der Taste <Keys.HardKey>Attribute Options</Keys.HardKey> (auf neueren 
+	Pulten <Keys.HardKey>Options</Keys.HardKey>) können alle Attributgruppen zwischen 'Include' und 'Exclude' 
+	umgeschaltet werden.
+
+![Setting a mask for recording a palette](/docs/images/Setting-a-mask-for-recording-a-palette.png)
+
+-	&nbsp;<Keys.SoftKey>Record By...</Keys.SoftKey> steuert, wie die erstellte Maske beim Speichern der
+    Palette verwendet wird:
+	-   &nbsp;<Keys.SoftKey>Channel in programmer</Keys.SoftKey> - es werden nur Kanäle gespeichert, die
+    sich im Programmierspeicher befinden (also vorher verändert wurden)
+	-   &nbsp;<Keys.SoftKey>Group in programmer</Keys.SoftKey> speichert alle Kanäle in jeder
+    Attribut-Gruppe, von der sich ein oder mehrere Kanäle im Programmierspeicher befinden. *Ist etwa ein Wert 
+	für Cyan im Programmierspeicher, so werden sämtliche Einstellungen aller Farbkanäle abgespeichert, auch wenn 
+	sie nicht im Programmierspeicher sind.*
+	-   &nbsp;<Keys.SoftKey>Group in mask</Keys.SoftKey> speichert sämtliche Werte für alle in der Maske
+    ausgewählten Attribute
+	-   &nbsp;<Keys.SoftKey>Mixed</Keys.SoftKey> speichert **Positionen** und **Farben** als 
+	Attributgruppen, alle anderen Kanäle jedoch einzeln.
+
+-   Das Pult vergibt automatisch eine Bezeichnung für die Palette (außer
+    die [Benutzereinstellung](../system-settings/user-settings.md#palettes) **Auto Legend** wurde deaktiviert). 
+	-   Bei **Farb-Paletten** werden die enthaltenen Farben angezeigt - sind
+		mehrere enthalten, so werden verschiedenfarbige Streifen angezeigt.
+	-   Bei **Gobo-Paletten** werden die Gobos grafisch dargestellt, sofern
+		das in der Personality hinterlegt ist (ggf. müssen die [Personalities
+		aktualisiert werden](../patching/changing-the-patch.md#bereits-gepatchte-personalities-aktualisieren)).
+    -   Für **CITP-Paletten (von einem Medienserver)** werden die übertragenen
+		Vorschaubilder angezeigt. 
+	-	Für **Pan und Tilt** werden allgemeine Bezeichner vergeben.
+	-	Für **alle anderen** Attribute wird der zuletzt veränderte Wert angezeigt. 
+	
+	![Automatic Legends set for Colour Palettes](/docs/images/Automatic-Legends-set-for-Colour-Palettes.png)
+
+-   Ebenso kann man beim Speichern mit <Keys.SoftKey>Provide a legend</Keys.SoftKey> der Palette
+    eine Bezeichnung geben. Zum späteren Ändern der Bezeichnung siehe
+    [Paletten beschriften und bemalen](#paletten-beschriften-und-bemalen).
+
+- Wird eine Palette auf einen bereits belegten Speicherplatz gespeichert, so bietet das Pult die 
+Optionen <Keys.SoftKey>Cancel</Keys.SoftKey> (Abbruch), <Keys.SoftKey>Replace</Keys.SoftKey>(Ersetzen) 
+und <Keys.SoftKey>Merge</Keys.SoftKey>(Kombinieren).
+  -  &nbsp;Mit <Keys.SoftKey>Replace</Keys.SoftKey> wird die bisher gespeicherte Palette gelöscht und 
+durch die neue ersetzt.
+  -  &nbsp;Bei der Wahl von <Keys.SoftKey>Merge</Keys.SoftKey> werden die beiden Paletten miteinander verschmolzen.
+  -  &nbsp;<Keys.SoftKey>Quick Merge</Keys.SoftKey> ist das Verschmelzen ausschließlich der Attribute, die bisher 
+  schon in der Palette enthalten sind.
+    
+    
+    Damit lassen sich etwa einzelne Werte zu einer existierenden 
+  gemeinsam genutzten Palette hinzufügen, oder enthaltene Werte 
+  einfach verändern. Wird die gewählte Paletten-Auswahltaste erneut
+  betätigt, erfolgt automatisch ein Quick Merge.
+
+-   Wenn nicht explizit vorgegeben, wählt das Pult automatisch, ob eine
+    globale, shared oder normale Palette erzeugt wird: eine **globale**
+    Palette wird gespeichert, wenn alle ausgewählten Geräte im
+    Programmer die gleichen Werte haben und die Attribute für globale
+    Paletten verfügbar sind. Sind die Werte zwar gleich, die Attribute
+    aber nicht für globale Paletten geeignet, so wird eine **shared**
+    Palette gespeichert. Sind einige Attribute für global geeignet und
+    einige nicht, so wird eine Palette mit den geeigneten Attributen als
+    global und mit den anderen als shared gespeichert. Sind schließlich
+    die Werte unterschiedlich, so wird eine **normale** Palette erstellt.
+	Diese Automatik lässt sich mit der [Benutzereinstellung](../system-settings/user-settings.md#palettes) **Minimum Palette Mode**
+	überschreiben bzw. deaktivieren.
+
+## Nested palettes -- Verknüpfte Paletten
+
+Paletten können Bezüge auf andere Paletten enthalten. So kann z.B. eine
+Palette 'odd/even' erstellt werden, bei der die ungeraden Geräte eine
+Farbe und die geraden Geräte eine andere Farbe zugewiesen bekommen,
+wobei die konkreten Farben aus anderen (Master-) Paletten referenziert
+werden. Werden nun die Master-Paletten geändert, so ändert sich die
+'odd/even'-Palette entsprechend.
+
+Die Option <Keys.SoftKey>Record/Don't Record Nested Palettes</Keys.SoftKey> im Menü "Record
+Palette" bestimmt, ob der Verweis auf die Masterpalette (*Vorgabe*)
+oder aber der jeweilige absolute Wert gespeichert werden soll.
+
+Wurde eine Palette mit Verknüpfungen zu anderen Paletten gespeichert, 
+so lässt sich das Aufrufen der verknüpften Paletten deaktivieren, so 
+dass nur die direkt in der Palette gespeicherten Werte verwendet werden. 
+Dies kann beim Updaten der verknüpften Paletten sinnvoll sein.
+
+1.	Drücken Sie <Keys.SoftKey>Options</Keys.SoftKey>.
+2.	Wählen Sie die Palette.. 
+3.	Auf dem Reiter <Keys.SoftKey>Palette</Keys.SoftKey> der Optionen deaktivieren Sie die 
+	Einstellung <Keys.SoftKey>Fire Nested Palettes</Keys.SoftKey>. 
+4.	Wird nun die Palette aufgerufen, so werden nur die direkt in dieser 
+	gespeicherten Werte verwendet, nicht aber die aus verknüpften Paletten.
+
+-	Der vorige Zustand lässt sich wieder herstellen, indem man die Option <Keys.SoftKey>Fire Nested Palettes</Keys.SoftKey> wieder aktiviert.
+
+## Schnellspeichern
+
+In den Paletten-Fenstern gibt es ebenso eine Schnellspeicher-Funktion.
+Dazu betätigen Sie einfach die gewünschte Schaltfläche - diese wird
+daraufhin rot und zeigt ein + -Zeichen. Nun lässt sich eine Bezeichnung
+vergeben sowie die Maskierung ändern. Mit einer weiteren Betätigung der
+Schaltfläche wird die Palette gespeichert.
+
+![Palette quick record](/docs/images/Palette-Quick-Record.png)
+
+Beim Verwenden der Schnellspeicherfunktion wird die Attributmaske
+automatisch abhängig vom jeweiligen Fenster eingestellt; so werden
+im Fenster **Positions** nur Pan/Tilt-Werte (**P**), bei **Colours** 
+nur Farben (**C**) und bei **Gobos and Beams** die anderen Attribute 
+(**IGBES**) abgespeichert. Dies geschieht nicht beim Speichern mittels 
+der <Keys.HardKey>Record</Keys.HardKey>-Taste.
+
+Schnellspeichern funktioniert auch bei Gruppen und Arbeitsumgebungen 
+(Workspaces).
+
+> Wird eine Show geladen, die auf einem **Pearl Expert** programmiert wurde, so lassen sich die dort auf die Tasten programmierten Paletten über das Fenster **Groups and Palettes** erreichen, siehe
+[Compatibility windows -- Die Kompatibilitäts-Fenster](../titan-basics/workspace-windows.md#compatibility-windows----die-kompatibilitäts-fenster).
+
+## Paletten beschriften und bemalen
+
+Für jede Palette lässt sich eine Beschriftung vergeben, die auf der
+Paletten-Schaltfläche angezeigt wird.
+
+1.  Drücken Sie im Hauptmenü <Keys.SoftKey>Set Legend</Keys.SoftKey>.
+2.  Klicken Sie auf die zu ändernde Palette.
+3.  Geben Sie die Bezeichnung mit der Tastatur ein.
+4.  Schließen Sie die Eingabe mit <Keys.HardKey>Enter</Keys.HardKey> ab.
+
+Auf den Schaltflächen wird die Palettennummer oben links angezeigt.
+Die enthaltenen Attribute (**IPCGBES**) werden unter der Beschriftung
+eingeblendet, etwa ein **P** für **Positions-Paletten**. In der oberen
+rechten Ecke steht ein **G** für eine **globale**, ein **N** für eine 
+&nbsp;**normale** bzw. ein **S** für eine **Shared** (gemeinsam genutzte) Palette.
+
+![Shared and normal palettes stored on a touch screen](/docs/images/Shared-and-normal-palettes-stored-on-a-touch-screen.png)
+
+Ebenso lassen sich Paletten bemalen, um etwa auf einen Blick die Farbe
+oder das Gobo zu erkennen. Drücken Sie dazu wiederum <Keys.SoftKey>Set Legend</Keys.SoftKey>,
+wählen die Palette aus, und wählen dann <Keys.SoftKey>Picture</Keys.SoftKey> - daraufhin öffnet
+sich der Picture-Editor:
+
+![Setting legend of palette using draw picture editor](/docs/images/Setting-legend-of-palette-using-draw-picture-editor.png)
+
+Oben links gibt es Reiter für die Bildschirmtastatur (damit wird aus der
+Bemalung wieder eine Beschriftung), zum freien Zeichnen, für die
+Bilder-Bibliothek sowie zum Laden einer separaten Datei. Im Zeichenfeld
+hat man rechts Werkzeuge zur Auswahl von Stift oder Radierer, für die
+Strichstärke und die Auswahl der Farbe. **Clear** löscht die ganze
+Zeichnung, **Enter** schließt den Zeichenvorgang ab und übernimmt das
+Bild. Mit **Min/Max** oben rechts lässt sich der Editor verkleinern oder
+vergrößern.
+
+Bei Auswahl der Bibliothek kann man ein Bild aus einer großen Zahl
+vorgefertigter Zeichnungen verwenden. Die Vorlagen sind in verschiedene
+Kategorien (links) eingeteilt.
+
+![Setting legend of palette using Icon Library](/docs/images/Setting-legend-of-palette-using-Icon-Library.png)
+
+## Erstellen einer Effekt-Palette
+
+Paletten mit [Shapes oder Pixelmapper-Effekten](../effects.md) können 
+sehr praktisch sein. (Keyframe-Shapes können allerdings nicht in 
+Paletten gespeichert werden).
+
+Dabei empfiehlt es sich, selektiv so vorzugehen, dass die Palette
+ausschließlich Effekt-Informationen enthält; so wird dann z.B. eine
+Palette mit einem Circle-Effekt die Geräte sich um den gerade aktuellen
+Pan/Tilt-Wert bewegen lassen. Dazu nutzen Sie entweder die Maskierung
+des FX-Attributs, oder Sie achten darauf, beim Speichern der Palette
+keine anderen Attributwerte in den Programmierspeicher zu schreiben.
+
+1.  Drücken Sie <Keys.HardKey>Clear</Keys.HardKey>, wählen Sie einige Geräte aus, und drücken Sie
+	<Keys.HardKey>Locate</Keys.HardKey>.
+	*Sie können auch deren Position verändern, um das Ergebnis besser 
+	zu sehen*.
+2.  Drücken Sie <Keys.SoftKey>Shapes and Effects</Keys.SoftKey>, dann <Keys.SoftKey>Shape Generator</Keys.SoftKey>, und
+	starten Sie einen Shape.
+	*Siehe [Shape Generator](../effects/shape-generator.md) zum 
+	Erstellen von Shapes*.
+3.  Ändern Sie die Parameter des Shapes nach Belieben.
+4.  Drücken Sie <Keys.HardKey>Record</Keys.HardKey>, dann <Keys.HardKey>Palette</Keys.HardKey> (Quick Record
+	funktioniert nicht bei Shape-Paletten).
+5.  Haben Sie in **Schritt 1** die Position oder weitere Attribute
+	verändert, so drücken Sie <Keys.SoftKey>Set Mask</Keys.SoftKey> und deaktivieren alles 
+	außer **FX**.
+6.  Klicken Sie auf eine Palettenschaltfläche, um die Palette zu
+	speichern.
+
+Effekt-Paletten lassen sich nicht als **[Quick Palette](using-palettes.md#quick-palettes----schnelle-paletten-ohne-ausgewählte-geräte)** verwenden. Es müssen immer Fixtures angewählt sein, um eine 
+Effekt-Palette anzuwenden.
+
+## Erstellen einer Palette mit Zeiten
+
+Es lassen sich Paletten erstellen, die ausschließlich **Zeiten**, aber keine
+Werte enthalten. Dies ist sinnvoll beim Speichern von Cues oder bei
+Zeiten für einzelne Attribute, um die Zeit nicht jedes Mal neu eingeben
+zu müssen. Auch für Zeiten gilt, dass Paletten beim Speichern als
+Referenz abgelegt werden: wird später die Zeit in der Palette geändert,
+so wirkt sich das auf alle damit erstellten Cues aus.
+
+1.  Drücken Sie <Keys.HardKey>Clear</Keys.HardKey>, wählen Sie einige Geräte aus, und drücken Sie
+	<Keys.HardKey>Locate</Keys.HardKey>.
+	*Sie können auch deren Position verändern, um das Ergebnis besser
+	sehen zu können*.
+2.  Drücken Sie <Keys.HardKey>TIME</Keys.HardKey>
+	(*auf früheren Pulten <Keys.HardKey>SET</Keys.HardKey> (Mobile/Sapphire) bzw. <Keys.HardKey>Next Time</Keys.HardKey> (Expert/Tiger)*).
+3.  Setzen Sie die Fadezeit auf 2 s. Damit wird dies als globale
+	Fadezeit in den Programmierspeicher geschrieben.
+4.  Drücken Sie <Keys.HardKey>Record</Keys.HardKey>, dann <Keys.HardKey>Palette</Keys.HardKey>.
+5.  Haben Sie in **Schritt 1** die Position oder weitere Attribute
+	verändert, so drücken Sie <Keys.SoftKey>Set Mask</Keys.SoftKey> und deaktivieren alles außer
+	**Time**.
+6.  Klicken Sie auf eine Palettenschaltfläche, um die Palette zu
+	speichern.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/palettes/editing-palettes.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/palettes/editing-palettes.md
@@ -1,0 +1,118 @@
+---
+id: editing-palettes
+title: Editieren von Paletten
+sidebar_label: Editieren von Paletten
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Anzeigen und Ändern einer Palette
+
+Die in einer Palette gespeicherten Werte lassen sich im Fenster **Palette
+View** anzeigen. Hier werden alle Geräte aufgelistet, für die die Palette
+Werte enthält. Mit einer Kontext-Schaltfläche lassen sich gespeicherte
+&nbsp;**Zeiten (Times)** anzeigen.
+
+Drücken Sie dazu <Keys.HardKey>Open/View</Keys.HardKey> und die anzuzeigende
+Paletten-Schaltfläche. Daraufhin öffnet sich das Fenster **Palette View**.
+
+![Palette View window](/docs/images/Palette-View-window.png)
+
+Die angezeigten Attribute **All/IPCGBES** und Gerätetypen lassen sich 
+mit den Schaltflächen links auswählen/filtern.
+
+Um einen Wert zu ändern, klicken Sie im Fenster darauf. Die Menütasten
+zeigen die verfügbaren Möglichkeiten; alternativ können Sie mit den
+Zifferntasten einen Wert eingeben.
+
+Es ist nicht möglich, Werte aus Paletten komplett zu löschen. Vielmehr
+lassen sich Werte per [Off] deaktivieren und können später wieder 
+aktiviert werden. Um einen Wert zu deaktivieren, klicken Sie diesen an 
+und drücken im Menü auf <Keys.SoftKey>Off</Keys.SoftKey> oder die Taste <Keys.HardKey>Off</Keys.HardKey>. Um ihn wieder zu
+aktivieren, wählen Sie den Wert an (zeigt jetzt [Off]) und drücken im 
+Menü auf <Keys.SoftKey>On</Keys.SoftKey> oder wieder auf die Taste <Keys.HardKey>Off</Keys.HardKey> (die Taste <Keys.HardKey>Off</Keys.HardKey> 
+schaltet den Wert ein oder aus).
+
+-   Enthält die Palette Verweise auf andere Paletten, so lässt sich mit
+    der Option <Keys.SoftKey>View/Hide Nested Palettes</Keys.SoftKey> einstellen, ob die
+    tatsächlichen Werte oder aber die Legende der verknüpften Palette
+    angezeigt wird.
+
+-   Enthält die Palette Shapes, so öffnet die Schaltfläche <Keys.SoftKey>View Shapes</Keys.SoftKey> 
+    die Shape-Anzeige mit allen enthaltenen Shapes und ihren
+    Parametern. Klickt man dort wiederum auf <Keys.SoftKey>View</Keys.SoftKey> ('Anzeigen'), so
+    öffnet sich die Shape-Geräteansicht **Shape Fixture View**, in der 
+	man die Parameter für einzelne Geräte ändern sowie mit **Add 
+	Fixtures** weitere Geräte hinzufügen kann.
+
+-   Enthält die Palette Pixelmapper-Effekte, so lassen sich diese mit <Keys.SoftKey>View Effects</Keys.SoftKey> öffnen, anzeigen und editieren.
+
+-   Mit der Kontextoption <Keys.SoftKey>View Playbacks Using Palette</Keys.SoftKey> wird angezeigt, in welchen 
+Playbacks die Palette verwendet wird.
+
+## Ändern des Inhalts einer Palette
+
+Um einen Eintrag einer Palette zu ändern, betätigen Sie die Taste <Keys.HardKey>Edit</Keys.HardKey> 
+(bzw. <Keys.HardKey>Update Palette</Keys.HardKey> auf dem Pearl Expert und Tiger Touch mk1),
+wählen die zu ändernde Palette (bei normalen Paletten werden
+automatisch die enthaltenen Geräte angewählt; bei Shared Paletten das
+erste Gerät des entsprechenden Typs), nehmen die gewünschten Änderungen
+vor, und betätigen die Funktionstaste <Keys.SoftKey>Update Palette x</Keys.SoftKey>, um die
+Änderungen zu übernehmen.
+
+Mit der Taste <Keys.HardKey>Edit</Keys.HardKey> lässt sich ebenso die 
+Bezeichnung und die Nummer der Palette ändern.
+
+Ebenso können Sie eine Palette auch für nur einzelne oder wenige Geräte
+aufrufen, modifizieren und die geänderten Werte wieder in die bestehende
+Palette speichern. Das Pult zeigt dabei Optionen zum Ersetzen (**Replace**),
+Kombinieren (**Merge**) oder **Quick Merge** der Paletten an. Wird **Merge**
+gewählt, so bleiben nicht veränderte Werte unberührt, während geänderte
+Werte zur Palette hinzugefügt werden. Quick Merge dagegen aktualisiert
+nur die Attribute, die in der originalen Palette bereits enthalten
+waren. *Wendet man dies auf eine reine Positionspalette an und hat z.B.
+auch die Farb-Werte editiert, so werden diese bei Quick Merge nicht in
+die Palette gespeichert*.
+
+Wird eine Palette zum Updaten zweimal geklickt, so erfolgt ein **Quick
+Merge**.
+
+-   Wahlweise lässt sich die [Benutzereinstellung](../system-settings/user-settings.md#handles)
+	**Prompt Replace** auf "Always Merge" (stets verschmelzen) stellen, um die Rückfrage des Pultes zu 
+	vermeiden. Ebenso kann man einfach die gewählte Paletten-Schaltfläche ein 
+	zweites Mal betätigen, um die Paletten zu verschmelzen.
+
+-   Weitere Geräte lassen sich zu bestehenden Paletten hinzufügen, ohne
+    die bereits programmierten zu beeinflussen. *Sind etwa bereits
+    Farbpaletten für Mac 600 vorhanden, so lassen sich Farben für Mac
+    500 hinzufügen, ohne die bereits gespeicherten Werte zu ändern.*
+
+-   Zum Löschen von Attributen aus Paletten dient die Taste <Keys.HardKey>Off</Keys.HardKey>
+	sowie die Menütaste <Keys.SoftKey>Off</Keys.SoftKey>, siehe voriger Abschnitt, sowie die
+	[<Keys.HardKey>Off</Keys.HardKey> -Funktion](../cues/editing-cues.md#deaktivieren-von-attributen-in-cues-mit-off).
+
+-   Beim Ändern einer Palette bleibt der Inhalt des Programmierspeichers
+    erhalten; nach dem Speichern der modifizierten Palette wird der
+    Programmierspeicher in den Zustand vor dem Ändern der Palette
+    zurückversetzt.
+
+## Anzeigen der Playbacks, die die Palette verwenden
+
+Wird eine Palette editiert, so kann es sinnvoll sein zu überprüfen, welche Playbacks diese Palette verwenden.
+Dazu lassen Sie sich den Inhalt der Palette wie oben beschrieben anzeigen, und aktivieren die Kontextoption <Keys.SoftKey>View Playbacks Using Palette</Keys.SoftKey>. Darauf öffnet sich das Fenster **Referencing Playbacks**, in dem alle
+relevanten Playbacks aufgeführt sind.
+
+## Aktualisieren von verwendeten Paletten
+
+Muss eine bereits verwendete Palette während der Show verändert werden,
+wenn z.B. der Grün-Ton nicht exakt die gewünschte Farbe trifft, so lässt
+sich das einfach per <Keys.HardKey>Update</Keys.HardKey> realisieren.
+
+1.  Während der Cue gestartet ist, wählen Sie die betreffenden Geräte
+    aus und stellen den gewünschten Wert ein.
+2.  Drücken Sie <Keys.HardKey>Update</Keys.HardKey> (Pearl Expert: <Keys.HardKey>Record Cue</Keys.HardKey>, <Keys.SoftKey>Update</Keys.SoftKey>)
+3.  Im Bildschirm werden die Paletten und Cues, die zum gestarteten Cue
+    gehören und upgedatet werden können, angezeigt.
+4.  Wählen Sie mit den Menütasten, was upgedatet werden soll, und drücken 
+	Sie nochmals <Keys.HardKey>Update</Keys.HardKey>.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/palettes/timing-with-palettes.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/palettes/timing-with-palettes.md
@@ -1,0 +1,108 @@
+---
+id: timing-with-palettes
+title: Arbeiten mit Zeiten in Paletten
+sidebar_label: Arbeiten mit Zeiten in Paletten
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Paletten können gleich mit Zeiten erstellt werden;
+alternativ kann beim Abruf einer Palette eine Zeit vorgegeben oder die
+gespeicherte überschrieben werden.
+
+## Paletten mit gespeicherten Zeiten
+
+[Enthält eine Palette auch Zeiten](creating-palettes.md#erstellen-einer-palette-mit-zeiten), 
+so werden diese mit berücksichtigt,
+wenn die Palette in Playbacks verwendet wird. Wurden also z.B. 2s 
+Fadezeit mit in der Palette abgespeichert und wird diese in einem Cue 
+verwendet, so ist für diesen bereits 2s Fadezeit eingestellt.
+
+Beim direkten Palettenaufruf hingegen wird die Fadezeit zunächst **nicht** 
+berücksichtigt, um das Programmieren nicht zu behindern. Es kann aber 
+per Tastenprofil aktiviert werden, was insbesondere beim [Improvisieren
+(Busking) mit Paletten](../running-the-show/playback-controls.md#improvisieren-busking-mit-paletten) 
+interessante Möglichkeiten eröffnet. Dazu ändern
+Sie die [Einstellung (Key Profiles für Paletten)](../system-settings/key-profiles#palettes) 
+<Keys.SoftKey>Palette Is Fired Ignoring Its Times</Keys.SoftKey> (Zeiten werden ignoriert) 
+in <Keys.SoftKey>Palette Is Fired With Its Times</Keys.SoftKey> (Palette wird
+mit Zeiten gestartet).
+
+## Überschreiben von Palettenzeiten
+
+<Video videoId="FF8szWCpVkE" title="Overriding Palette Times" />
+
+Das Überschreiben von Palettenzeiten ist hilfreich, um 'mal eben schnell
+eine Show zu drücken' (Busking). Wird eine Palette auf diesem Weg abgerufen, so
+wird ein Zeitparameter hinzugefügt, und die Palette blendet in der
+vorgegebenen Zeit ein.
+
+1.  Wählen Sie ein oder mehrere Geräte aus.
+2.  Tippen Sie mit den Zifferntasten die gewünschte Zeit ein.
+3.  Betätigen Sie die gewünschte Paletten-Schaltfläche.
+
+-   Damit werden alle eventuell in der Palette gespeicherte Zeiten
+    überschrieben.
+
+-   Die Überblendzeit muss bei jedem Palettenaufruf erneut eingegeben
+    werden. Um immer die gleiche Zeit zu verwenden, geben Sie diese als [Master Time](../palettes/timing-with-palettes.md#master-zeit-und-overlap-für-paletten) ein.
+
+-   Das Einblenden von Paletten kann etwa sinnvoll sein beim Abruf von
+    Paletten während einer Show, da sich damit langsame Positions- und
+    Farbwechsel (bei Geräten mit Farbmischsystem) erreichen lassen.
+
+## Manuelle Geräteüberlappung beim Palettenabruf
+
+Außerdem lässt sich die [Überlappung (Fixture Overlap)](../cues/cue-timing.md#einstellen-von-überblendzeiten-und-geräteversatz) 
+zwischen den Geräten einstellen: wenn die Palette auf eine Gruppe von 
+Geräten angewendet wird, so erfolgt das nacheinander auf die einzelnen
+Geräte. Damit lassen sich sehr einfach beeindruckende Effekte erzielen.
+
+&nbsp;**100%** bedeutet, dass alle Geräte gleichzeitig beeinflusst werden.
+
+&nbsp;**0%** bedeutet, dass ein Gerät erst voll eingeblendet 
+sein muss, bevor die Überblendung mit dem nächsten Gerät beginnt.
+
+1.  Geben Sie mit den Zifferntasten die Überlappung ein.
+2.  Drücken Sie <Keys.SoftKey>Set Overlap</Keys.SoftKey>
+3.  Geben Sie die gewünschte Überblendzeit ein.
+4.  Rufen Sie die gewünschte Palette auf.
+
+-   Die Überlappung muss bei jedem Aufruf neu eingegeben werden. Um
+    stets die gleiche Überlappung zu verwenden, stellen Sie diese 
+    als [Master Overlap](../palettes/timing-with-palettes.md#master-zeit-und-overlap-für-paletten) ein. 
+    Um das zu deaktivieren, setzen Sie ‚Master Overlap' auf 100%.
+
+-	Der Überlappungs-Effekt ist nur sichtbar mit einer Einfadezeit.
+
+>   Berücksichtigen Sie bei der Verwendung von Fixture Overlap, 
+	globalen Paletten und dem Abruf als Quick Palette (ohne angewählte
+	Geräte), dass das Overlap ggf. auf **sehr viele** Geräte
+	nacheinander angewendet wird, was zu unerwarteten Ergebnissen
+	führen kann.
+
+## Master-Zeit und Overlap für Paletten
+
+Mit der Option <Keys.SoftKey>Master Time</Keys.SoftKey> im Paletten-Menü (betätigen Sie dazu die
+Taste <Keys.HardKey>Palette</Keys.HardKey> oberhalb der Zifferntasten) lässt sich eine
+Standard-Überblendzeit vergeben, die stets genutzt wird, sofern keine
+andere Zeit manuell eingegeben wird. Das erleichtert das schnelle
+Steuern von Shows mit Paletten.
+
+Um das Faden von Paletten zu deaktivieren, stellt man die Master Time auf 0.
+
+In gleicher Weise arbeitet <Keys.SoftKey>Master Overlap</Keys.SoftKey> für die Überlappung. 
+Um diese zu deaktivieren, stellt man die Überlappung auf 100%.
+
+> Es lassen sich Macros erstellen, mit denen verschiedene Überblendzeiten vorgegeben werden können. Drücken
+Sie dazu <Keys.HardKey>Macro</Keys.HardKey>, <Keys.SoftKey>Record</Keys.SoftKey>, dann eine Taste/Schaltfläche 
+für das Macro. Nun drücken Sie <Keys.HardKey>Palette</Keys.HardKey>, <Keys.SoftKey>Master Time</Keys.SoftKey>, 
+z.B. <Keys.HardKey>3</Keys.HardKey> (für 3 Sek.), <Keys.HardKey>Exit</Keys.HardKey>, <Keys.HardKey>Macro</Keys.HardKey>.
+Wiederholen Sie diese Schritte mit unterschiedlichen Zeiten, z.B. 0 Sek. (hartes Umschalten), 5 Sek. etc.
+
+Etliche solche Macros für verschiedene Fadezeiten (<Keys.SoftKey>Palette Fade x s</Keys.SoftKey>)
+und Overlaps (<Keys.SoftKey>Palette Overlap y %</Keys.SoftKey>) sind bereits in der Macro-Library
+enthalten. Drücken Sie dafür <Keys.HardKey>Macro</Keys.HardKey> und die Menütaste <Keys.SoftKey>View All</Keys.SoftKey>. 
+Die Macros aus der Library lassen sich wie gewohnt per <Keys.HardKey>Copy</Keys.HardKey> auf beliebige Tasten 
+kopieren, um sie rasch im Zugriff zu haben.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/palettes/using-palettes.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/palettes/using-palettes.md
@@ -1,0 +1,100 @@
+---
+id: using-palettes
+title: Abrufen von Paletten
+sidebar_label: Abrufen von Paletten
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Abrufen eines Palettenwertes
+
+<Video videoId="_bmk7JEPpQo" title="Palettes Playback" />
+
+### Abrufen von Tasten/Schaltflächen
+
+Zum Abrufen eines Wertes aus einer Palette gehen Sie wie folgt vor:
+
+1.	Wählen Sie die zu ändernden Geräte aus. Gemeinsam genutzte Paletten
+	stellen jedes Gerät gleichen Typs auf den gleichen Wert. Normale
+	Paletten liefern unterschiedliche Werte für jedes Gerät. Sind keine
+	Geräte angewählt, so wirkt die Palette auf alle Geräte, für die sie
+	Informationen enthält.
+2.  Betätigen Sie die Schaltfläche der gewünschten Palette. Die
+	angewählten Geräte werden auf die in der Palette gespeicherten Werte
+	gesetzt.
+
+-   Beim Abruf von Paletten lässt sich eine Überblendzeit einstellen,
+    siehe [Arbeiten mit Zeiten in Paletten](timing-with-palettes.md).
+
+-   Ist eine Palette gerade im Programmer, so wird die entsprechende
+    Schaltfläche als aktiv markiert (das lässt sich in den
+    [Benutzereinstellungen](../system-settings/user-settings.md#palettes)
+	mit **Highlight Active Palettes** deaktivieren). Damit ist einfach erkennbar, welche Paletten gerade
+	verwendet werden.
+
+    ![Active Palette Highlighted](/docs/images/Active-Palette-Highlighted.png)
+
+### Abrufen per Nummer/Syntax
+
+Paletten lassen sich auch über ihre Nummer abrufen: geben Sie dazu die
+Nummer mit den Zifferntasten ein.
+
+1.  Wählen Sie einige Geräte aus.
+2.  Drücken Sie die Taste <Keys.HardKey>Palette</Keys.HardKey> oberhalb der Zifferntasten.
+3.  Geben Sie die Nummer der gewünschten Palette ein.
+4.  Drücken Sie <Keys.HardKey>Enter</Keys.HardKey> oder <Keys.SoftKey>Apply Palette</Keys.SoftKey>
+
+Die Menütaste <Keys.SoftKey>Apply Palette</Keys.SoftKey> zeigt dabei die Bezeichnung der
+abzurufenden Palette.
+
+>   Sollen mehrere Paletten gleichzeitig abgerufen werden, so bietet
+sich die ‚Blind-To-Live' Funktion an: schalten Sie das Pult in den
+Blind-Modus (mit der <Keys.HardKey>Blind</Keys.HardKey>-Taste, oder mit <Keys.HardKey>Avo</Keys.HardKey> <Keys.SoftKey>Blind Inactive</Keys.SoftKey>, 
+wählen die gewünschten Paletten, geben die Fadezeit 
+(in Sekunden) ein (wenn geschaltet werden soll: 0 eingeben), und 
+schalten durch nochmaliges Drücken der <Keys.HardKey>Blind</Keys.HardKey>-Taste das Pult 
+in den Live-Modus. Damit wird auf die gewählten Paletten live 
+übergeblendet.
+
+## Palettenseiten
+
+Wurden Paletten auf den Tasten des Pultes gespeichert, so kann man 
+mit <Keys.HardKey>Page +</Keys.HardKey>/<Keys.HardKey>Page -</Keys.HardKey> 
+auf verschiedene Seiten wechseln. Soll eine Palette stets verfügbar sein und nicht 
+mit den Seiten umgeschaltet werden, so lässt sich die Seitenumschaltung sperren, 
+siehe [Handle Paging](../cues/playback-options.md#handle-paging) für weitere Details.
+
+In jedem der Palettenfenster lassen sich die Schaltflächen entweder
+seitenweise - mit Schaltflächen für die Seiten - oder als große Liste
+mit einem Schiebereiter organisieren. Zum Umschalten zwischen den beiden
+Optionen klicken Sie auf den Kontext-Button **Pages Show/Hide**.
+
+## Anzeige nur der relevanten Paletten
+
+Ist die [Benutzereinstellung](../system-settings/user-settings.md#palettes) 
+**Filter Relevant Palettes** aktiviert, so werden beim Anwählen von Geräten die Paletten, die auf 
+diese Geräte nicht anwendbar sind, ausgegraut. So sieht man auf einen 
+Blick, welche Paletten für die angewählten Geräte zur Verfügung stehen.
+
+## Quick Palettes -- Schnelle Paletten ohne ausgewählte Geräte
+
+Beim Aufruf einer Palette, ohne dass Geräte ausgewählt sind, wird die
+Palette auf alle in der Palette vorhandenen Geräte angewendet; diese
+Funktion nennt sich **Quick Palette**.
+
+Wird z.B. eine Farbpalette aufgerufen, die für MAC 2000 programmiert 
+wurde, ohne dass MAC 2000 angewählt sind, so wird die Palette auf 
+&nbsp;**alle** MAC 2000 angewendet.
+
+> Effekt-Paletten können nicht als Quick Palettes verwendet werden -
+für diese müssen stets Fixtures ausgewählt werden.
+
+## Abruf einer Palette für alle Geräte in einem Cue
+
+Sie können ebenso Paletten auf alle Geräte in einem bestimmten Cue
+anwenden. Dazu drücken und halten Sie die entsprechende
+Paletten-Schaltfläche, und betätigen dazu die Auswahltaste des Cues, auf
+den die Palette angewendet werden soll.
+
+Alternativ kann man die **Flash**-Taste des Playbacks gedrückt halten und klickt dazu auf die gewünschte Palette.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching.md
@@ -1,0 +1,33 @@
+---
+id: patching
+title: Patchen
+sidebar_label: Patchen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Patchen ist der Prozess, mit dem Pult mitgeteilt wird
+
+-   welche Geräte (Dimmer, Movinglights etc.) angeschlossen sind
+-   auf welche DMX-Adressen diese reagieren
+-   welches Gerät auf welcher DMX-Linie liegt; ein Pult kann selbst 16
+    DMX-Universen ausgeben, weitere - bis zu insgesamt 64 - sind mit
+    Prozessoren über TitanNet erzielbar.
+-   mit welchen Schaltflächen/Tasten auf welches Gerät zugegriffen
+    werden soll
+-   bestimmte weitere Optionen für die einzelnen Geräte
+
+> Es empfiehlt sich, den Lichtaufbau vor dem tatsächlichen Einbau der Geräte zu planen, um die DMX-Adressen vorher vergeben zu können. Am einfachsten patcht man zunächst die Geräte im Pult, und kann dann die vergebenen Adressen am Pult auslesen (im Patch View-Fenster, <Keys.HardKey>Open/View</Keys.HardKey>, <Keys.HardKey>Patch</Keys.HardKey>) und an den Geräten einstellen.
+
+Verfügen die Geräte über RDM, so kann das Pult diese automatisch
+erkennen und patchen, siehe [Patchen mit Hilfe von RDM](./patching/patching-new-fixtures-or-dimmers.md#patchen-mit-hilfe-von-rdm).
+
+Bei älteren Pulten mit einem Schalter 'System/Run/Program' muss dieser zum Patchen
+auf 'Program' stehen.
+
+In der Grundeinstellung ist den DMX-Buchsen jeweils eine DMX-Linie
+zugewiesen. Um die Zuordnung zu ändern, nehmen Sie die entsprechenden
+Einstellungen in den [DMX-Einstellungen](./system-settings/dmx-output-mapping.md) im System-Menü vor.
+
+> Wenn Ihre angeschlossenen Geräte in keiner Weise auf irgendwelche Pult-Aktionen reagieren, überprüfen Sie, ob die DMX-Ausgänge in den [DMX-Einstellungen](./system-settings/dmx-output-mapping.md#configuring-dmx-outputs) korrekt zugewiesen und aktiviert sind.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching.md
@@ -11,9 +11,7 @@ Patchen ist der Prozess, mit dem Pult mitgeteilt wird
 
 -   welche Geräte (Dimmer, Movinglights etc.) angeschlossen sind
 -   auf welche DMX-Adressen diese reagieren
--   welches Gerät auf welcher DMX-Linie liegt; ein Pult kann selbst 16
-    DMX-Universen ausgeben, weitere - bis zu insgesamt 64 - sind mit
-    Prozessoren über TitanNet erzielbar.
+-   welches Gerät auf welcher DMX-Linie/welchem Universum liegt
 -   mit welchen Schaltflächen/Tasten auf welches Gerät zugegriffen
     werden soll
 -   bestimmte weitere Optionen für die einzelnen Geräte
@@ -26,8 +24,7 @@ erkennen und patchen, siehe [Patchen mit Hilfe von RDM](./patching/patching-new-
 Bei älteren Pulten mit einem Schalter 'System/Run/Program' muss dieser zum Patchen
 auf 'Program' stehen.
 
-In der Grundeinstellung ist den DMX-Buchsen jeweils eine DMX-Linie
-zugewiesen. Um die Zuordnung zu ändern, nehmen Sie die entsprechenden
+Zu Beginn jede interne Linie einer DMX-Buchse zugewiesen (soviele verfügbar sind), ebenso wird jede Linie per sACN ausgegeben. Um die Zuordnung zu ändern, nehmen Sie die entsprechenden
 Einstellungen in den [DMX-Einstellungen](./system-settings/dmx-output-mapping.md) im System-Menü vor.
 
 > Wenn Ihre angeschlossenen Geräte in keiner Weise auf irgendwelche Pult-Aktionen reagieren, überprüfen Sie, ob die DMX-Ausgänge in den [DMX-Einstellungen](./system-settings/dmx-output-mapping.md#configuring-dmx-outputs) korrekt zugewiesen und aktiviert sind.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/changing-the-patch.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/changing-the-patch.md
@@ -1,0 +1,394 @@
+---
+id: changing-the-patch
+title: Das Patch ändern
+sidebar_label: Das Patch ändern
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Die Patch-Ansicht (Patch View)
+
+Mit der Patch-Ansicht hat man einen kompletten Überblick über die
+aktuelle gepatchten Geräte; ebenso kann man diese dort parken,
+umpatchen, invertieren, austauschen und bezeichnen. Müssen mehrere
+Geräte auf einmal geändert, etwa umadressiert, werden, so ist dies in
+der Patch-Ansicht besonders einfach zu realisieren.
+
+Zum Öffnen der Patch-Ansicht wählen Sie <Keys.HardKey>Open/View</Keys.HardKey>, dann <Keys.HardKey>Patch</Keys.HardKey>, oder drücken Sie zweimal auf <Keys.HardKey>Open/View</Keys.HardKey> und wählen das Fenster <Keys.SoftKey>Patch View</Keys.SoftKey>.
+
+![Patch View](/docs/images/Patch-View.png)
+
+In der Spalte **Fixture Type** sind die verschiedenen Gerätetypen
+aufgelistet; dabei hat jeder Typ eine andere Farbe. Beim Klick auf diese
+Buttons werden nur Geräte dieses Typs angezeigt.
+
+&nbsp;**Line:** die verfügbaren DMX-Linien. Die Balkenanzeige zeigt die
+Auslastung der einzelnen Linien an. Klickt man auf die jeweilige
+Schaltfläche, werden Details der Linien angezeigt.
+
+Der **farbige Balken** oben zeigt, wie die einzelnen Gerätetypen auf der
+aktuell ausgewählten Linie verteilt sind. Klickt man auf einen Bereich,
+so werden die betreffenden Geräte unten ausgewählt.
+
+In der **Tabelle** werden Details der ausgewählten Geräte angezeigt;
+einige Parameter sind direkt in der Tabelle durch Anklicken änderbar;
+weitere Möglichkeiten ergeben sich durch die Multifunktionstasten.
+
+> Es lassen sich für mehrere Geräte gleichzeitig Änderungen vornehmen, indem man in der Tabelle den entsprechenden Bereich auswählt, oder indem man auf einer optionalen Tastatur <Keys.HardKey>Strg</Keys.HardKey> gedrückt hält und die einzelnen Geräte anklickt. Nehmen Sie dann die Änderungen mit den Multifunktionstasten vor und drücken Sie den Button <Keys.SoftKey>Set</Keys.SoftKey> oder die <Keys.HardKey>Enter</Keys.HardKey>-Taste.
+
+-   Zur besseren Übersicht lassen sich einzelne Tabellenspalten
+    ausblenden. Dazu dient der Eintrag <Keys.SoftKey>Choose Columns</Keys.SoftKey> aus dem
+    Kontextmenü. Daraufhin lassen sich einzelne Spalten aus- und wieder
+    einblenden.
+
+-   Einzelnen Geräten lassen sich Notizen hinzufügen. Dazu klicken Sie
+    auf die Zelle 'Notes' und geben den Text mit der Tastatur ein.
+
+-   Die Reiter am oberen Rand schalten die Anzeige wie folgt um:
+    **Personality List** listet alle im Pult vorhandenen Personalities
+    auf; **RDM** erlaubt die Anzeige und das Patchen von Geräten via RDM;
+    **Attribute Behaviour** gestattet es, Attribute zu fixieren, zu
+    invertieren, zu limitieren oder die Kennlinie zu verändern. Weitere
+    Informationen dazu finden sich in [im nächsten Abschnitt](./changing-the-patch.md#anzeige-weiterer-patch-details).
+
+-   Mittels Kontext-Option können geparkte Geräte angezeigt oder
+    ausgeblendet werden. Werden diese angezeigt, so erscheinen sie
+    ausgegraut an der Stelle, an der sie ursprünglich eingefügt waren.
+
+## Anzeige weiterer Patch-Details
+
+Zur Anzeige der Details einzelner Geräte drücken Sie in der
+Patch-Ansicht in der Tabelle auf die betreffende <Keys.SoftKey>View</Keys.SoftKey>-Schaltfläche,
+oder drücken <Keys.HardKey>Open/View</Keys.HardKey>, gefolgt von der entsprechenden
+Geräte-Schaltfläche. Darauf öffnet sich ein weiteres Fenster und zeigt
+die Patch-Details des jeweiligen Gerätes. Hier lassen sich z.B. auch
+einzelne Attribute invertieren oder fixieren.
+
+![Fixture View](/docs/images/Fixture-View.png)
+
+Wenn die Geräte über DIP-Schalter adressiert werden, so zeigt dieses
+Fenster die entsprechende Schalterstellung im Reiter 'DIP-Switches'.
+
+![Dip Switches](/docs/images/Dip-Switches.png)
+
+Weiter gibt es einen Reiter 'Personality' (ohne Abb.); auf diesem werden
+Details der jeweiligen Personality angezeigt. Dies ist insbesondere
+hilfreich für Geräte, die in verschiedenen Versionen verfügbar sind oder
+gepatcht werden können.
+
+## Ändern der DMX-Adresse in der Patch-Ansicht
+
+Die Zuordnung eines Gerätes zu einer DMX-Adresse und/oder DMX-Linie kann
+in der Patch-Ansicht auf einfache Weise geändert werden. Wählen Sie dazu
+die Adress-Zellen, die Sie ändern möchten:
+
+![Change DMX Address](/docs/images/Change-DMX-Address.png)
+
+Geben Sie nun die neue Adresse des ersten ausgewählten Gerätes ein und
+drücken <Keys.HardKey>Enter</Keys.HardKey>. (Verwenden Sie bei der Eingabe das Format
+Universum.Adresse - lassen Sie Universum und den Punkt weg, so wird nur
+die Adresse geändert).
+
+Alle angewählten Geräte werden daraufhin entsprechen umadressiert, wobei
+der jeweilige Offset (also etwaige Lücken zwischen den Adressen)
+erhalten bleibt.
+
+Mit der Kontext-Funktion <Keys.SoftKey>Swap Fixture Addresses</Keys.SoftKey> können die Adressen
+mit denen bereits gepatchter Geräte vertauscht werden, wobei zwischen
+den Modes <Keys.SoftKey>One for One</Keys.SoftKey> (1:1) und <Keys.SoftKey>Retain Layout</Keys.SoftKey> (Layout erhalten)
+gewählt werden kann. Wählen Sie wie gehabt die zu ändernden Geräte,
+klicken auf <Keys.SoftKey>Swap Fixture Addresses</Keys.SoftKey> und wählen die Geräte, mit denen
+getauscht werden soll.\
+Im Modus <Keys.SoftKey>One to One</Keys.SoftKey> (1:1) muss die Anzahl der zu tauschenden Geräte
+mit der Anzahl der Ziel-Geräte übereinstimmen, ansonsten wird eine
+Fehlermeldung ausgegeben. Im Modus <Keys.SoftKey>Retain Layout</Keys.SoftKey> (Layout erhalten)
+versucht die Software, durch automatisches Hinzufügen/Weglassen von
+Geräten die Anzahlen anzupassen. Funktioniert dies nicht, kann man mit
+<Keys.SoftKey>Cancel</Keys.SoftKey> abbrechen oder mit <Keys.SoftKey>Park Conflicting</Keys.SoftKey> die Geräte, die
+momentan 'im Weg' sind, parken.
+
+## Ändern der DMX-Adresse im Patch-Menü
+
+Die Zuordnung eines Gerätes zu einer DMX-Adresse und/oder DMX-Linie kann
+auch im Patch-Menü geändert werden, wobei die Programmierung erhalten
+bleibt.
+
+1. Drücken Sie <Keys.HardKey>Patch</Keys.HardKey> (wenn Sie sich nicht ohnehin im Patch-Modus
+befinden).
+2. Drücken Sie <Keys.SoftKey>Repatch Fixtures</Keys.SoftKey>.
+3. Betätigen Sie die Schaltfläche des zu ändernden Gerätes.
+4. Zum Ändern der DMX-Adresse drücken Sie <Keys.SoftKey>Address</Keys.SoftKey>, geben mit den
+Ziffern­tasten die neue Adresse ein, und drücken <Keys.HardKey>Enter</Keys.HardKey>. Falls die
+neue Adresse bereits anderweitig verwendet wird, wird eine Warnung
+angezeigt. <br/>
+ ![Address softkey](/docs/images/Address-softkey.png)
+5. Zum Ändern der DMX-Linie drücken Sie <Keys.SoftKey>DMX Line=x</Keys.SoftKey> und geben die
+Zahl der neuen DMX-Linie ein.
+6. Drücken Sie <Keys.HardKey>Enter</Keys.HardKey> oder <Keys.SoftKey>Repatch</Keys.SoftKey>, um die Änderungen zu
+bestätigen.
+7. Wiederholen Sie den Vorgang ab Schritt 3, um weitere Geräte zu
+ändern.
+
+-   Sie können auch Geräte 'parken' (mit der Funktion <Keys.SoftKey>Park</Keys.SoftKey>). Damit
+    wird das Gerät aus dem Patch entfernt, aber die Programmierung
+    bleibt erhalten. Die ursprüngliche DMX-Linie und --Adresse werden
+    gespeichert und können mit <Keys.SoftKey>Unpark</Keys.SoftKey> wiederhergestellt werden.
+
+-   Wenn die neue DMX-Adresse bereits anderweitig in Verwendung ist,
+    gibt das Pult eine Warnung aus (sofern das nicht in den
+    [Benutzereinstellungen](../system-settings/user-settings.md) 
+	deaktiviert ist,). Sie können dann entweder <Keys.SoftKey>Select another DMX address</Keys.SoftKey>
+    (eine andere DMX-Adresse auswählen) anwählen, um den Vorgang
+    abzubrechen, oder mit <Keys.SoftKey>Park Conflicting Fixtures</Keys.SoftKey> das Gerät zur
+    späteren Änderung parken. Damit bleibt die existierende
+    Programmierung erhalten, aber das Gerät muss zur weiteren Verwendung
+    auf eine freie DMX-Adresse gepatcht werden (siehe oben). 
+	
+	Mit der
+    Auswahl <Keys.SoftKey>Always Park Conflicting Fixtures</Keys.SoftKey> werden sämtliche Geräte
+    mit bereits belegten DMX-Adressen automatisch geparkt, ohne eine
+    Warnung auszugeben (kann in den Benutzereinstellungen geändert
+    werden).
+
+![Fixture Conflict](/docs/images/Fixture-Conflict.png)
+
+## Legenden/Bezeichnungen eingeben
+
+Jedes gepatchte Gerät lässt sich mit einer Bezeichnung versehen, die auf
+der entsprechenden Geräte-Auswahltaste angezeigt wird, um das Gerät
+später identifizieren zu können.
+
+1.  Drücken Sie die Taste <Keys.HardKey>Legend</Keys.HardKey> (nur auf dem D9/D7) oder klicken 
+Sie im Hauptmenü <Keys.SoftKey>Set Legend</Keys.SoftKey>.
+2.  Betätigen Sie die Auswahltaste des Gerätes, für das Sie eine
+Legende vergeben wollen.
+3.  Geben Sie die Legende mit der (Bildschirm-)Tastatur ein.
+4.  Klicken Sie <Keys.HardKey>Enter</Keys.HardKey>, um die Eingabe abzuschließen.
+
+-   Es lässt sich auch eine Zeichnung oder ein Bild als Gerätelegende
+    wählen.
+
+-   Mehrere Geräte lassen sich mit der gleichen Bezeichnung versehen;
+    dazu wählen Sie nach der Betätigung von <Keys.SoftKey>Set Legend</Keys.SoftKey> einfach
+    mehrere Geräte aus.
+
+-   Die Gerätenummer lässt sich im Menü <Keys.SoftKey>Set Legend</Keys.SoftKey> (Legende
+    eingeben) mit der Menütaste <Keys.SoftKey>User Number =...</Keys.SoftKey> ändern.
+    Insbesondere bei der Verwendung der numerischen Geräteauswahl ist es
+    sinnvoll, die Gerätenummern systematisch zu vergeben.
+
+-   Mehreren ausgewählten Geräten lassen sich automatisch Gerätenummern
+    (User Numbers) zuordnen, indem man alle Geräte auswählt und mit dem
+    o.g. Menü eine Nummer eingibt. Dem ersten Gerät der Gruppe wird die
+    eingegebene Nummer zugeordnet, und alle weiteren fortlaufend werden
+    nummeriert.
+
+-   Ebenso lässt sich eine Bezeichnung für die aktuelle Seite im
+    Geräte-Auswahlfenster vergeben. Dazu wählen Sie <Keys.SoftKey>Set Legend</Keys.SoftKey> aus
+    dem Hauptmenü, dann <Keys.SoftKey>Page Legends</Keys.SoftKey>, dann die zu ändernde Seite 
+	(wenn die Seiten nicht angezeigt werden, können Sie das im Kontextmenü
+	durch einen Klick auf <Keys.SoftKey>Pages Hide</Keys.SoftKey> aktivieren). Die vergebene 
+	Bezeichnung wird auf der Auswahltaste für die Seite sowie im HUD 
+	angezeigt.
+
+## Halo für Fixture-Buttons
+
+Für Fixture-Buttons (Geräte-Schaltflächen) kann ein Halo, also ein 
+farbiger Rand, eingerichtet werden, um diese noch übersichtlicher 
+darzustellen. Als Vorgabewert kann man den Halo manuell einstellen. 
+Alternativ kann der Halo automatisch die Farbe annehmen, die im 
+Patch-Fenster verwendet wird.
+
+Um den Halo manuell einzustellen, drücken Sie die Taste <Keys.HardKey>Legend</Keys.HardKey> (nur 
+auf dem D9) bzw. klicken Sie auf <Keys.SoftKey>Set Legend</Keys.SoftKey>, wählen
+das/die Fixture(s) aus und klicken auf die Option <Keys.SoftKey>Halo</Keys.SoftKey>. Darauf
+öffnet sich ein Colourpicker, um die Farbe auszuwählen. Mittels <Keys.SoftKey>System Colours</Keys.SoftKey> 
+hat man Zugriff auf vordefinierte Farben, und mit <Keys.SoftKey>Remove Halo</Keys.SoftKey> lässt sich der farbige Rand wieder entfernen.
+
+![Fixture Halo](/docs/images/Fixture-Halo.png)
+
+Zum Aktivieren der automatischen Halo-Farben halten Sie die
+<Keys.HardKey>Avo</Keys.HardKey>-Taste gedrückt und wählen <Keys.SoftKey>User Settings</Keys.SoftKey> (Benutzereinst.),
+dann <Keys.SoftKey>Handles</Keys.SoftKey>, und ändern schließlich die Einstellung für
+Fixture-Halos (Geräte-Halos) auf <Keys.SoftKey>Auto</Keys.SoftKey>. Daraufhin wird automatisch
+der Halo in der gleichen Farbe dargestellt, die auch im Fixtures-Fenster
+verwendet wird.
+
+Diese Geräte-Halos werden auch in der Intensity-Ansicht und in der
+Show-Library verwendet. In Listen-Ansichten wie dem DMX-Fenster, dem
+Channel Grid, der Cue- oder der Paletten-Ansicht werden diese Farben für
+die Filter links im Fenster verwendet. Ist eine Farbe manuell definiert,
+wird diese dargestellt, anderenfalls die automatische. Die o.g.
+Benutzereinstellung ist für diese Listendarstellung ohne Belang.
+
+![Cue View](/docs/images/Cue-View.png)
+
+## Das Fenster 'DMX View'
+
+Insbesondere zur Fehlersuche empfiehlt es sich, die tatsächlich vom Pult
+gesendeten DMX-Werte zu überprüfen. Dazu gibt es ein gesondertes
+Fenster: drücken Sie zweimal auf 
+[<Keys.HardKey>open/View</Keys.HardKey>](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster) 
+und wählen <Keys.SoftKey>DMX</Keys.SoftKey>.
+
+![DMX Workspace Window](/docs/images/DMX-Workspace-Window-With-Filters.png)
+
+Mit den Schaltflächen in der linken Spalte lässt sich die Anzeige nach 
+Attributen und Gerätetypen filtern sowie das anzuzeigende
+DMX-Universum wählen. Durch Scrollen nach rechts lassen sich weitere
+Informationen pro Kanal anzeigen.
+
+## Geräte austauschen
+
+<Video videoId="a_ES6UYQRJ4" title="Advanced Patching" />
+
+Die Funktion 'Fixture Exchange' (Geräteaustausch) erlaubt es, in einer
+bestehenden Show Geräte mit anderen Modellen zu ersetzen und dabei
+wesentliche Elemente der Programmierung (z.B. Zeiten, Bewegungsabläufe
+und Legenden) zu erhalten. Dies ist zweckmäßig etwa auf Tourneen oder
+in Hallen mit häufig wechselnden Veranstaltungen.
+
+Der Austausch von Geräten funktioniert am besten, wenn die
+Programmierung über Paletten erfolgte. Damit müssen verbleibende
+kleinere Abweichungen nur in ein paar wenigen Paletten, statt in einer
+Vielzahl von einzelnen Cues vorgenommen werden. Cues mit absoluten
+Werten dagegen müssen neu programmiert werden, vorzugsweise unter
+Verwendung von Paletten.
+
+Die Kanäle Pan, Tilt und Dimmer werden immer von einem Gerät auf das
+andere übernommen. Für andere Attribute versucht das Pult, eine
+sinnvolle Zuordnung zu erreichen, die per Exchange Mapping (siehe
+[nächster Abschnitt](./changing-the-patch.md#exchange-mapping))
+editiert werden kann. Alle anderen programmierten Dinge - Zeiten,
+Effekte, Paletten etc. - werden übernommen, so dass man mittels
+Aktualisieren der Paletten schnell die Show anpassen kann.
+
+Der Geräteaustausch eröffnet ferner einen interessanten Weg, neue Geräte
+in bereits bestehenden Shows zu verwenden, was zu einer nicht
+unerheblichen Zeitersparnis führen kann.
+
+-   Es empfiehlt sich eine Sicherung der Show vor größeren Änderungen
+    (wie dem Geräteaustausch). Sollte man sich doch anders entscheiden,
+    oder kommt es zu Problemen, so lassen sich mit einer Sicherung alle
+    Änderungen rückgängig machen.
+
+1.  Drücken Sie <Keys.HardKey>Patch</Keys.HardKey>, um in den Patch-Modus zu gelangen.
+2.  Wählen Sie das neue Gerät aus, das Sie verwenden möchten.
+3.  Betätigen Sie die Auswahltaste des Gerätes, welches ersetzt
+    werden soll.
+4.  Das Pult zeigt eine Warnung, dass das Gerät in Gebrauch ist.
+    Wählen Sie die Option <Keys.SoftKey>Exchange Fixture</Keys.SoftKey>.
+5.  Wiederholen Sie die Schritte 3 und 4 für weitere Geräte, die Sie
+    mit dem ausgewählten Typ ersetzen möchten.
+
+> Nach dem Austausch von Geräten müssen die von diesen verwendeten Paletten aktualisiert werden. Ist das Deaktivieren einzelner Werte in der Palette nicht möglich, empfiehlt es sich, aktuelle Werte für alle Attribute der betreffenden Attribut-Gruppe einzustellen und die Palette neu abzuspeichern. Nun können einzelne Attribut-Gruppen deaktiviert werden.
+
+## Exchange Mapping
+
+Werden Geräte ausgetauscht, so werden durch das Pult die Funktionen der
+alten Geräte auf die der neuen Geräte soweit wie möglich abgebildet, um
+möglichst das gleiche Ergebnis zu erzielen.
+
+Dennoch ist es möglich, dass das nicht perfekt funktioniert. In diesem
+Fall ist es möglich, mit Exchange Mapping die Zuordnung zwischen alten
+und neuen Funktionsbereichen zu bearbeiten. So lassen sich z.B. Gobos
+der alten Geräte durch Gobos der neuen Geräte ersetzen, auch wenn das
+gewünschte Gobo auf einer anderen Position des Goborades sitzt. Ebenso
+lässt sich z.B. die Geschwindigkeit der Goborotation so anpassen, dass
+die bisherigen Cues weitestgehend identisch funktionieren.
+
+Alle Änderungen wirken sofort auf die Show. Diese Mappings werden
+gespeichert und können auch künftig verwendet werden. Natürlich kann man
+mit dem Button <Keys.SoftKey>Clear All Mappings</Keys.SoftKey> auch wieder zu den
+Werkseinstellungen zurückkehren.
+
+![Exchange Mapping](/docs/images/Exchange-Mapping.png)
+
+Das Mapping wird wie folgt eingerichtet:
+
+1.  Drücken Sie <Keys.HardKey>Open/View</Keys.HardKey>, dann <Keys.HardKey>Patch</Keys.HardKey>, um die
+    Patch-Ansicht zu öffnen.
+2.  Wählen Sie den Reiter „Exchange Mapping".
+3.  In der ganz linken Spalte wählen Sie den zu bearbeitenden Gerätetyp.
+4.  Im Hauptfenster befinden sich nun links die Funktionen und Attribute
+	der alten und rechts die der neuen Geräte. Mit der Option <Keys.SoftKey>Sort</Keys.SoftKey> lässt
+	sich die Sortierung zwischen alphabetisch und nach DMX-Kanal umschalten.
+5.  Wählen Sie ein Attribut aus, um dessen Mapping zu bearbeiten. Das
+	gewählte Attribut wird nun bei beiden Geräten hellblau markiert. Braun
+	markierte Einträge sind gar nicht zugeordnet, etwa weil das andere Gerät
+	eine entsprechende Funktion nicht hat. In der Fenstermitte werden die
+	jeweils vorhandenen Attributfunktionen angezeigt, farbige Linien zeigen
+	die vorhandene Zuordnung.
+6.  Um eine Funktion neu zu mappen/zuzuweisen, klicken Sie auf die
+	entsprechende Funktion des alten Gerätes, dann auf die gewünschte
+	Funktion des neuen Geräts. Vorherige Zuweisungen werden dabei gelöscht.
+	Es lassen sich mehrere alte einer einzigen neuen Funktion zuweisen.
+7.  Um eine Zuweisung zu löschen, doppelklicken Sie (links) auf die
+	Funktion des alten Gerätes. Bestehen mehrere Zuweisungen, so
+	doppelklicken Sie (rechts) auf die Funktion des neuen Geräts.
+8.  Um eine Zuweisung zu ändern, klicken Sie (rechts) auf die bisher
+	zugeordnete Funktion des neuen Geräts, dann (rechts) auf die neu
+	gewünschte Funktion.
+
+-   Wurden mehrere alte Gerätetypen durch den gleichen neuen Typ
+    ersetzt, so können Sie ganz links in der Spalte 'Exchanged From'
+    nach Originaltyp umschalten.
+
+-   Wird das Mapping geändert, so erscheint am unteren Bildschirmrand
+    die Anzeige 'Unsaved Changes' (ungesicherte Änderungen). Hier können
+    Sie mit <Keys.SoftKey>Apply</Keys.SoftKey> die Änderungen speichern und übernehmen, 
+    mit <Keys.SoftKey>Cancel</Keys.SoftKey> die Bearbeitung abbrechen oder 
+    mit <Keys.SoftKey>Reset</Keys.SoftKey> die Werkseinstellungen wiederherstellen. Alle 
+    diese Befehle müssen mit <Keys.SoftKey>Confirm</Keys.SoftKey> bestätigt werden.
+
+![Exchange Mapping with range mapping](/docs/images/Exchange-Mapping-Range-Mapping.png)
+
+### Range mapping -- Zuweisen von Bereichen
+
+Umfasst die neue Funktion einen ganzen Bereich, z.B. 0...100%, so lässt
+sich ein bestimmter Bereich daraus auswählen, auf den das Mapping
+erfolgen soll.
+
+Sind mehrere Funktionen des alten Gerätes auf einen neuen Bereich
+zugewiesen, so werden dort mehrere 'Ziel'-Schaltflächen eingeblendet, so
+dass man für jede Ausgangsfunktion den Zielbereich einzeln festlegen
+kann.
+
+Um diese Festlegung zu treffen, wählen Sie zunächst den entsprechenden
+Ziel-Bereich. Klicken Sie dann unten auf <Keys.SoftKey>Edit Ranges</Keys.SoftKey> und wählen die
+Funktion aus, die Sie bearbeiten möchten. (Es lassen sich nur bereits
+erfolgte Zuweisungen bearbeiten; nicht gemappte Funktionen werden
+ausgegraut dargestellt). Es lassen sich nun die Unter- und Obergrenzen
+des Ziel-Bereiches mit den Encodern, mit den Rad-Schaltflächen oder -
+numerisch - mit den entsprechenden Funktionstasten einstellen.
+
+Sind die gewünschten Einstellungen erfolgt, so klicken Sie auf <Keys.SoftKey>Apply</Keys.SoftKey>, 
+dann auf <Keys.SoftKey>Confirm</Keys.SoftKey>. Mit <Keys.SoftKey>Cancel</Keys.SoftKey> 
+und <Keys.SoftKey>Confirm</Keys.SoftKey> dagegen werden die Änderungen verworfen.
+
+## Bereits gepatchte Personalities aktualisieren
+
+Mit dieser Funktion lassen sich die Personalities der in der Show
+verwendeten Geräte aktualisieren. Normalerweise sind Kopien der
+Personalities mit in der Show-Datei gespeichert, so dass beim
+[Aktualisieren der Personality-Bibliothek des Pultes](../fixture-personalities.md#aktualisieren-des-personality-speichers-des-pultes) bereits gepatchte
+Geräte nicht verändert werden.
+
+-   Es empfiehlt sich, vor dem Aktualisieren der Personalities eine 
+	Sicherung der Show vorzunehmen. Sollte man sich doch anders
+    entscheiden, oder es kommt zu Problemen, so lassen sich mit einer
+    Sicherung alle Änderungen rückgängig machen.
+
+1.  Installieren Sie die neueste Personality-Library auf dem Pult bzw. dem Computer (siehe 
+[Aktualisieren der Personality-Bibliothek des Pultes](../fixture-personalities.md#aktualisieren-des-personality-speichers-des-pultes))
+2.  Drücken Sie <Keys.HardKey>Patch</Keys.HardKey>, um in den Patch-Modus zu gelangen.
+3.  Drücken Sie <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>.
+4.  Drücken Sie <Keys.SoftKey>Update Personality</Keys.SoftKey>. 
+5.  Titan zeigt alle Gerätetypen, die in der Show gespeichert sind 
+    und für die Updates in der installierten Gerätebibliothek vorliegen.
+	Wählen Sie den oder die Typen, die Sie aktualisieren wollen, oder 
+	klicken Sie auf <Keys.SoftKey>Update All</Keys.SoftKey>, um alle Gerätetypen zu aktualisieren.
+
+-   Sollen viele Geräte aktualisiert/geupdatet werden, so kann das eventuell
+    einige Sekunden dauern.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/changing-the-patch.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/changing-the-patch.md
@@ -241,7 +241,7 @@ Attributen und Gerätetypen filtern sowie das anzuzeigende
 DMX-Universum wählen. Durch Scrollen nach rechts lassen sich weitere
 Informationen pro Kanal anzeigen.
 
-in der Spalte **Input** werden Werte angezeigt, die am Eingang anliegen (siehe [$$$Using DMX/sACN Input](/controlling-fixtures/changing-fixture-attributes.md#using-dmxsacn-input)). 
+in der Spalte **Input** werden Werte angezeigt, die am Eingang anliegen (siehe [Verwenden von DMX/sACN-Eingang](/controlling-fixtures/changing-fixture-attributes.md#verwenden-von-dmxsacn-eingang)). 
 Diese Spalte kann mit dem Button <Keys.ContextKey>Input Data</Keys.ContextKey> im Kontextmenü ein- und ausgeblendet werden.
 
 ## Geräte austauschen

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/changing-the-patch.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/changing-the-patch.md
@@ -25,7 +25,8 @@ Buttons werden nur Geräte dieses Typs angezeigt.
 
 &nbsp;**Line:** die verfügbaren DMX-Linien. Die Balkenanzeige zeigt die
 Auslastung der einzelnen Linien an. Klickt man auf die jeweilige
-Schaltfläche, werden Details der Linien angezeigt.
+Schaltfläche, werden Details der Linien angezeigt. (Es werden nur Linien angezeigt, 
+auf denen tatsächlich Geräte gepatcht sind).
 
 Der **farbige Balken** oben zeigt, wie die einzelnen Gerätetypen auf der
 aktuell ausgewählten Linie verteilt sind. Klickt man auf einen Bereich,
@@ -133,7 +134,8 @@ bestätigen.
 -   Sie können auch Geräte 'parken' (mit der Funktion <Keys.SoftKey>Park</Keys.SoftKey>). Damit
     wird das Gerät aus dem Patch entfernt, aber die Programmierung
     bleibt erhalten. Die ursprüngliche DMX-Linie und --Adresse werden
-    gespeichert und können mit <Keys.SoftKey>Unpark</Keys.SoftKey> wiederhergestellt werden.
+    gespeichert und können mit <Keys.SoftKey>Unpark</Keys.SoftKey> wiederhergestellt werden. (Um 
+	dagegen Geräte auf einem bestimmten Wert zu fixieren, nutzen Sie [Freeze](fixture-personality-options.md?#geräte-oder-attribute-fixieren-freeze)).
 
 -   Wenn die neue DMX-Adresse bereits anderweitig in Verwendung ist,
     gibt das Pult eine Warnung aus (sofern das nicht in den
@@ -238,6 +240,9 @@ Mit den Schaltflächen in der linken Spalte lässt sich die Anzeige nach
 Attributen und Gerätetypen filtern sowie das anzuzeigende
 DMX-Universum wählen. Durch Scrollen nach rechts lassen sich weitere
 Informationen pro Kanal anzeigen.
+
+in der Spalte **Input** werden Werte angezeigt, die am Eingang anliegen (siehe [$$$Using DMX/sACN Input](/controlling-fixtures/changing-fixture-attributes.md#using-dmxsacn-input)). 
+Diese Spalte kann mit dem Button <Keys.ContextKey>Input Data</Keys.ContextKey> im Kontextmenü ein- und ausgeblendet werden.
 
 ## Geräte austauschen
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/copying-moving-and-deleting-fixtures.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/copying-moving-and-deleting-fixtures.md
@@ -1,0 +1,73 @@
+---
+id: copying-moving-and-deleting-fixtures
+title: Kopieren, Verschieben und Löschen
+sidebar_label: Kopieren, Verschieben und Löschen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Kopieren oder Verschieben eines gepatchten Gerätes
+
+Mit den Taste <Keys.HardKey>Copy</Keys.HardKey> sowie <Keys.HardKey>Move</Keys.HardKey> lässt sich ein existierendes Gerät 
+kopieren oder auf eine andere Auswahltaste verschieben. Verknüpfungen 
+(Link) lassen sich für Geräte nicht erstellen. Mehrere Geräte lassen 
+sich in einem Schritt gemeinsam kopieren/verschieben.
+
+Fixtures kann man kopieren, wenn man die Show um weitere Geräte des
+gleichen Typs bereits gepatchter und programmierter Geräte erweitern
+muss. Dabei übernehmen die kopierten Fixtures sämtliche Eigenschaften
+und Programmierungen der bereits vorhandenen Geräte, haben bereits alle
+Paletten und sind in allen Cues. Die kopierten Geräte haben noch keine
+DMX-Adresse zugewiesen, sind also 'Geparkt'. Zum Zuweisen der Adresse 
+siehe [Das Patch ändern](./changing-the-patch.md).
+
+Das Verschieben ist sinnvoll, um eine übersichtliche Arbeitsoberfläche
+zu erhalten.
+
+1.  Betätigen Sie die Taste <Keys.HardKey>Copy</Keys.HardKey> zum Kopieren bzw. <Keys.HardKey>Move</Keys.HardKey> zum 
+    Verschieben (auf Pulten ohne eine **Move**-Taste dient <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Copy</Keys.HardKey> zum Verschieben).
+2.  Drücken Sie die Auswahltaste/Schaltfläche des zu kopierenden/
+	verschiebenden Gerätes. Es können auch mehrere auf einmal ausgewählt
+	werden, ggf. auch mit der Taste <Keys.HardKey>And</Keys.HardKey>.
+3.  Betätigen Sie eine freie Auswahltaste, auf die das Gerät
+	kopiert/verschoben werden soll.
+
+-   Die Taste <Keys.HardKey>Menu Latch</Keys.HardKey> fixiert das Menü 'Copy' bzw. 'Move', so 
+	dass man mit dem Kopieren/Verschieben fortfahren kann, ohne ständig 
+	die Taste <Keys.HardKey>Copy</Keys.HardKey> bzw. <Keys.HardKey>Move</Keys.HardKey> betätigen zu müssen. Zum Freigeben 
+	des Menüs einfach die Taste <Keys.HardKey>Menu Latch</Keys.HardKey> nochmal betätigen.
+
+-   Die Optionen <Keys.SoftKey>Retain Layout</Keys.SoftKey>(Darstellung erhalten) 
+    bzw. <Keys.SoftKey>Bunch Up</Keys.SoftKey>(Zusammenfassen) sind sinnvoll beim Kopieren einer Gruppe von
+    Geräten mit darin enthaltenen freien Auswahltasten: diese werden
+    entweder (zur Erhaltung der Darstellung) mit übernommen, oder aber
+    entfernt (und alle Geräte ohne Lücke zusammengefügt). Falls Sie nur
+    einzelne Geräte aktualisieren wollen, wählen Sie die zu
+    aktualisierende Personality aus.
+
+-   Während des Kopierens lässt sich einstellen, ob mit <Keys.SoftKey>Copy Legends</Keys.SoftKey>
+    die Bezeichnungen mit kopiert werden sollen, oder aber mit <Keys.SoftKey>Don't copy legends</Keys.SoftKey> 
+    den Geräten automatisch Standard-Bezeichner zugewiesen werden sollen.
+
+-   Im Verschieben-Modus dient die Option <Keys.SoftKey>Swap Items if Required</Keys.SoftKey> zum
+    automatischen Verlagern der Geräte, die beim Verschieben im Weg
+    sind. Dies ist hilfreich beim Verschieben von Geräten auf einer
+    nahezu vollen Seite.
+
+## Löschen eines gepatchten Gerätes
+
+Ein gepatchtes Gerät (oder Dimmer) lässt sich löschen, wenn etwa
+versehentlich ein falsches Gerät gepatcht wurde, sich die
+Bühnensituation verändert hat oder die betreffende Taste anderweitig
+benötigt wird.
+
+> Beim Löschen gehen sämtliche Programmierungen für das Gerät verloren. Das Löschen lässt sich auch nicht durch erneutes Patchen eines Gerätes auf dieselbe Auswahltaste rückgängig machen. Für den Fall, dass die Geräte später doch wieder gebraucht werden sollten, empfiehlt es sich, sie nicht zu löschen, sondern auf eine freie Geräte-Seite zu verschieben. 
+
+1.  Drücken Sie <Keys.HardKey>Patch</Keys.HardKey>, um in den Patch-Modus zu gelangen.
+2.  Drücken Sie die Taste <Keys.HardKey>Delete</Keys.HardKey>.
+3.  Betätigen Sie die Auswahltaste des zu löschenden Gerätes.
+4.  Die Auswahltaste (wenn es ein Button auf dem Bildschirm ist) wird rot hervorgehoben, und ein Bestätigungsdialog
+	erscheint. Betätigen Sie die Auswahltaste zur Bestätigung nochmals.
+
+-   Es lassen sich auch mehrere Geräte in einem Arbeitsgang löschen.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/fixture-personality-options.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/fixture-personality-options.md
@@ -1,0 +1,217 @@
+---
+id: fixture-personality-options
+title: Erweiterte Funktionen
+sidebar_label: Erweiterte Funktionen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Titan benutzt ein System von 'Personalities', gerätespezifische Dateien,
+welche notwendige Informationen enthalten, wie welches Movinglight 
+gesteuert werden muss. Avolites hat für eine Vielzahl von Movinglights 
+solche Dateien erstellt. Bei ganz neuen Geräten kann es aber erforderlich 
+sein, eine neue Personality zu erstellen. Siehe [Personalities](../fixture-personalities.md) für weitere Details dazu.
+
+Zusätzlich gibt es etliche Optionen, mit denen genau gesteuert werden kann,
+wie ein Movinglight reagiert. Die nachfolgend aufgeführten Einstellungen 
+lassen sich auch in der Patch-Ansicht vornehmen.
+
+## Pan und Tilt vertauschen
+
+Damit wird die Zuordnung der Steuerelemente für Pan und Tilt vertauscht.
+Dies ist etwa sinnvoll bei spiegelbewegten Geräten, die seitwärts
+ausgerichtet sind.
+
+1.  Drücken Sie <Keys.HardKey>Patch</Keys.HardKey>.
+2.  Drücken Sie <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>.
+3.  Betätigen Sie <Keys.SoftKey>Swap Pan and Tilt</Keys.SoftKey>.
+4.  Wählen Sie die Geräte aus, bei denen Pan und Tilt vertauscht werden
+soll. Drücken Sie <Keys.SoftKey>Pan and Tilt ...</Keys.SoftKey>, um für die angewählten Geräte
+zwischen <Keys.SoftKey>Swapped</Keys.SoftKey> (vertauscht) und <Keys.SoftKey>Normal</Keys.SoftKey> umzuschalten.
+5.  Drücken Sie <Keys.HardKey>Exit</Keys.HardKey>, um das Menü zu verlassen.
+
+## Attribute invertieren
+
+Mit dieser Option lassen sich einzelne Attribute ausgewählter Geräte
+invertieren. Das ist hilfreich z.B. wenn ein Gerät nach rechts läuft,
+während alle anderen nach links laufen. Damit spart man sich mindestens
+einen Weg auf die Truss, nur um die Einstellung am Gerät selbst zu
+korrigieren.
+
+1.  Drücken Sie <Keys.HardKey>Patch</Keys.HardKey>.
+2.  Drücken Sie <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>.
+3.  Drücken Sie <Keys.SoftKey>Invert Attribute</Keys.SoftKey>.
+4.  Wählen Sie die zu ändernden Geräte.
+5.  Wählen Sie das zu invertierende Attribut von den
+	Menütasten. Im Display wird mit <Keys.SoftKey>Inverted</Keys.SoftKey> angezeigt, wenn
+	ein Attribut invertiert ist.
+6.  Klicken Sie <Keys.HardKey>Exit</Keys.HardKey>, um den Vorgang abzuschließen.
+
+![Tilt Inverted](/docs/images/Tilt-Inverted.png)
+
+
+-   Es lassen sich bei mehreren Geräten gleichzeitig Attribute
+    invertieren, indem man mehrere Geräte anwählt. Allerdings zeigt in
+    diesem Fall das Display nicht an, ob in der Auswahl manche Geräte
+    bereits invertiert sind und andere nicht.
+
+-   Einige Attribute können nicht invertiert werden.
+
+-   Attribute können auch im Attribute Behaviour-Reiter der
+    Patch-Ansicht invertiert werden.
+
+## Attribute limitieren
+
+Für jedes Attribut lassen sich sowohl obere als auch untere Limits
+setzen. Damit kann etwa die Pan/Tilt-Bewegung begrenzt werden, oder bei
+Geräten mit Dimmer und Shutter auf einem Kanal kann der Shutterbereich
+gesperrt werden.
+
+Limits für Attribute können entweder über das Menü <Keys.HardKey>Patch</Keys.HardKey>, <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>, 
+oder über den Reiter 'Attribute Behaviour' im Patch View gesetzt werden.
+
+1.  Drücken Sie die Taste <Keys.HardKey>Patch</Keys.HardKey>.
+2.  Drücken Sie <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>.
+3.  Wählen Sie <Keys.SoftKey>Set Limits</Keys.SoftKey>.
+4.  Wählen Sie das/die gewünschte(n) Gerät(e) aus.
+5.  Wählen Sie über die Menütasten die zu ändernden Attribute sowie,
+    ob das obere (upper) oder das untere (lower) Limit gesetzt werden soll.
+6.  Geben Sie den gewünschten Wert in Prozent ein, oder wählen Sie <Keys.SoftKey>Set To Current Value</Keys.SoftKey>, 
+    um den momentanen Wert zu übernehmen. Mit <Keys.SoftKey>Remove Limit</Keys.SoftKey> wird das Limit gelöscht.
+7.  Beenden Sie den Vorgang mit <Keys.HardKey>Exit</Keys.HardKey>.
+
+Im Reiter 'Attribute Behaviour' der Patch-Ansicht setzen Sie Limits mit
+Hilfe der entsprechenden Kontext-Schaltflächen.
+
+Auch bei gesetzten Limits können Werte außerhalb derselben in den
+Programmierspeicher geschrieben werden; dies wird oberhalb des
+jeweiligen Rades mit dem Symbol "limited" angezeigt.
+
+![limited](/docs/images/Limited-Dimmer.png)
+
+## Fixture Offset -- Geräte-Offset
+
+Für jedes Attribut jedes Gerätes lässt sich ein Offset einstellen.
+Insbesondere ist das sinnvoll, um Positionen (Pan/Tilt) anzupassen, wenn
+Geräte anders hängen, als in der Programmierung vorgesehen. Das Offset
+wird unmittelbar vor der DMX-Signalausgabe angewandt, beeinflusst dann
+also sämtliche Paletten und Cues.
+
+Das Offset kann auf vier Arten eingestellt werden:
+
+-   Gerät(e) auswählen, <Keys.HardKey>Locate</Keys.HardKey>, dann die Attribute so einstellen,
+    dass die ursprünglich vorgesehenen Locate-Positionen erreicht
+    werden. Nun drücken Sie <Keys.HardKey>Record</Keys.HardKey>, <Keys.HardKey>Locate</Keys.HardKey> 
+    und wählen <Keys.SoftKey>Update Offset</Keys.SoftKey>. Damit werden nicht die Locate-Werde verändert, sondern die
+    eingestellte Abweichung wird als Offset gespeichert. Das ist ein
+    schneller visueller Weg, das Offset einzurichten.
+
+-   Ebenso kann das Offset mittels Paletten eingestellt werden. Wählen
+    Sie das/die Gerät(e) aus, rufen Sie eine Palette ab und stellen dann
+    die Attribut-Werte manuell auf die richtigen Werte (z.B. die
+    korrekte Position). Nun drücken Sie <Keys.HardKey>Record</Keys.HardKey>, klicken wieder die Palette
+	an und wählen <Keys.SoftKey>Update Offset</Keys.SoftKey>. Auch hier wird nicht die Palette geändert,
+    sondern die Abweichung zwischen der Palette und der aktuellen
+    Position wird als Offset gespeichert.
+
+-   In der Patch-Ansicht gibt es für die bereits gepatchten Geräte Pan
+    und Tilt extra Zellen mit den Offset-Werten; diese werden dort
+    angezeigt und können editiert werden.
+
+-   Ebenfalls in der Patch-Ansicht, Reiter 'Attribute Behaviour'
+    (Attribut-Verhalten) kann man die Kontext-Option <Keys.SoftKey>Offset</Keys.SoftKey> wählen und
+    die Werte anzeigen lassen bzw. ändern,
+
+## Kennlinien für Geräte und Attribute
+
+Kennlinien bestimmen, wie sich ein Attribut bei Änderung des DMX-Wertes
+verhält. Dies kommt vor allem zur Anwendung bei Dimmerkanälen, um den
+Helligkeitsverlauf für verschiedene Gerätearten anzugleichen, kann aber
+auf alle anderen Attribute ebenfalls angewendet werden.
+
+Kennlinien können entweder über das Menü <Keys.HardKey>Patch</Keys.HardKey>, <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>,
+oder über den Reiter 'Attribute Behaviour' im Patch View gesetzt werden.
+
+1.  Drücken Sie die Taste <Keys.HardKey>Patch</Keys.HardKey>.
+2.  Drücken Sie <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>.
+3.  Wählen Sie <Keys.SoftKey>Set Curve</Keys.SoftKey>.
+4.  Wählen Sie das/die gewünschte(n) Gerät(e) aus.
+5.  Wählen Sie über die Menütasten die zu ändernden Attribute aus.
+6.  Wählen Sie über die Menütasten die gewünschte Kennlinie
+	aus; die Vorgabe ist "Linear".
+7.  Beenden Sie den Vorgang mit <Keys.HardKey>Exit</Keys.HardKey>.
+
+Die verschiedenen Kennlinien sind im Abschnitt [Curves -- Kennlinien/Kurven](../system-settings/curves.md) näher erläutert.  
+
+## Geräte oder Attribute fixieren (Freeze)
+
+Mit dieser Funktion lassen sich einzelne Attribute oder komplette Geräte
+fixieren. Diese werden dann weder vom Programmierspeicher noch von
+programmierten Cues/Cuelisten beeinflusst.
+
+1.  Drücken Sie <Keys.HardKey>Patch</Keys.HardKey>.
+2.  Drücken Sie <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>.
+3.  Drücken Sie <Keys.SoftKey>Freeze Fixture or Attribute</Keys.SoftKey>
+4.  Wählen Sie die zu fixierenden Geräte.
+5.  Wählen mit den Menütasten, welches Attribut oder ob das gesamte
+	Gerät fixiert werden soll. Im Display wird die gewählte Einstellung
+	angezeigt.
+6.  Klicken Sie <Keys.HardKey>Exit</Keys.HardKey>, um den Vorgang abzuschließen.
+
+-   Das Fixieren kann auch im Attribute Behaviour-Reiter der
+    Patch-Ansicht erfolgen.
+
+-   Fixierte Attribute werden durch das Symbol "Frozen" bei den
+    Attributwerten oberhalb der Encoder angezeigt.
+    ![Frozen attribute display](/docs/images/Wheel-Frozen.png)
+
+## Zurücksetzen der Geräteoptionen auf Vorgabewerte
+
+Die Menütaste <Keys.SoftKey>Reset Behaviour</Keys.SoftKey> setzt die folgenden Geräteoptionen auf die jeweiligen Vorgabewerte zurück:
+
+- Oberes Limit
+- Unteres Limit
+- Offset
+- Fixierung (Freeze) 
+- Kennlinien/Kurven
+- Invertierung
+
+Reagiert ein Gerät nicht wie erwartet, so empfiehlt es sich, alle Optionen auf ihre Vorgabewerte zurückzusetzen.
+
+1. Drücken Sie <Keys.HardKey>Patch</Keys.HardKey>.
+2. Drücken Sie <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>.
+3. Drücken Sie <Keys.SoftKey>Next</Keys.SoftKey>.
+4. Drücken Sie <Keys.SoftKey>Reset Behaviour</Keys.SoftKey>.
+5. Wählen Sie das/die Gerät(e) aus, das zurückgesetzt werden soll.
+6. Drücken Sie zur Bestätigung <Keys.SoftKey>Confirm</Keys.SoftKey>.
+
+## Die Personality editieren
+
+Sollte einmal eine Personality nicht wie erwartet funktionieren
+oder will man das Verhalten gezielt ändern, so kann sie direkt
+im Pult editiert werden.
+
+1.  Drücken Sie <Keys.HardKey>Patch</Keys.HardKey>.
+2.  Drücken Sie <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>.
+3.  Drücken Sie <Keys.SoftKey>Edit Personality</Keys.SoftKey>.
+4.  Im Display wird eine Liste der aktuell verwendeten
+    Personalities angezeigt. Wählen Sie die zu editierende mit der
+	entsprechenden Taste.
+5.  Der Personality Builder wird nun gestartet.
+6.  Beim Speichern von Änderungen werden diese als benutzereigene
+	Personality gespeichert; außerdem erfolgt eine Rückfrage, ob die 
+	Änderungen direkt in die Show übernommen werden sollen.
+
+-   Von Ihnen erstellte/geänderte Personalities werden in das dafür
+    vorgesehene Verzeichnis D:\\Personalities (beim Titan Simulator, Titan
+    Mobile und Titan Go ist dies \\Eigene
+    Dokumente\\Titan\\Personalities) gespeichert. Dieses Verzeichnis
+    wird beim Patchen zuerst durchsucht, und beim Updaten der
+    allgemeinen Personalities nicht verändert.
+
+-   Für den Personality Builder gibt es auf
+    [www.avolites.com](http://www.avolites.com) ein gesondertes
+    Handbuch.
+
+> Sollten Sie auf ein Problem in einer von Avolites gelieferten Personality stoßen, so teilen Sie dies bitte über das Formular auf der [Personality-Website](https://personalities.avolites.com/) mit (Gerät raussuchen, dann ganz rechts auf den Käfer (engl. Bug ) klicken).

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/fixture-personality-options.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/fixture-personality-options.md
@@ -147,19 +147,20 @@ Die verschiedenen Kennlinien sind im Abschnitt [Curves -- Kennlinien/Kurven](../
 ## Geräte oder Attribute fixieren (Freeze)
 
 Mit dieser Funktion lassen sich einzelne Attribute oder komplette Geräte
-fixieren. Diese werden dann weder vom Programmierspeicher noch von
+auf einen bestimmten Wert fixieren. Fixierte Geräte/Attribute werden dann weder vom Programmierspeicher noch von
 programmierten Cues/Cuelisten beeinflusst.
 
-1.  Drücken Sie <Keys.HardKey>Patch</Keys.HardKey>.
-2.  Drücken Sie <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>.
-3.  Drücken Sie <Keys.SoftKey>Freeze Fixture or Attribute</Keys.SoftKey>
-4.  Wählen Sie die zu fixierenden Geräte.
-5.  Wählen mit den Menütasten, welches Attribut oder ob das gesamte
+1.  Stellen Sie das Attribut bzw. Gerät wie gewünscht ein.
+2.  Drücken Sie <Keys.HardKey>Patch</Keys.HardKey>.
+3.  Drücken Sie <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>.
+4.  Drücken Sie <Keys.SoftKey>Freeze Fixture or Attribute</Keys.SoftKey>
+5.  Wählen Sie die zu fixierenden Geräte.
+6.  Wählen mit den Menütasten, welches Attribut oder ob das gesamte
 	Gerät fixiert werden soll. Im Display wird die gewählte Einstellung
 	angezeigt.
-6.  Klicken Sie <Keys.HardKey>Exit</Keys.HardKey>, um den Vorgang abzuschließen.
+7.  Klicken Sie <Keys.HardKey>Exit</Keys.HardKey>, um den Vorgang abzuschließen.
 
--   Das Fixieren kann auch im Attribute Behaviour-Reiter der
+-   Das Fixieren kann auch mittels der Checkbox **Frozen** in der
     Patch-Ansicht erfolgen.
 
 -   Fixierte Attribute werden durch das Symbol "Frozen" bei den

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/patching-new-fixtures-or-dimmers.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/patching-new-fixtures-or-dimmers.md
@@ -1,0 +1,327 @@
+---
+id: patching-new-fixtures-or-dimmers
+title: Geräte und Dimmer patchen
+sidebar_label: Geräte und Dimmer patchen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Gerätetasten und -buttons
+
+Um Movinglights oder Dimmer steuern zu können, müssen diese
+zunächst einer Schaltfläche oder Taste zugewiesen werden. Gepatcht
+werden kann auf die Buttons im Fenster 'Fixtures', auf die
+Macro/Exekutor-Tasten sowie auf die normalen Playbacks mit Fadern
+(Speicherplätze). Wird direkt auf Playbacks gepatcht, so steuert der
+Fader die Helligkeit des jeweiligen Geräts.
+
+Ist das Fenster 'Fixtures' nicht sichtbar, so drücken Sie <Keys.HardKey>Open/View</Keys.HardKey>, 
+dann <Keys.HardKey>Fixture</Keys.HardKey>, oder drücken Sie zweimal auf <Keys.HardKey>Open/View</Keys.HardKey> 
+und wählen <Keys.SoftKey>Fixtures</Keys.SoftKey>, oder Sie rufen den Workspace <Keys.SoftKey>Fixtures and Groups</Keys.SoftKey> auf.
+
+![Fixtures Window](/docs/images/Fixtures-Window.png)
+
+Geräteauswahltasten werden entweder seitenweise -- mit gesonderten
+Tasten zur Umschaltung der Seiten -- oder mit einer Schiebeleiste zum
+Wechseln angezeigt. Mit der Schaltfläche <Keys.SoftKey>Pages Show/Hide</Keys.SoftKey> im
+Kontextbereich (links neben den Menübuttons, bzw. im Kontextmenü des 
+Gerätefensters beim Sapphire Touch und Titan Go) lässt sich zwischen den 
+beiden Darstellungsarten umschalten. Zwischen einzelnen Seiten der 
+Anzeige lässt sich jederzeit wechseln.
+
+Titan gestattet es ferner, einzelne Dimmer und Scheinwerfer zu Gruppen
+zusammenzufassen, um schnell auf eine bestimmte Zusammenstellung von
+Geräten Zugriff zu haben. Gruppen werden im nächsten Kapitel
+beschrieben.
+
+Sobald Geräte gepatcht wurden, können die Details in der [Patch-Übersicht](./changing-the-patch.md#patch-view) angezeigt und geändert werden.
+
+## Patchen von Dimmern
+
+Jede Gerätetaste kann einen oder mehrere Dimmer steuern. Die Zuordnung
+(das Patchen) erfolgt entweder über das Patch-Menü (s.u.) oder über das
+Fenster [Patch View](./changing-the-patch.md#patch-view).
+
+1. Drücken Sie die Taste <Keys.HardKey>Patch</Keys.HardKey>, dann <Keys.SoftKey>Dimmer</Keys.SoftKey>.
+2. <Keys.SoftKey>DMX Line=</Keys.SoftKey> zeigt die aktuell zum Patchen ausgewählte DMX-Linie.
+Drücken Sie diese, und geben Sie ggf. eine neue Nummer zum Ändern der
+DMX-Linie ein. <Keys.SoftKey>Address=xx</Keys.SoftKey> zeigt die aktuelle DMX-Adresse an, die als
+nächstes gepatcht werden würde; zum Ändern drücken diese Taste, geben
+die neue Adresse am Zifferntastenblock ein und drücken <Keys.HardKey>Enter</Keys.HardKey>.
+
+  ![DMX Line](/docs/images/DMX-Line.png)
+3. Um einen einzelnen Dimmer zu patchen, betätigen Sie einen der
+Buttons im Fixtures-Fenster, eine Macro/Exekutor-Taste oder die blaue
+Taste bei einem Fader. Um eine Reihe von Dimmern zu patchen, geben Sie
+die gewünschte Anzahl bei <Keys.SoftKey>Quantity</Keys.SoftKey> ein und bestätigen die Anwahltaste
+für den ersten Dimmer (ebenso kann man einfach mit dem Finger über den
+entsprechenden Bereich von Buttons streichen, oder bei Tasten die erste
+gedrückt halten und dazu die letzte drücken). Die so angelegte Reihe von
+Dimmern wird auf fortlaufende DMX-Kanäle gepatcht.
+4. Die verwendeten Schaltflächen erscheinen nun dunkelblau, um
+anzuzeigen, dass sie bereits belegt sind, und zeigen einige Details der
+Geräte/Dimmer an. Wurde auf ein Playback oder eine Macro-Taste gepatcht,
+so leuchtet die jeweilige LED schwach auf, um die Belegung anzuzeigen.
+5. Nun wiederholen Sie den Vorgang ab Schritt 2 für weitere Dimmer.
+
+-   Beim Einstellen der DMX-Adresse mit <Keys.SoftKey>Address=xx</Keys.SoftKey> kann man ebenso
+    die DMX-Linie (Universum) angeben: geben Sie dazu
+    \{Linie\}.\{DMX-Adresse\} ein, etwa 2.56 für Kanal 56 auf Linie 2.
+-   Zur Anzeige der gepatchten DMX-Kanäle drücken Sie <Keys.HardKey>Open/View</Keys.HardKey>, 
+	dann <Keys.HardKey>Patch</Keys.HardKey>, um die [Patch-Übersicht (Patch View)](./changing-the-patch.md#die-patch-ansicht-patch-view) zu öffnen.
+-   <Keys.SoftKey>User Number = xx</Keys.SoftKey> erlaubt die Eingabe einer benutzerdefinierten
+    Nummer für jedes gepatchte Gerät, um später die Zuordnung zu
+    erleichtern. Diese Benutzernummer/Gerätenummer ('User Number')
+    lässt sich später im Menü 'Repatch Fixture' verändern.
+-   Einer Anwahltaste lassen sich auch mehrere Dimmer zuordnen. Das ist
+    zweckmäßig z.B. wenn sämtliche Scheinwerfer eines Bereiches
+    gemeinsam gesteuert werden sollen. Um eine solche Zuordnung
+    vorzunehmen, betätigen Sie einfach die gleiche Anwahltaste beim
+    Patchen des nächsten Dimmers. Zur Kontrolle, ob der Patchvorgang
+    erfolgreich war, überprüfen Sie die angezeigte DMX-Adresse: mit
+    jedem gepatchten Dimmer erhöht sich diese um 1.
+-   Um einen Dimmer, der wie eben beschrieben gemeinsam mit mehreren auf
+    einer Schaltfläche gepatcht war, getrennt zu patchen, ohne die
+    bestehende Programmierung zu verlieren, kopieren Sie die bestehende
+    Schaltfläche und ändern das Patching der kopierten auf die
+    gewünschte Adresse.
+
+## Patchen von Movinglights
+
+Bewegungsscheinwerfer (intelligente Scheinwerfer) sind etwas
+komplizierter zu patchen als Dimmer, da hier mehr Funktionen pro Gerät
+verwaltet werden müssen (Pan, Tilt, Farbe etc.), während Dimmer nur
+einen Kanal haben.
+
+Avolites-Pulte benutzen ein System von 'Personalities', um solche
+Scheinwerfer zu steuern. Das bedeutet, Sie brauchen gar nicht genau zu
+wissen, wie jedes Gerät arbeitet -- Sie teilen dem Pult einfach nur mit,
+was Sie machen möchten, und das Pult sendet die entsprechenden
+Steuersignale. Es gibt Personality-Dateien für nahezu jedes verfügbare
+Gerät; diese definieren die jeweils verfügbaren Kanäle und
+Steuermöglichkeiten. Sollte für ein bestimmtes Gerät keine Personality
+in Ihrem Tiger Touch vorhanden sein, so lassen sich weitere von der
+Avolites-Website downloaden, Sie können sich selbst eine Personality
+schreiben, oder Avolites kann die entsprechende Datei für Sie
+generieren. im Abschnitt [Personalities](../fixture-personalities.md) 
+gibt es weitere Informationen dazu.
+
+Die Zuordnung (das Patchen) erfolgt entweder über das Patch-Menü (s.u.)
+oder über das Fenster [Patch View](./changing-the-patch.md#patch-view).
+
+1. Drücken Sie die Taste <Keys.HardKey>Patch</Keys.HardKey>.
+2. Drücken Sie <Keys.SoftKey>Fixtures</Keys.SoftKey>.
+
+  ![Patch Menu](/docs/images/Patch-Menu.png)
+3. Wählen Sie aus der Liste den Hersteller des Gerätes; mit <Keys.SoftKey>Previous</Keys.SoftKey> (zurück) 
+  oder <Keys.SoftKey>Next</Keys.SoftKey> (weiter) kann man durch die Liste
+  blättern. Oder tippen Sie auf der Tastatur einfach die ersten Buchstaben
+  des Herstellers, um die Suche zu vereinfachen.
+4. Wählen Sie das entsprechende Gerät (auch hier kann man mit F und G
+  blättern, oder die ersten Buchstaben des Gerätes auf der Tastatur tippen).
+5. Wählen Sie ggf. die korrekte Betriebsart (Modus) des Gerätes mit den Funktionstasten aus.
+6. <Keys.SoftKey>Address = </Keys.SoftKey> zeigt die erste freie DMX-Adresse. Ändern Sie diese
+  ggf. mit dem Ziffernblock. Betätigen Sie <Keys.SoftKey>DMX line=xx</Keys.SoftKey>, um auf eine
+  andere DMX-Linie zu wechseln, oder geben Sie die Adresse als <Keys.SoftKey>Linie</Keys.SoftKey>.<Keys.SoftKey>Adresse</Keys.SoftKey> ein (z.B. 2.45 für Kanal 45 auf Linie 2).
+
+  ![Address Input](/docs/images/Address-Input.png)
+7. Um das Gerät zu patchen, betätigen Sie einen der Buttons im
+Fixtures-Fenster, eine Macro/Exekutor-Taste oder die blaue Taste bei
+einem Fader.
+8. Die verwendeten Schaltflächen erscheinen nun dunkelblau, um
+anzuzeigen, dass sie bereits belegt sind, und zeigen einige Details der
+Geräte/Dimmer an. Wurde auf ein Playback oder eine Macro-Taste gepatcht,
+so leuchtet die jeweilige LED schwach auf, um die Belegung anzuzeigen.
+9. Wiederholen Sie den Vorgang ab Schritt 7, um weitere Geräte zu
+patchen. Die DMX-Adresse wird dabei automatisch hochgezählt.
+
+-   Um eine Reihe von gleichen Geräten zu patchen, geben Sie die Anzahl
+    mit <Keys.SoftKey>Quantity</Keys.SoftKey> ein und bestätigen die Anwahltaste für das ersten
+    Gerät (ebenso kann man einfach mit dem Finger über den
+    entsprechenden Bereich von Buttons streichen, oder bei Tasten die
+    erste gedrückt halten und dazu die letzte drücken). Die so angelegte
+    Reihe von Geräten wird auf fortlaufende DMX-Kanäle gepatcht.
+
+-   Mit <Keys.SoftKey>Options</Keys.SoftKey>, <Keys.SoftKey>Offset</Keys.SoftKey> kann man Lücken in die Gerätefolge
+    einbauen, wenn mehrere Geräte gleichzeitig gepatcht werden. Dies ist
+    besonders hilfreich, wenn man bereits damit rechnet, später Geräte
+    austauschen zu müssen. Der Offset-Wert ist dabei die gesamte
+    Kanalanzahl, die man pro Gerät reservieren möchte; sollen Geräte
+    z.B. in 30er Schritten gepatcht werden, so gibt man als Offset 30
+    ein.
+
+-   Es lässt sich nur ein Gerät pro Auswahltaste patchen. Ein Patchen
+    eines weiteren Gerätes auf eine bereits belegte Taste/Schaltfläche
+    ist nicht möglich.
+
+-   Zum Patchen eines Gerätes, welches einen separaten Dimmer benötigt
+    (wie etwa ein VL5), können Sie den Dimmerkanal auf die gleiche
+    Auswahltaste wie das eigentliche Gerät patchen, so dass man alles
+    gemeinsam steuern kann. Diese Funktion nennt sich 'Pending Dimmer'
+    (abhängiger Dimmer). In der [Patch-Ansicht (Patch View)](./changing-the-patch.md#patch-view) 
+    werden solche Geräte mit einem Blitz-Symbol hinter der Gerätenummer angezeigt.
+
+-   <Keys.SoftKey>Options</Keys.SoftKey>, <Keys.SoftKey>Preset Palettes</Keys.SoftKey> bestimmt, ob das Pult beim Patchen
+    bereits Paletten für Farbe, Gobo und Position des Gerätes anlegen
+    soll; diese werden in den entsprechenden Arbeitsfenstern angezeigt.
+    Diese Option ist als Vorgabewert deaktiviert, aber ggf. sehr
+    hilfreich, so dass es sich lohnt, diese in Erinnerung zu behalten.
+
+-   Mit <Keys.SoftKey>Options</Keys.SoftKey>, <Keys.SoftKey>AutoGroups</Keys.SoftKey> lässt sich festlegen, ob das Pult
+    automatisch die gepatchten Geräte in Gruppen ordnet. Die automatisch
+    erstellten Gruppen sind eine Gruppe pro Gerätetyp sowie jeweils eine
+    Gruppe für gleichzeitig gepatchte Geräte.
+
+-   Um die Belegung der DMX-Kanäle anzuzeigen, wählen Sie <Keys.HardKey>Open/View</Keys.HardKey>,
+    &nbsp;<Keys.HardKey>Patch</Keys.HardKey>. Um Details eines einzelnen Gerätes anzuzeigen, wählen Sie 
+    &nbsp;<Keys.HardKey>open/View</Keys.HardKey> und die jeweilige Geräte-Schaltfläche. Dabei
+    wird auf den Schaltflächen die DMX-Adresse (im Format
+    &#123;DMX-Linie&#125;.&#123;Adresse&#125;) angezeigt - das lässt sich über das
+    Kontextmenü abschalten.
+
+-   Wird beim Patchen die Kapazität einer DMX-Linie überschritten, setzt
+    Titan das Patchen am Beginn der folgenden DMX-Linie fort.
+    Versucht man etwa, ein Movinglight (mit mehr als 3 Kanälen) auf
+    Kanal 1.510 zu patchen, so wird es tatsächlich auf 2.1 gepatcht.
+
+-   Wenn die Personality die erforderlichen Informationen enthält, so
+    wird im Dialog-Bereich ein Symbolbild des Geräts angezeigt, so dass
+    man überprüfen kann, das richtige Modell gewählt zu haben.
+    
+    ![Fixture Mode](/docs/images/Fixture-Mode.png)
+
+## Automatisches Patchen in Capture
+
+Um den Capture Visualiser zu benutzen, drücken Sie zweimal auf 
+[<Keys.HardKey>Open/View</Keys.HardKey>](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster) 
+und wählen <Keys.SoftKey>Capture Visualiser</Keys.SoftKey>. Einige
+Pulte verfügen auch über eine gesonderte <Keys.HardKey>Visualiser</Keys.HardKey>-Taste. Daraufhin
+öffnet sich das Visualiser-Fenster mit einer automatisch aus dem Patch
+generierten Darstellung von Geräten.
+
+Die gepatchten Geräte werden in der Reihenfolge dargestellt, in der sie
+gepatcht wurden. Daraufhin lässt sich das Geräte-Layout mit der
+Capture-Steuerung entsprechend anpassen, siehe [Steuerung des Visualisers](../capture-visualiser.md).
+
+-   Das automatische Patchen der Geräte in Capture lässt sich in den 
+    Capture-Einstellungen deaktivieren (Reiter 'Stage').
+
+-   Geräte-Modes, bei denen die Darstellung in Capture funktioniert,
+    werden mit einem Capture-Logo dargestellt (siehe Bild) - fehlt dieses
+    Logo, kann das Gerät nicht im integrierten Capture dargestellt werden.
+    
+    ![Fixture Modes](/docs/images/Fixture-Modes.png)
+
+-   Wird die [Capture-Vollversion](../capture-visualiser/linking-the-console-to-stand-alone-capture.md) 
+    (ab Nexum) auf einem externen Computer verwendet, so werden Änderungen am 
+	Patch sowohl vom Pult zu Capture als auch in umgekehrter Richtung 
+	übertragen und automatisch synchronisiert.
+
+## Geräte mit mehreren Zellen (Sub-Fixtures)
+
+Manche Geräte haben mehrere identische, unabhängig voneinander
+steuerbare Bereiche (etwa manche RGB-LED-Blinder). Um nun nicht jede
+Zelle einzeln patchen zu müssen, besteht das gesamte Gerät aus einem
+übergreifenden 'Super Fixture', das die Master-Kanäle enthält, sowie den
+entsprechenden Zellen als Teilgeräte - Sub Fixtures. Dies ist
+insbesondere beim Arbeiten mit dem Pixelmapper sinnvoll, da sich damit sehr
+einfach komplette Geräte verschieben oder rotieren lassen.
+
+Wählt man das Gesamtgerät mittels seiner Schaltfläche aus, so werden
+alle Zellen synchron beeinflusst. Um Zugriff auf die einzelnen Zellen zu
+erhalten, verwenden Sie den Attribut-Editor oder drücken Sie <Keys.HardKey>Unfold</Keys.HardKey>
+und die Auswahltaste des Geräts. Die aktuelle Seite des
+‚Fixtures'-Fensters zeigt nun die einzelnen Sub Fixtures/Zellen. 
+
+Ist das Gerät auf einen Fader gepatcht, so werden die Zellen auf den Fadern
+dieser Seite eingeblendet. Teilgeräte lassen sich auch per Tastatur-Syntax auswählen, siehe [Geräte mit mehreren Zellen/Subfixtures](../controlling-fixtures.md#geräte-mit-mehreren-zellensubfixtures).
+
+Um zur normalen Anzeige zurückzukehren, drücken Sie <Keys.HardKey>Unfold</Keys.HardKey> und
+wählen <Keys.SoftKey>Exit Unfold</Keys.SoftKey>.
+
+> Sub-Fixtures werden in der jeweiligen Personality definiert. Sollte also einmal ein Gerät nicht wie gewünscht arbeiten, laden Sie die aktuelle Personality-Bibliothek von Avolites herunter.
+
+## Aktive Geräte/Medienserver
+
+Zur Verwendung von Ai Medienservern sei auf den Abschnitt [Synergy](../synergy.md) 
+für weitere Details zu Synergy verwiesen, dem neuen System direkter
+Steuerung der Server vom Pult aus.
+
+Andere Medienserver, die CITP unterstützen, können über die Funktion
+<Keys.SoftKey>Active Fixtures</Keys.SoftKey> im Patch-Menü gepatcht werden. Damit lassen sich
+Vorschaubilder der Clips des Medienservers auf dem Pult anzeigen (im
+Fenster Attribut-Editor).
+
+Sind Pult und Medienserver korrekt in einem Netzwerk konfiguriert, so
+drückt man <Keys.HardKey>Patch</Keys.HardKey>, <Keys.SoftKey>Active Fixtures</Keys.SoftKey>, <Keys.SoftKey>CITP Media Servers</Keys.SoftKey> und
+erhält eine Liste aller im Netzwerk gefundenen Medienserver mit ihren
+Layern. Jeder Layer kann nun separat wie ein Movinglight gepatcht
+werden.
+
+## Patchen mit Hilfe von RDM
+
+RDM (Remote Device Management) ist ein System, mit dem die verwendeten
+Geräte automatisch ihre jeweilige Adresse und ihren Betriebsmodus an das
+Pult melden können. Damit kann sowohl das Patchen weitgehend
+automatisiert, als auch die Betriebsart einzelner Geräte bei Bedarf
+geändert werden.
+
+>  RDM funktioniert bei Titan-Pulten nur über Art-Net und RDM-fähige Nodes, nicht über die normalen DMX-Buchsen. RDM muss in den verwendeten Geräten eingebaut sein, was leider noch längst nicht bei allen Geräten der Fall ist. Ebenso muss die gesamte verwendete DMX-Peripherie (Splitter etc.) RDM-kompatibel sein.             
+
+Drücken Sie die Taste <Keys.HardKey>Open/View</Keys.HardKey>, dann <Keys.HardKey>Patch</Keys.HardKey>. In der
+sich öffnenden [Patch-Anzeige (Patch View)](./changing-the-patch.md#patch-view) wählen Sie den Reiter RDM. Nun
+werden alle vom Pult per RDM gefundenen Geräte angezeigt; mit dem Befehl
+&nbsp;<Keys.SoftKey>Full Discover</Keys.SoftKey> aus dem Kontextmenü lässt sich die Liste
+aktualisieren.
+
+![RDM Discovery](/docs/images/RDM-Discovery.png)
+
+-   Wählen Sie ein oder mehrere Gerät(e) aus und betätigen Sie den
+    Button <Keys.SoftKey>Patch</Keys.SoftKey> aus dem Kontextmenü.
+
+-   Zum Ändern etwa von Betriebsart oder Adresse klicken Sie auf die
+    entsprechenden Tabellenzellen.
+
+-   Klicken Sie auf <Keys.SoftKey>Identify</Keys.SoftKey> bei einzelnen Geräten (ggf. nach rechts
+    scrollen), um einzelne Geräte zu identifizieren.
+
+-   Mit der Taste <Keys.SoftKey>RDM Quick Patch</Keys.SoftKey> aus dem Kontextmenü lassen sich
+    die per RDM gefundenen Geräte automatisch patchen.
+
+## Geparkte Geräte
+
+Versucht man, ein Gerät so zu patchen, zu kopieren oder zu verschieben, dass seine Kanäle sich mit die denen
+eines bereits gepatchten Geräts überschneiden, so wird im Menü die Option angeboten, die überschneidenden Geräte 
+zu **Parken**. Geparkte Geräte behalten alle ihre Programmierung, erzeugen aber keinen DMX-Output.
+
+Geparkte Geräte können in der [Patch-Ansicht](../patching/changing-the-patch.md#die-patch-ansicht-patch-view)
+durch Zuweisen einer passenden DMX-Adresse aktiviert werden. In diesem Fenster gibt es extra einen Filter 
+zur Anzeige aller geparkten Geräte.
+
+## Geräte suchen und finden
+
+Mitunter ist ein Gerät falsch adressiert oder mit der falschen DMX-Linie
+verbunden.
+
+Mit der Funktion "Find Fixture" lassen sich derart 'verlorene' Gerät
+schnell wiederfinden; damit werden für die gewählte Adresse und
+Personality Locate-Werte gesendet. Reagiert das Gerät korrekt, so ist
+die richtige Adresse gefunden.
+
+1. Drücken Sie die Taste <Keys.HardKey>Patch</Keys.HardKey>, wählen Sie <Keys.SoftKey>Fixtures</Keys.SoftKey>, und wählen
+Sie den Typ des gesuchten Geräts aus.
+2. Klicken Sie auf <Keys.SoftKey>Options</Keys.SoftKey>, dann auf <Keys.SoftKey>Find Fixture</Keys.SoftKey>, um den
+Suchmodus zu aktivieren.
+3. Mit Encoder B kann man nun durch alle möglichen DMX-Adressen
+durchschalten; mit Encoder A kann man die zu verwendende DMX-Linie wählen.
+4. Reagiert das gesuchte Gerät mit Locate-Werten, so ist die korrekte
+Adresse gefunden.
+5. Deaktivieren Sie nun <Keys.SoftKey>Find Fixture</Keys.SoftKey> und (wenn nicht bereits
+geschehen) patchen Sie das Gerät. Dabei wird automatisch die soeben
+gefundene DMX-Adresse vorgegeben.
+
+-   Mit Encoder C kann man den DMX-Slot wählen; dabei wird immer in
+    Vielfachen der vom Gerät belegten Kanalzahl vorgegangen (verwendet
+    ein Gerät z.B. 16 Kanäle, so schaltet dies die Adressen in
+    Vielfachen von 16 weiter).

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/patching-new-fixtures-or-dimmers.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/patching/patching-new-fixtures-or-dimmers.md
@@ -120,7 +120,7 @@ oder über das Fenster [Patch View](./changing-the-patch.md#patch-view).
   des Herstellers, um die Suche zu vereinfachen.
 4. Wählen Sie das entsprechende Gerät (auch hier kann man mit F und G
   blättern, oder die ersten Buchstaben des Gerätes auf der Tastatur tippen).
-5. Wählen Sie ggf. die korrekte Betriebsart (Modus) des Gerätes mit den Funktionstasten aus.
+5. Wählen Sie die Betriebsart (Modus) des Gerätes mit den Funktionstasten aus (muss mit dem am Gerät eingestellten Modus übereinstimmen).
 6. <Keys.SoftKey>Address = </Keys.SoftKey> zeigt die erste freie DMX-Adresse. Ändern Sie diese
   ggf. mit dem Ziffernblock. Betätigen Sie <Keys.SoftKey>DMX line=xx</Keys.SoftKey>, um auf eine
   andere DMX-Linie zu wechseln, oder geben Sie die Adresse als <Keys.SoftKey>Linie</Keys.SoftKey>.<Keys.SoftKey>Adresse</Keys.SoftKey> ein (z.B. 2.45 für Kanal 45 auf Linie 2).
@@ -298,6 +298,9 @@ zu **Parken**. Geparkte Geräte behalten alle ihre Programmierung, erzeugen aber
 Geparkte Geräte können in der [Patch-Ansicht](../patching/changing-the-patch.md#die-patch-ansicht-patch-view)
 durch Zuweisen einer passenden DMX-Adresse aktiviert werden. In diesem Fenster gibt es extra einen Filter 
 zur Anzeige aller geparkten Geräte.
+
+> Auf den Pulten mancher anderer Hersteller bedeutet 'Parken' das Fixieren der Geräte auf einem bestimmten Wert. In
+Titan dient dazu [Freeze](fixture-personality-options.md?#geräte-oder-attribute-fixieren-freeze).
 
 ## Geräte suchen und finden
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start.md
@@ -1,0 +1,28 @@
+---
+id: quick-start
+title: Schnellstartanleitung
+sidebar_label: Schnellstartanleitung
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Dieser Abschnitt soll einen schnellen Einstieg in Ihr Titan-Pult
+ermöglichen; dazu sind die meisten wichtigen Arbeitsschritte kurz
+beschrieben. Jeder Abschnitt verweist dabei auf den entsprechenden
+Abschnitt im Handbuch, in dem weitere Details zu finden sind.
+
+-   'Richtige' fest beschriftet Tasten werden schwarz (ggf. rot) angezeigt,
+    z.B. <Keys.HardKey>Record</Keys.HardKey> oder <Keys.HardKey>Avo</Keys.HardKey>.
+-   Menü-Tasten werden <Keys.SoftKey> blau </Keys.SoftKey> gezeigt. 
+-   Kontext-Buttons werden grau dargestellt, z.B. <Keys.ContextKey>so</Keys.ContextKey>.
+
+
+Für die meisten Funktionen werden die Fenster auf dem/den Display(s)
+genutzt. Um ein anderes Fenster zu öffnen, drücken Sie zweimal die Taste
+&nbsp;<Keys.HardKey>View</Keys.HardKey> (heißt auf manchen Pulten auch <Keys.HardKey>Open</Keys.HardKey>, daher steht in diesem
+Handbuch meist <Keys.HardKey>Open/View</Keys.HardKey>). Auf jedem Bildschirm wird ein Overlay mit
+Buttons für jedes verfügbare Fenster eingeblendet -- klicken Sie einfach
+den gewünschten Button an. Zusammenstellungen von Fenstern können als
+Workspace gespeichert werden (entweder in dem 12er Block neben den
+Menütasten oder am Bildschirmrand). Siehe [Workspace Windows](./titan-basics/workspace-windows.md) für weitere Details.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/controlling-fixtures.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/controlling-fixtures.md
@@ -1,0 +1,74 @@
+---
+id: controlling-fixtures
+title: Geräte steuern
+sidebar_label: Geräte steuern
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Zum Steuern werden einzelne oder mehrere Geräte mit den
+Geräte-Schaltflächen ausgewählt. Die Buttons der ausgewählten Geräte
+werden hellblau dargestellt.
+
+Drücken Sie <Keys.HardKey>Locate</Keys.HardKey>, um die ausgewählten Geräte zu "homen" (50%
+Pan/Tilt, kein Gobo, open white), siehe [Locate](../controlling-fixtures.md#geräte-auf-startposition-setzen-locate). Halten
+Sie die <Keys.HardKey>Locate</Keys.HardKey>-Taste gedrückt und drücken Sie dazu einzelne
+Attribute, um diese **nicht** zurückzusetzen (um z.B. Pan/Tilt nicht
+zurückzusetzen, halten Sie <Keys.HardKey>Locate</Keys.HardKey> und drücken dazu <Keys.HardKey>Position</Keys.HardKey>).
+
+Wählen Sie nun einzelne Attribute zum Bearbeiten aus (Attribut-Tasten
+sind beschriftet mit Intensity/Dimmer, Colour, Gobo usw.), und stellen
+Sie die gewünschten Werte mit den Rädern ein; Attribute und Werte werden
+dabei im Display angezeigt
+(Siehe [Einstellen von Attributen mit den Encodern](../controlling-fixtures.md#einstellen-von-attributen-mit-den-encodern)).
+
+Ebenso können Sie den Attribut-Editor öffnen (<Keys.HardKey>View/Open</Keys.HardKey>, <Keys.HardKey>
+Options</Keys.HardKey>), um Einstellungen mit den Schaltflächen auszuwählen und um
+einzelne Zellen/Subfixtures von Geräten mit mehreren Zellen zu
+beeinflussen.
+(Siehe [Geräte mit mehreren Zellen/Subfixtures](../controlling-fixtures.md#geräte-mit-mehreren-zellensubfixtures)).
+
+Verwenden Sie Paletten, um häufig benutzte Farben, Positionen etc. zu
+speichern, siehe nächste Seite.
+
+## Geräte-Gruppen
+
+Geräte können zur schnelleren Auswahl [zu Gruppen zusammengefasst](../controlling-fixtures/fixture-groups.md) werden:
+drücken Sie <Keys.HardKey>Group</Keys.HardKey>, <Keys.SoftKey>Record Group</Keys.SoftKey>, wählen die zu gruppierenden
+Geräte aus, geben ggf. eine Legende ein (mit <Keys.SoftKey>Provide a legend</Keys.SoftKey>), und
+klicken auf eine Gruppen-Schaltfläche oder Taste (wenn es eine
+Playback-Taste mit Fader ist, wird daraus ein Gruppen-Masterfader). Die
+Reihenfolge der Geräteauswahl etwa zur Verwendung innerhalb von
+Effekten/Shapes wird mit den Gruppen gespeichert.  Ebenso wird das Layout der Geräte pro Gruppe gespeichert und
+etwa für Pixelmapper-Effekte sowie Shapes verwendet.
+
+## Shapes & Effekte
+
+Titan verfügt über drei Arten von Effekten: vorprogrammierte Effekte
+([Shapes](../effects/shape-generator.md)), Muster, die man selbst erstellt ([Keyframe-Shapes](../effects/key-frame-shapes.md)), sowie ([Pixelmapper-Effekte](../effects/pixel-mapper.md)).
+
+Wählen Sie mehrere Geräte aus; dabei bestimmt die Reihenfolge der
+Auswahl die Reihenfolge innerhalb des Shapes.
+
+Im Hauptmenü drücken Sie <Keys.SoftKey>Shapes and Effects</Keys.SoftKey>, <Keys.SoftKey>Shape Generator</Keys.SoftKey>,
+<Keys.SoftKey>Create</Keys.SoftKey>. 
+Wählen Sie das gewünschte Attribut, auf das der Effekt
+angewendet werden soll.
+
+Ebenso können Sie aus der Effekt-Bibliothek (2 x <Keys.HardKey>Open/View</Keys.HardKey>, 
+<Keys.SoftKey>Shape Library</Keys.SoftKey>) direkt einen Effekt auswählen. Die Liste
+lässt sich mit den Attribut-Tasten filtern.
+
+Stellen Sie mit den Rädern und der Auswahl <Keys.SoftKey>Adjust Speed, Size and
+Spread</Keys.SoftKey>/<Keys.SoftKey>Adjust Phase, Spread and Offset</Keys.SoftKey> die Effekt-Parameter wie
+gewünscht ein. Dabei bestimmt ‚Spread' die Verteilung des Effekts auf
+die Geräte.
+
+[Keyframe-Shapes](../effects/key-frame-shapes.md) arbeiten ähnlich wie [Chaser](../chases.md). Wichtigster Unterschied
+ist, dass man den genauen Kurvenverlauf selbst bestimmen kann.
+
+Um den [Pixelmapper](../effects/pixel-mapper.md), zu verwenden, müssen 
+entsprechende Gruppen erstellt werden. Wählen Sie dann die Gruppe aus, und 
+stellen Sie mit dem [Layout-Editor](../controlling-fixtures/fixture-groups.md#gerätereihenfolge-und--anordnung-in-den-gruppen) die Anordnung der Geräte innerhalb der Gruppe ein, bevor
+Sie schließlich mit dem Effekt-Editor Effekte erstellen.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/controlling-fixtures.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/controlling-fixtures.md
@@ -34,22 +34,24 @@ speichern, siehe nächste Seite.
 
 ## Geräte-Gruppen
 
-Geräte können zur schnelleren Auswahl [zu Gruppen zusammengefasst](../controlling-fixtures/fixture-groups.md) werden:
-drücken Sie <Keys.HardKey>Group</Keys.HardKey>, <Keys.SoftKey>Record Group</Keys.SoftKey>, wählen die zu gruppierenden
-Geräte aus, geben ggf. eine Legende ein (mit <Keys.SoftKey>Provide a legend</Keys.SoftKey>), und
-klicken auf eine Gruppen-Schaltfläche oder Taste (wenn es eine
-Playback-Taste mit Fader ist, wird daraus ein Gruppen-Masterfader). Die
-Reihenfolge der Geräteauswahl etwa zur Verwendung innerhalb von
-Effekten/Shapes wird mit den Gruppen gespeichert.  Ebenso wird das Layout der Geräte pro Gruppe gespeichert und
-etwa für Pixelmapper-Effekte sowie Shapes verwendet.
+Geräte können zur schnelleren Auswahl [zu Gruppen zusammengefasst](../controlling-fixtures/fixture-groups.md) werden. 
+Um eine Gruppe zu speichern, wählen Sie die zu gruppierenden Geräte aus, klicken auf einen freien Button im 
+Groups-Fenster (daraufhin erscheint ein rotes +), geben ggf. eine Legende ein, und klicken nochmal auf den vorher gewählten Button.
+
+Zum Speichern einer Gruppe auf einem Fader wählen Sie die gewünschten Fixtures aus, drücken <Keys.HardKey>Group</Keys.HardKey>, <Keys.SoftKey>Record
+Group</Keys.SoftKey>, und betätigen die Auswahltaste des Faders. Dieser wird der Masterfader der Gruppe. 
+
+Die Reihenfolge der Geräteauswahl etwa zur Verwendung innerhalb von
+Effekten/Shapes wird mit den Gruppen gespeichert. Ebenso wird das Layout der Geräte pro Gruppe gespeichert und
+etwa für Pixelmapper-Effekte sowie Shapes verwendet, siehe [Gruppenlayout](../controlling-fixtures/fixture-groups.md#gruppenlayout).
 
 ## Shapes & Effekte
 
 Titan verfügt über drei Arten von Effekten: vorprogrammierte Effekte
 ([Shapes](../effects/shape-generator.md)), Muster, die man selbst erstellt ([Keyframe-Shapes](../effects/key-frame-shapes.md)), sowie ([Pixelmapper-Effekte](../effects/pixel-mapper.md)).
 
-Wählen Sie mehrere Geräte aus; dabei bestimmt die Reihenfolge der
-Auswahl die Reihenfolge innerhalb des Shapes.
+Wählen Sie mehrere Geräte aus (individuell oder als Gruppe); dabei bestimmt die Reihenfolge der
+Auswahl bzw. das Layout in der Gruppe die Reihenfolge innerhalb des Shapes.
 
 Im Hauptmenü drücken Sie <Keys.SoftKey>Shapes and Effects</Keys.SoftKey>, <Keys.SoftKey>Shape Generator</Keys.SoftKey>,
 <Keys.SoftKey>Create</Keys.SoftKey>. 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/dmx-network-setup.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/dmx-network-setup.md
@@ -1,0 +1,27 @@
+---
+id: dmx-network-setup
+title: DMX / Netzwerkeinrichtung
+sidebar_label: DMX / Netzwerkeinrichtung
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Das Pult arbeitet intern mit max. 64 DMX-Universen. Geräte und Dimmer werden auf eine der 64 **DMX-Linien** gepatcht, die wiederum auf die DMX-anschlüsse und die Ausgabe per Art-Net oder sACN geroutet werden (siehe [DMX-Ausgänge einrichten](../system-settings/dmx-output-mapping.md)).
+
+- Beim T1 / T2 / T3 ist die Anzahl der Universen auf 1 / 2 / 16 begrenzt. Pulte können normalerweise bis zu 16 Universen (D9/D7: 32) ausgeben, und für weitere sind TNPs (Titan Network Processor) erforderlich. Für einfache Shows und für Setups mit vielen freien Kanälen pro Universum funktionieren auch mehr als 16 Universen (D9/D7: 32) pro Pult, aber es kann zu Performance-Einbußen und gelegentlichen Rucklern kommen, daher ist das nicht zu empfehlen.
+
+Mehrere Pulte lassen sich per Ethernet vernetzen und gestatten so den
+[Mehrbenutzerbetrieb](../titan-basics/multi-user-operation.md) sowie [Backup](../running-the-show/linking-consoles-for-multi-user-or-backup.md#pulte-für-den-backup-betrieb-einrichten).
+
+Öffnen Sie das **System**-Menü (<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>) und drücken Sie <Keys.SoftKey>DMX Settings</Keys.SoftKey>.
+
+Wählen Sie links einen Node aus (den gewünschten Ausgabe-Anschluss), und
+klicken Sie auf den Pfeil. Rechts wählen Sie nun das Universum,
+das ausgegeben werden soll. Mit dem kleinen <Keys.ContextKey>Zahnrad</Keys.ContextKey> lassen sich
+verschiedene weitere Einstellungen pro Linie vornehmen (siehe [DMX-Ausgänge einrichten](../system-settings/dmx-output-mapping.md)).
+
+Zum Ändern der IP-Adresse des Pultes wählen Sie im **System**-Menü <Keys.SoftKey>[Netzwerkeinstellungen](../networking.md)</Keys.SoftKey>.
+
+Zum Ändern individueller [Benutzereinstellungen](../system-settings/user-settings.md) halten Sie 
+die <Keys.HardKey>Avo</Keys.HardKey>-Taste gedrückt und drücken Sie <Keys.SoftKey>User Settings</Keys.SoftKey>.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/dmx-network-setup.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/dmx-network-setup.md
@@ -7,9 +7,15 @@ sidebar_label: DMX / Netzwerkeinrichtung
 import Keys from '@site/src/components/key.ts';
 import Video from '@site/src/components/video.tsx';
 
-Das Pult arbeitet intern mit max. 64 DMX-Universen. Geräte und Dimmer werden auf eine der 64 **DMX-Linien** gepatcht, die wiederum auf die DMX-anschlüsse und die Ausgabe per Art-Net oder sACN geroutet werden (siehe [DMX-Ausgänge einrichten](../system-settings/dmx-output-mapping.md)).
+Titan arbeitet intern mit max. 64 DMX-Universen. Geräte und Dimmer werden auf eine der 64 **DMX-Linien** gepatcht, die wiederum auf die DMX-Anschlüsse und die Ausgabe per Art-Net oder sACN geroutet werden.
+Dabei können die ausgegebenen Universen im Bereich 1 - 9999 nummeriert werden; insgesamt können aber nicht mehr Universen ausgegeben werden, als die jeweilige Hardware/Lizenz gestattet.
 
-- Beim T1 / T2 / T3 ist die Anzahl der Universen auf 1 / 2 / 16 begrenzt. Pulte können normalerweise bis zu 16 Universen (D9/D7: 32) ausgeben, und für weitere sind TNPs (Titan Network Processor) erforderlich. Für einfache Shows und für Setups mit vielen freien Kanälen pro Universum funktionieren auch mehr als 16 Universen (D9/D7: 32) pro Pult, aber es kann zu Performance-Einbußen und gelegentlichen Rucklern kommen, daher ist das nicht zu empfehlen.
+Pulte können nicht alle 64 Universen direkt ausgeben. Ggf. sind dafür TNPs (Titan Network Processor) erforderlich.
+
+- Siehe [DMX-Ausgänge einrichten](../system-settings/dmx-output-mapping.md) zu den Details und maximalen Universen der verschiedenen Pulte.
+
+Auf Pulten mit einer begrenzten Zahl von Universen, die ausgegeben werden können, können zwar alle Universen gepatcht werden, es werden aber nur die mit den niedrigsten Nummern ausgegeben.
+Es ist nicht möglich, das Limit durch Anschluss weiterer Hardware zu erweitern; so wird z.B. auch bei zwei gleichzeitig angeschlossenen T1 nur ein Universum ausgeben.
 
 Mehrere Pulte lassen sich per Ethernet vernetzen und gestatten so den
 [Mehrbenutzerbetrieb](../titan-basics/multi-user-operation.md) sowie [Backup](../running-the-show/linking-consoles-for-multi-user-or-backup.md#pulte-für-den-backup-betrieb-einrichten).
@@ -25,3 +31,5 @@ Zum Ändern der IP-Adresse des Pultes wählen Sie im **System**-Menü <Keys.Soft
 
 Zum Ändern individueller [Benutzereinstellungen](../system-settings/user-settings.md) halten Sie 
 die <Keys.HardKey>Avo</Keys.HardKey>-Taste gedrückt und drücken Sie <Keys.SoftKey>User Settings</Keys.SoftKey>.
+
+Es können sACN-Eingänge eingerichtet werden, um Signale von anderen Pulten zu empfangen. Siehe [Verwenden von DMX/sACN-Eingang](/controlling-fixtures/changing-fixture-attributes.md#verwenden-von-dmxsacn-eingang).

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/patching-fixtures.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/patching-fixtures.md
@@ -1,0 +1,42 @@
+---
+id: patching-fixtures
+title: Geräte patchen
+sidebar_label: Geräte patchen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Drücken Sie die Taste <Keys.HardKey>Patch</Keys.HardKey> und wählen dann <Keys.SoftKey>Dimmers</Keys.SoftKey> oder
+<Keys.SoftKey>Fixtures</Keys.SoftKey>.
+
+Um Movinglights zu patchen, wählen Sie mit den Menütasten den Hersteller
+(mit der Tastatur kann nach Eingabe der Anfangsbuchstaben die Liste
+entsprechend verkürzt werden), als nächstes den gewünschten Gerätetyp,
+und dann den Mode.
+
+Geben Sie dann die entsprechenden Werte für <Keys.SoftKey>DMX Line</Keys.SoftKey>, <Keys.SoftKey>Address</Keys.SoftKey>,
+<Keys.SoftKey>User Number</Keys.SoftKey> und <Keys.SoftKey>Legend</Keys.SoftKey> ein; dabei zeigt das Pult bereits eine
+passende Vorbelegung (z.B. nächste freie Adresse).
+
+Betätigen Sie eine oder mehrere Schaltflächen im
+Geräte(Fixtures)-Fenster, um die Geräte zu patchen, oder patchen Sie mit
+den blauen Tasten direkt auf einzelne Fader.  (Siehe [Geräte und Dimmer patchen](../patching/patching-new-fixtures-or-dimmers.md)).
+
+Um mehrere gleiche Geräte oder mehrere Dimmer auf einmal zu patchen,
+wählen Sie mehrere Geräte-Schaltflächen aus, indem Sie darüber
+streichen, oder geben Sie die Anzahl mit <Keys.SoftKey>Quantity</Keys.SoftKey> ein. (Bei
+Fadern/Tasten: die erste Taste gedrückt halten und dazu eine weitere
+Taste drücken).
+
+Um die DMX-Adresse oder das Universum zu ändern, wählen Sie <Keys.SoftKey>Repatch Fixtures</Keys.SoftKey> (siehe [Repatch Fixtures](../patching/changing-the-patch.md#ändern-der-dmx-adresse-im-patch-menü)).
+
+## Patch anzeigen
+
+Zum Anzeigen der gepatchten Geräte drücken Sie
+&nbsp;<Keys.HardKey>Open/View</Keys.HardKey>, dann <Keys.HardKey>Patch</Keys.HardKey> zum Öffnen der [Patch-Ansicht](../patching/changing-the-patch.md#patch-view).
+
+## Geräteoptionen einstellen
+
+Drücken Sie <Keys.HardKey>Patch</Keys.HardKey>, <Keys.SoftKey>Edit Fixtures</Keys.SoftKey>, oder verwenden Sie die
+Patch-Ansicht.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/patching-fixtures.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/patching-fixtures.md
@@ -7,29 +7,27 @@ sidebar_label: Geräte patchen
 import Keys from '@site/src/components/key.ts';
 import Video from '@site/src/components/video.tsx';
 
-Drücken Sie die Taste <Keys.HardKey>Patch</Keys.HardKey> und wählen dann <Keys.SoftKey>Dimmers</Keys.SoftKey> oder
-<Keys.SoftKey>Fixtures</Keys.SoftKey>.
+Drücken Sie die Taste <Keys.HardKey>Patch</Keys.HardKey> und wählen dann <Keys.SoftKey>Dimmers</Keys.SoftKey> oder <Keys.SoftKey>Fixtures</Keys.SoftKey>.
 
 Um Movinglights zu patchen, wählen Sie mit den Menütasten den Hersteller
 (mit der Tastatur kann nach Eingabe der Anfangsbuchstaben die Liste
 entsprechend verkürzt werden), als nächstes den gewünschten Gerätetyp,
 und dann den Mode.
 
-Geben Sie dann die entsprechenden Werte für <Keys.SoftKey>DMX Line</Keys.SoftKey>, <Keys.SoftKey>Address</Keys.SoftKey>,
-<Keys.SoftKey>User Number</Keys.SoftKey> und <Keys.SoftKey>Legend</Keys.SoftKey> ein; dabei zeigt das Pult bereits eine
+Geben Sie dann die entsprechenden Werte für <Keys.SoftKey>DMX Line</Keys.SoftKey>, <Keys.SoftKey>Address</Keys.SoftKey>, <Keys.SoftKey>User Number</Keys.SoftKey> und <Keys.SoftKey>Legend</Keys.SoftKey> ein; dabei zeigt das Pult bereits eine
 passende Vorbelegung (z.B. nächste freie Adresse).
 
-Betätigen Sie eine oder mehrere Schaltflächen im
-Geräte(Fixtures)-Fenster, um die Geräte zu patchen, oder patchen Sie mit
-den blauen Tasten direkt auf einzelne Fader.  (Siehe [Geräte und Dimmer patchen](../patching/patching-new-fixtures-or-dimmers.md)).
+Betätigen Sie eine oder mehrere Schaltflächen im Geräte(Fixtures)-Fenster, um die Geräte zu patchen, siehe [Geräte und Dimmer patchen](../patching/patching-new-fixtures-or-dimmers.md).
 
 Um mehrere gleiche Geräte oder mehrere Dimmer auf einmal zu patchen,
 wählen Sie mehrere Geräte-Schaltflächen aus, indem Sie darüber
-streichen, oder geben Sie die Anzahl mit <Keys.SoftKey>Quantity</Keys.SoftKey> ein. (Bei
-Fadern/Tasten: die erste Taste gedrückt halten und dazu eine weitere
-Taste drücken).
+streichen, oder geben Sie die Anzahl mit <Keys.SoftKey>Quantity</Keys.SoftKey> ein. 
 
-Um die DMX-Adresse oder das Universum zu ändern, wählen Sie <Keys.SoftKey>Repatch Fixtures</Keys.SoftKey> (siehe [Repatch Fixtures](../patching/changing-the-patch.md#ändern-der-dmx-adresse-im-patch-menü)).
+Um die DMX-Adresse oder das Universum bereits gepatchter Geräte zu ändern, wählen Sie <Keys.SoftKey>Repatch Fixtures</Keys.SoftKey> (siehe [Repatch Fixtures](../patching/changing-the-patch.md#ändern-der-dmx-adresse-im-patch-menü)) 
+oder verwenden die unten beschriebene Patchansicht.
+
+Um bereits verwendete Geräte durch Geräte eines anderen Typs zu ersetzen, patchen Sie die neuen Fixtures auf die Gerätebuttons der bereits vorhanden und 
+wählen <Keys.SoftKey>Exchange Fixture</Keys.SoftKey>  (siehe [Geräte austauschen](../patching/changing-the-patch.md#geräte-austauschen)). 
 
 ## Patch anzeigen
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/programming-cues-and-chases.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/programming-cues-and-chases.md
@@ -1,0 +1,76 @@
+---
+id: programming-cues-and-chases
+title: Programmieren von Cues und Chasern
+sidebar_label: Programmieren von Cues und Chasern
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Cues
+
+Stellen Sie die Geräte/Werte wie gewünscht ein.
+
+Drücken Sie <Keys.HardKey>Record</Keys.HardKey>.
+
+Stellen Sie <Keys.SoftKey>Record Mode</Keys.SoftKey> auf 'Channel' (es werden nur die geänderten
+Attribute gespeichert), 'Fixture' (Speichern aller Attribute der
+gewählten/geänderten Geräte), 'Stage' (Speichern sämtlicher Attribute
+aller aktiven Geräte, d.h. mit Dimmer \> 0), oder ‚Quick Build'
+(Erstellen des Cues aus Paletten oder Playbacks je nach Schaltfläche).
+
+Zum Speichern drücken Sie die **Auswahltaste** eines Faders, eine Macro-/Executor-Taste oder
+betätigen Sie eine Schaltfläche im ‚Playbacks'-Fenster (siehe [Erstellen eines Cues](../cues/creating-a-cue.md)).
+
+## Chaser
+
+Drücken Sie zweimal <Keys.HardKey>Record</Keys.HardKey> (oder <Keys.HardKey>Record</Keys.HardKey> und dann <Keys.SoftKey>Create Chase</Keys.SoftKey>).
+
+Drücken Sie die **Auswahltaste** eines Faders, eine Macro-/Executor-Taste, oder betätigen Sie eine
+Schaltfläche im ‚Playbacks'-Fenster.
+
+Stellen Sie Geräte/Attribute für den ersten Chase-Step ein, und drücken
+Sie wieder die Taste/Schaltfläche zum Speichern, Wiederholen Sie diesen
+Vorgang für alle Chase-Schritte. Mit ‚Quick Build' können rasch aus
+einzelnen Paletten und Cues Chase-Steps erstellt werden.
+
+Drücken Sie zum Abschluss <Keys.HardKey>Exit</Keys.HardKey> (siehe [Einen Chaser programmieren](../chases/creating-a-chase.md#einen-chaser-programmieren)).
+
+## Timings
+
+Sämtliche (Fade-)Zeiten, sowohl für Cues als auch für einzelne
+Attribute, werden ebenfalls im Programmierspeicher verwaltet und ggf.
+beim Speichern eines Cues berücksichtigt.
+
+Zum Einstellen der im Programmierspeicher vorgemerkten Zeiten drücken
+Sie die Taste <Keys.HardKey>Times</Keys.HardKey> (vormals <Keys.HardKey>Set</Keys.HardKey> auf dem Quartz/Titan Mobile/Sapphire
+Touch/Tiger Touch II bzw. <Keys.HardKey>Next Time</Keys.HardKey> auf dem Pearl Expert/Tiger
+Touch).
+
+Sobald ein Chase gestartet ist, kann Geschwindigkeit und Crossfade mit
+den Rädern A und B eingestellt werden.
+
+Das Ändern der Zeiten bereits gespeicherter Cues erfolgt im Hauptmenü:
+drücken Sie <Keys.SoftKey>Edit Times</Keys.SoftKey>, und dann die Auswahltaste/Schaltfläche des
+Cues/Chasers. Die Menütasten bieten nun verschiedene Timing-Optionen.
+
+&nbsp;<Keys.SoftKey>Fixture Overlap</Keys.SoftKey> verändert das 'Überlappen' (Gleichzeitigkeit) der
+Geräte: 100% = alle fahren/blenden gleichzeitig; 0% = alle
+fahren/blenden nacheinander, siehe [Fixture Overlap](../cues/cue-timing.md#einstellen-von-überblendzeiten-und-geräteversatz).
+
+Mit <Keys.SoftKey>Attribute times</Keys.SoftKey> lassen sich für einzelne Attribute
+unterschiedliche Zeiten vergeben.
+
+Mit <Keys.SoftKey>Fixture order</Keys.SoftKey> lässt sich die Reihenfolge der Geräte für Shapes
+sowie für das [Überlappen](../cues/cue-timing.md#einstellen-von-überblendzeiten-und-geräteversatz) einstellen.
+
+Siehe auch [Zeiten für Cues](../cues/cue-timing.md).
+
+## Cuelisten
+
+Cues lassen sich in [Cuelisten](../cue-lists/creating-a-cue-list.md) 
+speichern, so dass die gesamte Show per Go-Taste gefahren werden kann. 
+Ebenso lassen sich Chaser per [Autoload](../cue-lists/creating-a-cue-list.md#autoloading-laden-eines-externen-cues) in
+Cuelisten aufrufen. Cuelisten können im Tracking- oder
+Non-Tracking-Modus arbeiten; diese Einstellung kann in den
+<Keys.SoftKey>Optionen</Keys.SoftKey> der Cueliste vorgenommen werden. 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/programming-palettes.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/programming-palettes.md
@@ -1,0 +1,59 @@
+---
+id: programming-palettes
+title: Programmieren von Paletten
+sidebar_label: Programmieren von Paletten
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Stellen Sie die zu speichernden Attribute wie gewünscht ein. Ist ein
+Attribut bei allen Geräten dieses Typs gleich (etwa Farben oder
+Gobos), so genügt zum Speichern ein Gerät, und die Palette wird als
+‚shared' (gemeinsam genutzt) angelegt.
+
+Drücken Sie <Keys.HardKey>Record</Keys.HardKey>, <Keys.HardKey>Palette</Keys.HardKey> (siehe auch Schnellspeichern, s.u.).
+
+Wählen Sie <Keys.SoftKey>Set Mask</Keys.SoftKey>, um die zu speichernden Attribute auszuwählen.
+Beim Schnell­speichern von Paletten in die jeweiligen Palettenfenster
+werden die zu speichernden Attribute automatisch gewählt.
+
+Klicken Sie auf eine Schaltfläche in einem
+der Fenster ‚Colours', ‚Positions' oder ‚Gobos and Beams'.
+
+Siehe [Erstellen von Paletten](../palettes/creating-palettes.md).
+
+Zum Aufrufen einer Palette wählen Sie die gewünschten Geräte aus,
+stellen nun ggf. die Maske der abzurufenden Attribute mit den
+Attribut-Tasten ein und betätigen dann die gewünschte
+Paletten-Taste/Schaltfläche.
+
+Zum Eingeben einer Legende drücken Sie <Keys.SoftKey>Set Legend</Keys.SoftKey> und dann die
+Paletten-Taste/Schaltfläche. Zum Zeichnen wählen Sie <Keys.SoftKey>Picture</Keys.SoftKey>.
+
+## Schnellspeichern
+
+Betätigen Sie eine freie Schaltfläche in einem der Paletten-Fenster;
+diese zeigt daraufhin ein ‚+' auf rotem Grund. Betätigen Sie die
+Schaltfläche zum Speichern nochmals. Die Maske wird automatisch anhand
+des Fensters gewählt (z.B. werden so im Positions-Fenster nur Positionen
+gespeichert). Siehe [Schnellspeichern von Paletten](../palettes/creating-palettes.md#schnellspeichern).
+
+## Improvisieren mit Paletten
+
+Um beim Improvisieren einer Show Paletten mit Fadezeit abzurufen, wählen
+Sie die Geräte, geben die gewünschte Überblendzeit per
+Zifferntasten ein und rufen dann die Paletten auf (die Überblendzeit
+muss bei jedem Aufruf eingegeben werden). Wurden keine Geräte
+ausgewählt, so wird die Palette auf ALLE Geräte angewendet.
+
+Um eine [Überlappung](../palettes/timing-with-palettes.md#manuelle-geräteüberlappung-beim-palettenabruf) einzugeben, tippen Sie mit den Zifferntasten einen
+Wert von 0...100, drücken dann <Keys.SoftKey>Set Overlap</Keys.SoftKey> und rufen schließlich
+die Palette auf.
+
+Um für alle Paletten eine [generelle Einblendzeit](../palettes/timing-with-palettes.md#master-zeit-und-overlap-für-paletten) einzustellen, drücken
+Sie <Keys.HardKey>Palette</Keys.HardKey>, dann <Keys.SoftKey>Master Time</Keys.SoftKey>.
+
+Mit Einblendzeit aufgerufene Paletten werden nicht in den
+Programmierspeicher übernommen; beim Programmieren sollte diese Option
+also nicht verwendet werden.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/tips-and-tricks.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/quick-start/tips-and-tricks.md
@@ -1,0 +1,76 @@
+---
+id: tips-and-tricks
+title: Tipps und Tricks
+sidebar_label: Tipps und Tricks
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Im folgenden Abschnitt werden Wege zum schnellen Arbeiten mit Titan aufgelistet. Dabei werden die Tastendrücke wie folgt beschrieben:
+
+``<n>`` : geben Sie mit dem Ziffernblock eine Zahl ein. 
+
+"<Keys.HardKey>Avo</Keys.HardKey> + ": halten Sie die (erste) Taste gedrückt.
+
+## Gerät steuern und Speichern
+
+-  Alle Geräte anwählen: <Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>ALL</Keys.HardKey> <Keys.HardKey>ALL</Keys.HardKey> <Keys.HardKey>ALL</Keys.HardKey>
+-  Alle Geräte mit Output > 0 anwählen: <Keys.HardKey>Select If</Keys.HardKey> <Keys.HardKey>Select If</Keys.HardKey>
+-  Ausgewählte Geräte auf 100% stellen (im Programmer): <Keys.HardKey>@</Keys.HardKey><Keys.HardKey>@</Keys.HardKey>
+-  Ausgewählte Geräte auf ``<n>`` % stellen (im Programmer): <Keys.HardKey>@</Keys.HardKey> ``<n>`` <Keys.HardKey>Enter</Keys.HardKey> (der Wert wird in 0...99% angegeben, wenn nicht in den Benutzereinstellungen anders angegeben)
+-  Clear mit Fadezeit: ``<n>`` <Keys.HardKey>Clear</Keys.HardKey> cleart über die angegebene Zeit
+-  &nbsp;<Keys.HardKey>Wheel @</Keys.HardKey> Tasten: Schnellzugriff auf Freeze, Off, oder On für das gerade auf dem entsprechenden Wheel liegende Attribut. Per Doppelklick wird der entsprechende Wert auf 100% gesetzt, wenn es sich um einen Prozent-Bereich handelt (z.B. Dimmer, RGB oder CMY). [(mehr dazu)](../controlling-fixtures/changing-fixture-attributes.md#adjusting-attributes-with-the--buttons)
+-  Anzeigen/Auswählen der Zellen von Fixtures: <Keys.HardKey>Unfold</Keys.HardKey>, dann die Geräte auswählen.
+-  Geräte nach Schema (gerade, ungerade etc.) wählen: <Keys.HardKey>Group</Keys.HardKey> gedrückt halten und aus dem Menü wählen
+-  Schnelle Auswahl nach Schema: Geräte oder Gruppe wählen, dann <Keys.HardKey>ALL</Keys.HardKey>, um nach einem bestimmten Schema auszuwählen (gerade, ungerade, jedes x-te etc.)
+-  Alle Zellen in den gerade angewählten Geräten auswählen: <Keys.HardKey>.</Keys.HardKey> <Keys.HardKey>Enter</Keys.HardKey> 
+-  Festlegen, was gespeichert wird: 1 x <Keys.HardKey>Record</Keys.HardKey> speichert einen Cue, 2 x speichert einen Chase, 3 x speichert eine Cueliste, 4 x speichert eine Timeline
+-  Schnellaufruf Palette speichern: <Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>Palette</Keys.HardKey>
+-  Schnellaufruf Gruppe speichern: <Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>Group</Keys.HardKey>
+-  Schnellaufruf Macro speichern: <Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>Macro</Keys.HardKey>
+-  Speichern von Zeiten in Paletten/Cues: <Keys.HardKey>Time</Keys.HardKey> legt die Zeit im Programmer für nachfolgende Speichervorgänge fest
+-  Timecode eingeben: <Keys.HardKey>Through</Keys.HardKey> und <Keys.HardKey>And</Keys.HardKey> wirken als links/rechts-Tasten, um zwischen Stunden/Minuten/Sekunden/Frames zu navigieren
+-  "Move" (Verschieben) auf Pulten ohne Move-Taste: <Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>COPY</Keys.HardKey>
+-  Mehrfaches Verschieben/Kopieren/Löschen: mit der Taste <Keys.HardKey>Latch Menu</Keys.HardKey> kann das jeweilige Menü eingerastet werden. Drücken Sie also erst <Keys.HardKey>COPY</Keys.HardKey>, <Keys.HardKey>MOVE</Keys.HardKey> oder <Keys.HardKey>Delete</Keys.HardKey> gefolgt von <Keys.HardKey>Latch Menu</Keys.HardKey>, um in dem jeweiligen Menü zu bleiben.
+
+## Steuern der Show
+
+-  BPM/Rate direkt einstellen: ``<n>`` eingeben, dann den gewünschten Master anwählen
+-  Macro ``<n>`` -mal ausführen: ``<n>`` eingeben, dann das Macro aufrufen
+-  Fadezeit des folgenden Cues überschreiben: ``<n>`` <Keys.HardKey>GO</Keys.HardKey> 
+-  Alle laufenden Playbacks releasen: <Keys.HardKey>Release</Keys.HardKey> <Keys.HardKey>Release</Keys.HardKey>
+-  Schnellaufruf Mask FX erstellen: <Keys.HardKey>Mask FX</Keys.HardKey> <Keys.HardKey>Mask FX</Keys.HardKey> für die ausgewählten Geräte (oder für alle, wenn keins ausgewählt ist)
+-  Legenden für Seiten auf dem Wing eingeben: <Keys.SoftKey>Set Legend</Keys.SoftKey> <Keys.HardKey>Go Page</Keys.HardKey> (auf dem Wing).
+
+## Anzeigen, Menüs und Fenster
+
+-  Patch-Ansicht: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Patch</Keys.HardKey>
+-  Fixtures-Fenster: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Fixture</Keys.HardKey>
+-  Gruppen-Fenster: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Group</Keys.HardKey>
+-  Macros-Fenster: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Macro</Keys.HardKey>
+-  Attribute Editor: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Options</Keys.HardKey>
+-  Aktive Playbacks: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Off</Keys.HardKey>
+-  Positions-Paletten: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Position</Keys.HardKey>
+-  Farb-Paletten: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Colour</Keys.HardKey>
+-  Gobos&Beams-Paletten: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Gobo</Keys.HardKey> (oder <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Beam</Keys.HardKey>)
+-  Shape-Paletten: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Shape</Keys.HardKey>
+-  Intensitäts-Ansicht: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Intensity</Keys.HardKey>
+-  Cuelisten-Anzeige der aktuell gesteuerten Cueliste: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Connect/Cue</Keys.HardKey>
+-  Exit aller Menüs zum Hauptmenü: <Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>EXIT</Keys.HardKey>, das beendet auch Unfold
+-  Textsuche in Menüs: das Menü aufrufen und den gesuchten Text mit der Tastatur eingeben.
+-  scheinbar fehlende Menüpunkte: Suchleiste überprüfen, ob eventuell ein Suchtext eingegeben wurde
+-  Fenster zu klein: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Min/Max</Keys.HardKey> zum Wiederherstellen der ursprünglichen Größe
+-  Fenster auf anderes Display verschieben: <Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>Size/Position</Keys.HardKey> 
+-  Alle Fenster schließen: <Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>Close</Keys.HardKey>
+-  Einen Workspace löschen: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Delete</Keys.HardKey> <Keys.ContextKey>Workspace</Keys.ContextKey>
+-  Einen Workspace-Button verschieben/kopieren: <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Move</Keys.HardKey> <Keys.ContextKey>Workspace</Keys.ContextKey> oder <Keys.HardKey>Open/View</Keys.HardKey> <Keys.HardKey>Copy</Keys.HardKey> <Keys.ContextKey>Workspace</Keys.ContextKey>
+-  Capture-Kamera mit den Wheels steuern: Kontextmenü <Keys.ContextKey>Camera Move</Keys.ContextKey>, dann mit den Encodern wie gewünscht steuern
+
+## Einrichtung, Betriebssystem, Hardware
+
+-  Schnellzugriff Show speichern: <Keys.HardKey>DISK</Keys.HardKey> <Keys.HardKey>DISK</Keys.HardKey>
+-  beim Patchen den nächsten freien Kanal finden: in der Patch-Ansicht im Kanal-Balken auf den unbelegten Bereich klicken. Befindet man sich dabei gerade im Patch-Menü, so wird die nächste freie Adresse direkt als Vorschlag übernommen.
+-  Uhr des Pultes stellen: in der Leiste am oberen Rand auf die Uhr klicken. Bitte vorher unbedingt die Zeitzone überprüfen und ggf. korrigieren, um zu vermeiden, dass die Lizenz ungültig wird.
+-  Helligkeit von Pultleuchte und Display: System-Menü öffnen (<Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>DISK</Keys.HardKey>), nun kann die Helligkeit mit den Wheels eingestellt werden (nicht bei allen Pulten)
+-  wenn einzelne Tasten defekt sind: Das Virtual Panel aus dem <Keys.SoftKey>Tools</Keys.SoftKey> Menü kann verwendet werden, bis eine Reparatur erfolgt.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/remote-control.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/remote-control.md
@@ -1,0 +1,31 @@
+---
+id: remote-control
+title: Fernsteuerung
+sidebar_label: Fernsteuerung
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Verbindet man die Software/das Pult mit einem WLAN, so kann man auf einem Android- oder iOS-Gerät 
+(Smartphone oder Tablett) die **Titan Remote** App verwenden, um Titan drahtlos zu steuern.
+Dies ist insbesondere hilfreich beim Installieren und Testen der Geräte und beim Einleuchten. 
+Ebenso lassen sich mit der Fernsteuerung Cues und Paletten abrufen und speichern.
+
+Die **Titan Remote** App steht im [Google Play Store](https://play.google.com/store/apps/details?id=com.avolites.titanremote) und im [Apple App
+Store](https://apps.apple.com/ky/app/titan-remote/id688791174) zum Download bereit.
+
+> Ältere Versionen der App liefen immer nur mit der passenden Softwareversion auf dem Pult zusammen,
+  entsprechend lagen auch die Apps in unterschiedlichen Versionen vor. Dies ist nun nicht mehr der Fall,
+  und die Titan Remote App hat auch keine Versionsnummer mehr im Namen.
+  
+![Titan Remote - Android App Screenshot](/docs/images/Remote-Tablet-View.png)
+
+Es lassen sich auch mehrere Fernsteuerungen gleichzeitig mit einem Pult verbinden, wobei das Pult voll 
+funktionsfähig bleibt. Jede Remote arbeitet wie ein eigener Benutzer in einem Mehrbenutzersystem und
+verfügt über einen **eigenen Programmierspeicher**, so dass z.B. ein Programmierer mit der Remote und 
+ein anderer unabhängig davon mit dem Pult arbeiten kann.
+
+- Um am Pult den Programmer der Remote zu löschen (womit alle auf der Remote vorgenommenen Änderungen 
+verlorengehen), halten Sie <Keys.HardKey>Clear</Keys.HardKey> gedrückt und wählen aus dem 
+Menü <Keys.SoftKey>Clear all programmers</Keys.SoftKey>.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/remote-control.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/remote-control.md
@@ -21,6 +21,8 @@ Store](https://apps.apple.com/ky/app/titan-remote/id688791174) zum Download bere
   
 ![Titan Remote - Android App Screenshot](/docs/images/Remote-Tablet-View.png)
 
+Das Layout der Anzeige der Remote hängt von der Displaygröße ab und kann nicht verändert werden.
+
 Es lassen sich auch mehrere Fernsteuerungen gleichzeitig mit einem Pult verbinden, wobei das Pult voll 
 funktionsfähig bleibt. Jede Remote arbeitet wie ein eigener Benutzer in einem Mehrbenutzersystem und
 verfügt über einen **eigenen Programmierspeicher**, so dass z.B. ein Programmierer mit der Remote und 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/remote-control/operating-the-remote.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/remote-control/operating-the-remote.md
@@ -1,0 +1,128 @@
+---
+id: operating-the-remote
+title: Verwenden der Titan Remote-App
+sidebar_label: Verwenden der Titan Remote-App
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Im Kapitel [Einrichten der Fernsteuerung](setting-up-the-remote.md) wird beschrieben,
+wie ein Mobilgerät (Handy oder Tablett) mit Titan verbunden wird.
+
+![Titan Remote Android App status bar](/docs/images/Remote-Topbar.png)
+
+Die Titelleiste der App zeigt den Verbindungsstatus an:
+- grün: gute Verbindung. In der rechten Ecke wird die Antwortzeit angezeigt. 
+- rot: Verbindung unterbrochen oder sehr langsam (Antwortzeit über eine Sekunde). 
+- orange: Verbindung langsam (Antwortzeit über 250ms).
+
+> Wird eine rote oder orange Titelleiste angezeigt, so sollte die Verbindung überprüft und z.B. der 
+Standort des Access-Points geändert werden, so dass eine freie Sichtlinie zwischen diesem und dem Mobilgerät besteht.
+
+Mit den Buttons **Keypad / Fixture / Group / Palette / Cue** wählen Sie, was gesteuert werden soll. 
+Mit der Taste Keypad werden die Zifferntasten ein- oder ausgeblendet (diese verdecken ggf. andere Anzeigen).
+
+Einige Buttons können für erweiterte Funktionen länger gedrückt gehalten werden. Diese Buttons werden 
+mit einem Kreissymbol angezeigt.
+
+Die Anzeige der App variiert mit der Bildschirmauflösung Ihres Gerätes. Auf Tabletts und Geräten mit großen 
+Bildschirmen lassen sich mehr Fenster gleichzeitig anzeigen.
+
+Auf Mobiltelefonen ist die Anzeige immer hochkant (Portrait); auf Tabletts wird die Anzeige durch die Orientierung beim Starten der App bestimmt. iPads können auch bei laufender App die Anzeige an die Orientierung anpassen. Die App berücksichtigt die Systemeinstellungen für den Dark Mode (Hell/Dunkel-Umschaltung).
+
+## Keypad -- Tastatur
+
+Mit der Tastatur lassen sich die häufigsten Aufgaben genauso wie auf dem Pult erledigen. Fixtures 
+und Dimmer können einzeln oder zu mehreren ausgewählt, locatet und aktiviert werden.
+
+![Titan Remote Android App with keypad](/docs/images/Remote-Keypad.png)
+
+Die Steuerung erfolgt unter Verwendung der Gerätenummern (die Nummer in der oberen linken Ecke der 
+Geräte-Buttons). Möchte man z.B. Dimmer Nr. 3 auf 50% setzen, so lautet die Eingabe
+
+**`3 @ 5 Enter`**
+
+Um die Dimmer 1 bis 10 auf 80% zu setzen:
+
+**`1 Thro 10 @ 8 Enter`**
+
+Für 100% klicken Sie zweimal auf @, z.B.
+
+**`1 Thro 10 @ @`**
+
+> Um ein oder mehrere Geräte auf Locate-Werte zu setzen, klicken Sie statt
+auf @ auf <Keys.SoftKey>Locate</Keys.SoftKey>.
+
+Es können mehrere Bereiche von Geräten mit der AND-Taste ausgewählt
+werden, z.B.
+
+**`1 Thro 10 And 20 Thro 30 @ 6 Enter`**.
+
+## Auswählen von Geräten
+
+Mit den Fenstern **Fixture** und **Group** lassen sich Geräte genauso wie auf dem Pult anwählen. 
+Sind viele Geräte zu verwalten, so ist die Verwendung von Gruppen zu empfehlen. In diesem Fall 
+kann mit **Highlight** das aktuell gesteuerte Gerät angezeigt, mit **Prev** bzw. **Next** vor- und zurückgegangen 
+sowie mit **All** alle Geräte der Gruppe ausgewählt werden. Hält man **All** gedrückt, so kann 
+man Geräte nach Muster auswählen, z.B. even/odd (gerade/ungerade).
+
+![Fixture View in Titan Remote Android App](/docs/images/Remote-Fixtures.png)
+
+Zum Scrollen im Fixture-Screen wischt man einfach in diesem Fenster (Klicken und Ziehen). Um auf eine 
+andere Seite zu wechseln, klickt und zieht man die Titelleiste des Fensters nach unten.
+
+## Steuern von Attributen
+
+Mit den Buttons **IPCGBES** wählen Sie die zu steuernde Attributgruppe. Darauf werden Schieberegler
+für die einzelnen Funktionen angezeigt.
+
+![Colour Control in Titan Remote Android App](/docs/images/Remote-Colour-Attributes.png)
+
+Für variable Werte wie z.B. Pan, Tilt oder die Farbmischung können die Fader einfach angeklickt und 
+gezogen werden. Mit den Pfeilen oben und unten kann man direkt auf 0% und 100% springen. Zum 'Fannen' 
+(Auffächern) - stets mit dem Muster 'Line' - klicken sie den gewünschten Fader mit zwei Fingern an und spreizen 
+diese (oder ziehen sie zusammen), wie vom Zoom gewohnt.
+
+Für Attribute mit festen Wertebereichen, z.B. Farb- oder Goboräder, wird der jeweilige Name angezeigt. 
+Mit den Pfeilen unten und oben kann zwischen den einzelnen Farben, Gobos etc. gewechselt werden.
+
+Gibt es mehr als drei Attribute in der jeweiligen Attributgruppe des Gerätes, klicken Sie zum 
+Durchschalten wiederholt auf den entsprechenden **IPCGBES**-Button.
+
+Klicken Sie auf <Keys.SoftKey>Clear</Keys.SoftKey>, um den Programmierspeicher der Remote zu
+löschen. Wenn Sie <Keys.SoftKey>Clear</Keys.SoftKey> länger anklicken, so werden alle
+Programmierspeicher gelöscht, also auch der des Pultes. Das kann
+sinnvoll sein, wenn dort versehentlich noch etwas aktiv ist, was bei der
+Verwendung der Remote stört.
+
+- Nach der Verwendung der Remote drücken Sie **Clear**, um den Programmer der Remote zu löschen, ansonsten 
+bleiben vorgenommene Änderungen erhalten und überschreiben die Informationen vom Pult. Vom Pult aus lässt 
+sich der Programmer der Remote löschen, indem man am Pult <Keys.HardKey>Clear</Keys.HardKey> gedrückt hält 
+und im Menü <Keys.SoftKey>Clear all programmers</Keys.SoftKey> wählt. Ist ein anderer Programmer aktiv, so 
+wird das mit einem Punkt in Cyan bei den betroffenen Attributen angezeigt.
+
+In der **Cue**-Ansicht können auch im Fenster 'Playbacks' gespeicherte 
+Cues gestartet werden. Hält man die Schaltfläche eines aktiven Cues 
+angeklickt, so kann man diesen deaktivieren oder releasen (freigeben).
+
+- Cues, die auf normalen Fader-Handles gespeichert sind, stehen in der 
+  Remote nicht zur Verfügung. Um diese verwenden zu können, kopieren/verschieben 
+  sie die gewünschten Cues ins Playbacks-Fenster.
+
+## Speichern von Paletten, Gruppen und Cues
+
+Mit der Remote lassen sich auch Paletten, Gruppen und Cues speichern: nehmen
+Sie die gewünschten Einstellungen vor, klicken Sie auf <Keys.SoftKey>Rec</Keys.SoftKey> und dann
+auf eine Schaltfläche in der entsprechenden Ansicht. Ebenso kann man
+einfach eine leere Schaltfläche länger gedrückt halten (Quick Record) --
+das ist gleichbedeutend mit dem Doppelklick auf dem Pult.
+
+Wird etwas programmiert, so kann man auch die Legende - als Text oder als Bild - eingeben. Ebenso kann man einen 
+bereits programmierten Button länger anklicken, um dessen Legende einzugeben.
+
+![Remote edit legend](/docs/images/Remote-Legend.png)
+
+Beim Speichern auf eine bereits bestehende Palette kann man wählen zwischen Merge (Verschmelzen) und Replace (Ersetzen).
+
+Beim Speichern von Cues wird der aktuell am Pult eingestellte Speichermodus (Record By Fixture, Record By Channel) verwendet.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/remote-control/programming-touch-panels.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/remote-control/programming-touch-panels.md
@@ -1,0 +1,64 @@
+---
+id: programming-touch-panels
+title: Using touch panels
+sidebar_label: Using Touch Panels
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Multiple D3-Touch control panels can be connected to a Titan control system by Ethernet. The touch panels provide
+simple control of 8 playbacks in 4 playback groups. This is useful for venue staff to control working lights, house lights or simple show states.
+
+Users can also trigger up to 8 macros and lock/unlock the panel.
+
+![D3-Touch](/docs/images/D3-touch-front.png)
+
+
+
+## Connecting the touch panel
+
+Touch panels are connected into the Titan system by wired Ethernet. You can use a Power-over-Ethernet (PoE) equipped network switch, a PoE injector
+or a DC adaptor to power the panel.
+
+You will need to set suitable IP addresses on the console and on the touch panel or configure DHCP on your network to automatically provide suitable addresses -
+read more about [Networking the Console](../networking.md).
+
+## Programming playbacks for the touch panel
+
+The touch panel allows the user to select one of four Playback Groups. Within a playback group only one playback can be active, the others automatically turn off (see [Playback Groups](../running-the-show/playback-controls.md#playback-groups)). The touch panel shows playback groups with the user numbers 1001-1004.
+
+The legend on the touch screen buttons is taken from the playback legend set on the console. The colour of the button is set by the halo colour of the playback.
+
+To configure a Playback Group to appear on the touch panel, do this:
+
+1. Create a Playback Group containing the playbacks you want to be shown (see [Playback Groups](../running-the-show/playback-controls.md#playback-groups)).
+2. At the top level menu press <Keys.SoftKey>Set Legend</Keys.SoftKey> then the select button for the Playback Group.
+3. Press <Keys.SoftKey>User Number=</Keys.SoftKey> and set a number between 1001-1004.
+4. Press <Keys.SoftKey>Legend=</Keys.SoftKey> or <Keys.SoftKey>Picture</Keys.SoftKey> and provide a legend for the button.
+5. If you wish, set the button colour by pressing <Keys.SoftKey>Halo</Keys.SoftKey> and selecting a colour.
+6. Repeat steps 2-5 to set the Legend/Colour for each playback in the Playback Group.
+
+- Each Playback Group to be displayed on the touch panel must have a unique number between 1001-1004. The Playback Groups are displayed in numerical order.
+
+## Programming macros for the touch panel
+
+By touching the Macro button (bottom left), the touch panel shows eight user macros, with the user numbers 1001-1008.
+To configure a macro to be shown on the touch panel, do this:
+
+1. Record a macro (see [Macros](../titan-basics/front-panel-buttons.md#key-macro-buttons))
+2. At the top level menu press <Keys.SoftKey>Set Legend</Keys.SoftKey> then the select button for the macro.
+3. Press <Keys.SoftKey>User Number=</Keys.SoftKey> and set a number between 1001-1008.
+4. Press <Keys.SoftKey>Legend=</Keys.SoftKey> or <Keys.SoftKey>Picture</Keys.SoftKey> and provide a legend for the button.
+5. If you wish, set the button colour by pressing <Keys.SoftKey>Halo</Keys.SoftKey> and selecting a colour.
+
+- Each macro to be displayed on the touch panel must have a unique number between 1001-1008. The macros are displayed in numerical order.
+
+
+## Locking / unlocking the touch panel
+
+The touch panel can be locked by pressing the Lock icon in the bottom right of the screen.
+The Passcode to unlock is set in the **Lock** tab of [User Settings](../system-settings/user-settings.md#lock). 
+(Numeric codes only).
+
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/remote-control/programming-touch-panels.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/remote-control/programming-touch-panels.md
@@ -1,64 +1,61 @@
 ---
 id: programming-touch-panels
-title: Using touch panels
-sidebar_label: Using Touch Panels
+title: Verwenden von Touch-Panels
+sidebar_label: Verwenden von Touch-Panels
 ---
 
 import Keys from '@site/src/components/key.ts';
 import Video from '@site/src/components/video.tsx';
 
-Multiple D3-Touch control panels can be connected to a Titan control system by Ethernet. The touch panels provide
-simple control of 8 playbacks in 4 playback groups. This is useful for venue staff to control working lights, house lights or simple show states.
+Durch Verbinden mehrerer D3-Touch-Panels per Ethernet kann ein größeres Titan-Steuerungssystem aufgebaut werden. Dabei ermöglichen 
+die Panels einen einfachen Weg der Steuerung, für bis zu 8 Playbacks in vier Playback-Gruppen. Damit kann dem Hauspersonal die Steuerung 
+z.B. des Arbeitslichts, des Hauslichts oder auch einfacher Lichtstimmungen für die Show ermöglicht werden.
 
-Users can also trigger up to 8 macros and lock/unlock the panel.
+Ebenso können bis zu acht Macros verwendet sowie das Panel ge- und entsperrt werden.
 
 ![D3-Touch](/docs/images/D3-touch-front.png)
 
 
 
-## Connecting the touch panel
+## Ein Touch-Panel verbinden
 
-Touch panels are connected into the Titan system by wired Ethernet. You can use a Power-over-Ethernet (PoE) equipped network switch, a PoE injector
-or a DC adaptor to power the panel.
+Touch-Panels werden per kabelgebundenem Ethernet mit dem Titan-System verbunden. Die Stromversorgung erfolgt per Power-over-Ethernet (PoE)
+durch einen entsprechenden Switch, mit einem PoE-Injektor, oder über ein Steckernetzteil.
 
-You will need to set suitable IP addresses on the console and on the touch panel or configure DHCP on your network to automatically provide suitable addresses -
-read more about [Networking the Console](../networking.md).
+Auf dem Pult und auf dem Panel müssen passende IP-Adressen eingestellt werden, oder man aktiviert DHCP. Mehr dazu siehe [Netzwerkeinrichtung](../networking.md).
 
-## Programming playbacks for the touch panel
+## Programmieren von Playbacks für das Touch-Panel
 
-The touch panel allows the user to select one of four Playback Groups. Within a playback group only one playback can be active, the others automatically turn off (see [Playback Groups](../running-the-show/playback-controls.md#playback-groups)). The touch panel shows playback groups with the user numbers 1001-1004.
+Auf dem Touch-Panel kann jeweils eine von vier Playback-Gruppen ausgewählt werden. Innerhalb einer solchen Gruppe kann immer nur ein Playback aktiv sein, d.h. die Playbacks deaktivieren sich gegenseitig (siehe [Playback-Gruppen](../running-the-show/playback-controls.md#playback-gruppen)). Auf dem Touch-Panel werden die Playback-Gruppen mit den Nummern 1001-1004 verwendet.
 
-The legend on the touch screen buttons is taken from the playback legend set on the console. The colour of the button is set by the halo colour of the playback.
+Die auf dem Touch-Panel angezeigten Legenden kommen von den in Titan eingestellten Legenden, die Farbe der Buttons ist die Halo-Farbe der Playbacks in Titan.
 
-To configure a Playback Group to appear on the touch panel, do this:
+Um eine Playbackgruppe zu erstellen, die auf dem Touch-Panel verwendet werden kann, gehen Sie wie folgt vor:
 
-1. Create a Playback Group containing the playbacks you want to be shown (see [Playback Groups](../running-the-show/playback-controls.md#playback-groups)).
-2. At the top level menu press <Keys.SoftKey>Set Legend</Keys.SoftKey> then the select button for the Playback Group.
-3. Press <Keys.SoftKey>User Number=</Keys.SoftKey> and set a number between 1001-1004.
-4. Press <Keys.SoftKey>Legend=</Keys.SoftKey> or <Keys.SoftKey>Picture</Keys.SoftKey> and provide a legend for the button.
-5. If you wish, set the button colour by pressing <Keys.SoftKey>Halo</Keys.SoftKey> and selecting a colour.
-6. Repeat steps 2-5 to set the Legend/Colour for each playback in the Playback Group.
+1. Erstellen Sie in Titan eine Playback-Gruppe aus den zu verwendenden Playbacks, siehe [Playback-Gruppen](../running-the-show/playback-controls.md#playback-gruppen).
+2. Drücken Sie im Hauptmenü auf <Keys.SoftKey>Set Legend</Keys.SoftKey> und wählen die Auswahltaste der gewünschten Playback-Gruppe.
+3. Drücken Sie auf <Keys.SoftKey>User Number=</Keys.SoftKey> und vergeben eine Nummer zwischen 1001 und 1004.
+4. Drücken Sie auf <Keys.SoftKey>Legend=</Keys.SoftKey> oder <Keys.SoftKey>Picture</Keys.SoftKey> und geben eine Legende ein (Name oder Skizze/Bild).
+5. Falls gewünscht, können Sie <Keys.SoftKey>Halo</Keys.SoftKey> drücken und eine Farbe für den Button wählen.
+6. Wiederholen Sie die Schritte 2-5 für die anderen Playbacks der Gruppe.
 
-- Each Playback Group to be displayed on the touch panel must have a unique number between 1001-1004. The Playback Groups are displayed in numerical order.
+- Jede Playback-Gruppe, die auf dem Touch-Panel angezeigt werden soll, muss eine eindeutige Nummer zwischen 1001 und 1004 erhalten. Die Playback-Gruppen werden in der Reihenfolge der Nummern angezeigt.
 
-## Programming macros for the touch panel
+## Programmieren von Macros für das Touch-Panel
 
-By touching the Macro button (bottom left), the touch panel shows eight user macros, with the user numbers 1001-1008.
-To configure a macro to be shown on the touch panel, do this:
+Klickt man auf dem Touch-Panel auf den Button 'Macros' (unten links), so werden auf dem Panel die Macros mit den Nummern 1001-1008 angezeigt.
+Zum Erstellen eines Macros für das Touch-Panel gehen Sie wie folgt vor:
 
-1. Record a macro (see [Macros](../titan-basics/front-panel-buttons.md#key-macro-buttons))
-2. At the top level menu press <Keys.SoftKey>Set Legend</Keys.SoftKey> then the select button for the macro.
-3. Press <Keys.SoftKey>User Number=</Keys.SoftKey> and set a number between 1001-1008.
-4. Press <Keys.SoftKey>Legend=</Keys.SoftKey> or <Keys.SoftKey>Picture</Keys.SoftKey> and provide a legend for the button.
-5. If you wish, set the button colour by pressing <Keys.SoftKey>Halo</Keys.SoftKey> and selecting a colour.
+1. Speichern Sie ein Macro (siehe [Macros -- Tastnfolgen](../titan-basics/front-panel-buttons.md#macros----tastenfolgen))
+2. Drücken Sie im Hauptmenü auf <Keys.SoftKey>Set Legend</Keys.SoftKey> und wählen den Button des gewünschten Macros.
+3. Drücken Sie auf <Keys.SoftKey>User Number=</Keys.SoftKey> und vergeben eine Nummer zwischen 1001 und 1008.
+4. Drücken Sie auf <Keys.SoftKey>Legend=</Keys.SoftKey> oder <Keys.SoftKey>Picture</Keys.SoftKey> und geben eine Legende ein (Name oder Skizze/Bild).
+5. Falls gewünscht, können Sie <Keys.SoftKey>Halo</Keys.SoftKey> drücken und eine Farbe für den Button wählen.
 
-- Each macro to be displayed on the touch panel must have a unique number between 1001-1008. The macros are displayed in numerical order.
-
-
-## Locking / unlocking the touch panel
-
-The touch panel can be locked by pressing the Lock icon in the bottom right of the screen.
-The Passcode to unlock is set in the **Lock** tab of [User Settings](../system-settings/user-settings.md#lock). 
-(Numeric codes only).
+- Jedes Macro, das auf dem Touch-Panel angezeigt werden soll, muss eine eindeutige Nummer zwischen 1001 und 1008 erhalten. Die Macros werden in der Reihenfolge der Nummern angezeigt.
 
 
+## Sperren/Entsperren des Touch-Panels
+
+Mit dem Button mit dem Schloss-Symbol unten rechts kann das Panel gesperrt werden.
+Der Code zum Entsperren kann in den Benutzereinstellungen des Pultes gesetzt werden (siehe [Benutzereinstellungen - Lock](../system-settings/user-settings.md#lock)). Es sind nur Ziffern als Passcode möglich.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/remote-control/setting-up-the-remote.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/remote-control/setting-up-the-remote.md
@@ -1,0 +1,46 @@
+---
+id: setting-up-the-remote
+title: Einrichten der Fernsteuerung
+sidebar_label: Einrichten der Fernsteuerung
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Pult und Remote müssen über Netzwerk und WLAN verbunden sein. Wie immer bei Netzwerken 
+für den Showbetrieb empfehlen wir ein separates Netzwerk, das nicht mit dem Internet oder 
+anderen Geräten verbunden ist.
+
+Am einfachsten ist es, das Pult direkt mit einem WLAN-Accesspoint zu verbinden.
+
+Der Accesspoint sollte so aufgestellt sein, dass zwischen dem Mobilgerät und dem Accesspoint 
+eine freie Sichtlinie besteht.
+
+Auf dem Pult und dem Accesspoint sind passende IP-Adressen einzustellen, siehe [Netzwerkeinrichtung](../networking.md).
+
+## Verbinden des Mobilgeräts
+
+Sowohl bei Android- als auch bei Apple-Geräten kommt eine Fehlermeldung, sobald man sich mit 
+einem Netzwerk ohne Internetzugang verbindet. Bei Apple-Geräten wird neben dem Netzwerknamen dauerhaft 
+ein sich drehendes Icon angezeigt, das man aber ignorieren kann. Bei Android-Geräten kommt eine Rückfrage, 
+ob man sich wirklich verbinden möchte; diese beantwortet man mit "Always Connect" (immer verbinden).
+
+Ist im Netzwerk keine automatische Adressvergabe per DHCP aktiviert, so muss am Mobilgerät manuell eine 
+passende IP-Adresse im gleichen Bereich wie die des Pultes eingestellt werden, 
+siehe [Netzwerkeinrichtung](../networking.md). Bei Android-Geräten muss anstelle der Subnetz-Maske eine entsprechende
+Netzwerkpräfix-Länge (Network Prefix Length) eingestellt werden. Bei einem Subnetz 255.0.0.0 ist der Präfix 8, bei 255.255.0.0 ist er 16, bei 255.255.255.0 ist er 24.
+
+## Auswahl des Pultes in der App
+
+Sobald das Mobilgerät mit dem Netzwerk verbunden ist, öffnen Sie die Titan Remote App. Hier wird eine Liste 
+der im Netzwerk vorhandenen Titan-Pulte angezeigt.  Am unteren Rand stehen Details der Netzwerkverbindung, 
+die ggf. bei der Fehlersuche hilfreich sein können.
+
+![Titan Remote App connection screen](/docs/images/Remote-Connection-Screen.png)
+
+mit dem Titan Emulator lässt sich die Remote testen und vorführen, ohne mit einem Pult verbunden zu sein.
+
+Je nach Netzwerk kann es sein, dass das Pult nicht in der Liste angezeigt wird. In diesem Fall klicken Sie oben rechts 
+auf das + und geben die IP-Adresse des Pultes manuell ein. Daraufhin wird auch das angegebene Pult in der Liste angezeigt.
+
+Um ein manuell hinzugefügtes Pult wieder aus der Liste zu löschen, wischen Sie dieses nach links und klicken dann auf den Button **Delete**.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show.md
@@ -1,0 +1,205 @@
+---
+id: running-the-show
+title: Steuern der Show
+sidebar_label: Steuern der Show
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+It's Showtime! In diesem Kapitel werden die Funktionen des Pultes während des Showablaufs erläutert.
+
+## Sichern der Show
+
+Das Wichtigste während des Programmierens, am Ende des Programmierens,
+und beim Beginn der Show, ist das [Sichern der Daten](./titan-basics/loading-and-saving-shows.md#die-show-speichern). 
+Ein Backup kann sowohl auf der internen Festplatte als auch auf einem 
+USB-Stick gespeichert werden. Der USB-Stick empfiehlt sich
+insbesondere, um die Show auch auf ein anderes Pult transferieren zu
+können.
+
+## Das Pult beschriften
+
+Während der Show ist es wichtig zu wissen, was denn nun wo programmiert
+ist. Beschriften Sie Ihr Pult, entweder mit der elektronischen
+Beschriftung/Bemalung (siehe [Legenden und Bezeichnungen](./titan-basics/workspace-windows.md/#legenden-und-bezeichnungen)), oder mit Klebeband und Stift.
+
+## Display-Ansicht speichern
+
+Es lassen sich diverse **Workspaces** (Arbeitsumgebungen) einrichten, die
+ihrerseits die Anordnung und Anzeige der verschiedenen Fenster
+speichern. Diese Arbeitsumgebungen lassen sich auf den Schaltflächen
+links der Menütasten (linker Bildschirmrand beim Diamond 9, Diamond 7, Sapphire Touch und Titan 
+Go sowie bei externen Displays) speichern und abrufen. Workspaces lassen 
+sich auch auf Executor-Tasten speichern.
+
+Drücken Sie zweimal auf <Keys.HardKey>Open/View</Keys.HardKey>, um die Auswahl der anzuzeigenden 
+Fenster einzublenden. Siehe [Auswahl und Positionierung der Arbeitsfenster](./titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster)
+für weitere Details zu den verschiedenen Fenstern.
+
+Man kann auch die Workspaces per [Set List](./running-the-show/set-list-window.md) 
+ passend zum jeweiligen Song umschalten.
+
+## Das Pult sperren
+
+Das Pult lässt sich sperren, um unbeabsichtigte oder unbefugte Eingriffe
+zu verhindern. Es lässt sich eine Grafik einstellen, die bei gesperrtem Pult angezeigt wird.
+Ebenso kann ein Workspace definiert werden, der als *Venue Mode* angezeigt wird, so dass 
+bei gesperrtem Zustand z.B. nur die Playbacks zur Verfügung stehen und das Personal das Licht einschalten kann.
+
+Bei gesperrtem Pult sind sämtliche Funktionen deaktiviert, abgesehen vom
+DMX-Ausgang und den aktuell laufenden Playbacks.
+
+1. Halten Sie dazu <Keys.HardKey>AVO</Keys.HardKey> gedrückt.
+2. Klicken Sie auf <Keys.SoftKey>Lock</Keys.SoftKey>.
+3. Geben Sie nun ein Passwort ein (Buchstaben oder Ziffern).
+4. Drücken Sie <Keys.SoftKey>Lock</Keys.SoftKey>.
+5. Zum Entsperren muss das gleiche Passwort wieder eingegeben werden.
+
+Die Eingabeaufforderung für das Passwort wird nach einigen Sekunden der Inaktivität ausgeblendet, erscheint aber 
+sofort wieder, sobald eine Taste betätigt oder der Bildschirm angetippt wird.
+
+Sie können ein **Programmer Password** speichern, so dass Sie nicht immer wieder das Passwort zum Sperren eingeben müssen. Dazu klicken Sie bei Schritt 3 auf <Keys.SoftKey>Set Saved Password</Keys.SoftKey> (auch möglich im Tab 'Lock' der Benutzereinstellungen). Ist ein 'Programmer Password' gespeichert, so kann man Schritt 3 überspringen und das Pult einfach mit <Keys.HardKey>Avo</Keys.HardKey> <Keys.SoftKey>Lock</Keys.SoftKey> <Keys.SoftKey>Lock</Keys.SoftKey> sperren.
+
+> Das Pult kann jederzeit mit dem Code "68340" entsperrt werden. <br/>
+  Durch das Sperren und das Passwort ist die Show weder verschlüsselt noch sonstwie geschützt. Es handelt sich um eine einfache Sperre, um ungewollte - versehentliche oder mutwillige - Bedienung des Pultes zu verhindern.
+
+### Hintergrundbild für den Sperrbildschirm
+
+Man kann extra ein Bild als Hintergrundbild für den Sperrbildschirm festlegen. Drücken Sie dazu <Keys.HardKey>Avo</Keys.HardKey> und wählen das Menü <Keys.SoftKey>User Settings</Keys.SoftKey> (Benutzereinstellungen). Auf der Seite **Lock** kann man bei **Lock Screen Background** ein Bild laden oder eine Grafik zeichnen.
+
+Wird ein Bild geladen, so kann man mit der Option <Keys.SoftKey>Scaling Mode</Keys.SoftKey> einstellen, wie das Bild auf den/die Displays skaliert wird:
+
+-   None: keine Skalierung, das Bild wird in Originalgröße angezeigt
+-   Letterbox: skaliert, bis entweder Breite oder Höhe formatfüllend
+    dargestellt werden, und lässt ansonsten schwarze Ränder
+-   Fill: skaliert, bis das Bild in voller Breite oder Höhe dargestellt
+    wird.
+-   Stretch: Das Bild wird auf den gesamten Bildschirm aufgezogen und
+    ggf. verzerrt dargestellt
+
+Mit dem Button <Keys.SoftKey>Clear</Keys.SoftKey> wird ein eingestelltes Bild wieder gelöscht.
+
+Um ohne Skalierung den ganzen Bildschirm auszufüllen, müssen Bilder in diesem Format vorliegen:
+
+Konsole | Auflösung
+-- | --
+D9 (-330 / -215) | 1920 x 1080
+D7 (-330 / -215) | 1920 x 1200
+Sapphire Touch | 1366 x 786
+Arena | 1366 x 786
+Tiger Touch II | 1366 x 786
+Quartz | 1280 x 800
+TNP | 800 x 480
+
+### Eingeschränkter Zugriff mit dem Venue Mode
+
+Man kann einen Workspace definieren, der bei gesperrtem Pult aktiv ist und damit eingeschränkte Bedienung bietet. Dies ist der **Venue Mode** workspace. Damit kann man z.B. dem Personal Zugriff auf das Saallicht gestatten, ohne selbst am Pult zu sein. Das Pult kann so eingerichtet werden, dass es direkt in den Venue Mode startet (s.u.).
+
+1.  Speichern Sie einen Workspace mit den gewünschten Fenstern, z.B. dem Playbacks-Fenster oder mit virtuellen Fadern, auf die die gewünschten Lichtstimmungen gespeichert sind.
+2.  Rufen Sie die Einstellung **Venue Mode Workspace** auf der Seite **Lock** der Benutzereinstellungen auf (<Keys.HardKey>Avo</Keys.HardKey> gedrückt halten und <Keys.SoftKey>User Settings</Keys.SoftKey> drücken), und wählen Sie den gewünschten Workspace mit den Menütasten.
+3.  Soll der Venue Mode direkt beim Starten des Pultes aktiv sein, setzen Sie ein **Programmer Password** und stellen Sie  **Lock on Startup** auf **Venue mode** (s.u.).
+4.  Sperren Sie das Pult wie oben beschrieben. Darauf erscheint der angegebene Workspace.
+5.  Um das Pult zu entsperren, klicken Sie auf <Keys.SoftKey>Programmer Mode</Keys.SoftKey> rechts oben und geben das gesetzte Passwort ein.
+
+![Venue Mode example](/docs/images/venue-mode.png)
+
+Die Hardware-Tasten des Pultes sind im gesperrten Zustand deaktiviert. Nur die folgenden Fenster können als Venue Mode workspace verwendet und bedient werden:
+
+-  Alle Fenster, in die gespeichert werden kann (Colours, Playbacks, Media, etc.)
+-  Active Playbacks
+-  Audio Triggers
+-  Capture Visualiser
+-  Channel Grid
+-  DMX
+-  Event Log
+-  Intensity View
+-  Pioneer DJ
+-  Pixel Map Preview
+-  Playback Groups
+-  Timecode Windows
+-  Video Multi View
+-  Virtual Faders
+
+Die Auswahl von Fixtures ist deaktiviert. Quick Palettes können aber verwendet werden.
+
+>   Menüs sind im Venue Mode deaktiviert. Damit gehen auch Macros nicht, die Menüs oder damit verknüpfte Funktionen aufrufen. Auch Funktionen, bei denen eine Taste mehrfach gedrückt werden muss, gehen im Venue Mode nicht, denn auch diese benötigen das Menüsystem (Beispiel: Doppelklick auf <Keys.HardKey>Release</Keys.HardKey> zum Aufruf der Funktion *Release All*). 
+
+### Direkt in den Venue Mode starten
+
+Mit der Einstellung **Lock on Startup** auf der Seite **Lock** der [Benutzereinstellungen](./system-settings/user-settings.md#lock) kann man einstellen, in welchen Status das Pult bzw. die Software nach dem Neustart startet unabhängig davon, wie es vorher heruntergefahren wurde. 
+
+- Damit das Pult im Venue Mode oder im gesperrten Zustand startet, muss ein **Programmer Password** vergeben werden.
+
+Ggf. ist es sinnvoll, in den Benutzereinstellungen auf dem Reiter **Lock** ein **Venue Mode Password** einzustellen. 
+Um das Pult zu sperren, klicken Sie rechts oben auf <Keys.SoftKey>Lock</Keys.SoftKey>. Damit wird der normale 
+Sperrbildschirm angezeigt. Gibt man nun zum Entsperren das 'Venue Mode Passwort' ein, so öffnet sich der 
+'Venue Mode workspace', und man hat eingeschränkten Zugriff.
+
+Ebenso lässt sich einstellen, dass immer die gleiche Show beim Programmstart geladen wird, auch wenn vor dem 
+Herunterfahren eine andere Show aktiv war. Dazu dient die Option **Start Up Show** im Disk-Menü, siehe [Eine Show zum automatischen Starten festlegen](./titan-basics/loading-and-saving-shows.md#eine-show-zum-automatischen-starten-festlegen).
+
+## Verwenden der 'Move'-Funktion
+
+Wenn im Laufe des Programmierens die Anordnung von Paletten, Geräten und
+Speicherplätzen etwas unübersichtlich geworden ist, ist es an der Zeit,
+mit der 'Move'-Funktion wieder aufzuräumen. Beim Verschieben der
+programmierten Details bleiben sämtliche logischen Bezüge und
+Verknüpfungen selbstverständlich erhalten.
+
+Das Verschieben von Geräten, Paletten, Gruppen und Speicherplätzen ist
+sehr einfach:
+
+1.  Drücken Sie <Keys.HardKey>Move</Keys.HardKey> (ist diese Taste nicht vorhanden dann <Keys.HardKey>AVO</Keys.HardKey> 
+und dazu die Taste <Keys.HardKey>Copy</Keys.HardKey>).
+2.  Betätigen Sie die **Auswahltasten** der zu verschiebenden Dinge.
+3.  Drücken Sie die **Auswahltasten**, auf die verschoben werden soll.
+
+Beim Verschieben eines kompletten Bereichs kann es passieren, dass
+dieser verschiedene Dinge und auch unbelegte Plätze enthält. In diesem
+Falle lässt mit den Menütasten <Keys.SoftKey>Bunch Up</Keys.SoftKey> (Zusammenfassen) wählen, um
+sämtliche Lücken in dem Bereich zu entfernen.
+
+Mit <Keys.SoftKey>Swap Items if Required</Keys.SoftKey> (Verschieben falls erforderlich) wird
+versucht, einzelne Speicherplätze, die dem Verschieben im Wege wären,
+woandershin zu verschieben. Dies bietet sich an, wenn die aktuelle Seite
+nahezu voll ist.
+
+-   Steht nicht genügend Platz zur Verfügung (ist z.B. etwas im Weg,
+    oder ist nicht genügend Platz am Ende der Seite), so wird das
+    Verschieben scheitern.
+
+-   Wenn Sie mehrere Dinge nacheinander verschieben wollen, können Sie die
+    Move-Funktion mit der Taste <Keys.HardKey>Latch Menu</Keys.HardKey> einrasten, um sie nicht
+    jedes Mal erneut aufrufen zu müssen.
+
+## Blind-Modus
+
+Sollen noch schnell ein paar kleine Änderungen an Cues oder Paletten mit
+Hilfe des Visualisers vorgenommen werden, ohne den Live-Betrieb zu
+stören, lässt sich das Pult auch in den Blind-Modus schalten. Dazu
+drückt man die Taste <Keys.HardKey>Blind</Keys.HardKey> (nicht alle Pulte verfügen nicht über diese
+-- in diesem Fall hält man <Keys.HardKey>Avo</Keys.HardKey> gedrückt und wählt den Menüpunkt
+&nbsp;<Keys.SoftKey>Blind</Keys.SoftKey>). Im Blind-Modus haben Änderungen der Programmierung keinen 
+Einfluss auf das Ausgangssignal, nur bereits programmierte Playbacks funktionieren wie gewohnt. Die 
+Taste <Keys.HardKey>Blind</Keys.HardKey> leuchtet, und im Info-Bereich steht **BLIND MODE**.
+
+Um wieder zum **Live-Modus** zurückzukehren, drücken Sie wieder auf <Keys.HardKey>Blind</Keys.HardKey>.
+
+Um ein Playback zu überprüfen, kann man das Playback selbst Blind
+schalten. Dazu hält man die <Keys.HardKey>Blind</Keys.HardKey>-Taste und drückt die Auswahltaste des
+Playbacks. Um das Playback wieder Live zu schalten, geht man
+genauso vor. Playbacks können auch über die Playback-Optionen Blind
+geschaltet werden.
+
+Dabei kann von der eingestellten Blind-Stimmung sanft in den
+Live-Betrieb übergeblendet werden, ohne dass man erst ein Playback
+speichern muss. Ebenso kann man im Blind die nächste Stimmung aus
+mehreren Paletten kombinieren und dann in diese einfaden. (Noch
+einfacher geht das mit dem [Scene Master](./running-the-show/playback-controls.md#scene-master)).
+
+Um nach Live überzublenden, tippen Sie mit den Zifferntasten die gewünschte Zeit
+in Sekunden ein und drücken die <Keys.HardKey>Blind</Keys.HardKey>-Taste.
+
+-  Sind im Programmer Attribut-Zeiten gesetzt worden, so haben diese
+Vorrang vor der manuell eingegebenen Zeit.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show.md
@@ -86,6 +86,7 @@ Konsole | Auflösung
 -- | --
 D9 (-330 / -215) | 1920 x 1080
 D7 (-330 / -215) | 1920 x 1200
+D3 | 1280 x 800
 Sapphire Touch | 1366 x 786
 Arena | 1366 x 786
 Tiger Touch II | 1366 x 786
@@ -200,6 +201,3 @@ einfacher geht das mit dem [Scene Master](./running-the-show/playback-controls.m
 
 Um nach Live überzublenden, tippen Sie mit den Zifferntasten die gewünschte Zeit
 in Sekunden ein und drücken die <Keys.HardKey>Blind</Keys.HardKey>-Taste.
-
--  Sind im Programmer Attribut-Zeiten gesetzt worden, so haben diese
-Vorrang vor der manuell eingegebenen Zeit.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/linking-consoles-for-multi-user-or-backup.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/linking-consoles-for-multi-user-or-backup.md
@@ -1,0 +1,72 @@
+---
+id: linking-consoles-for-multi-user-or-backup
+title: Backup und Mehrbenutzerbetrieb
+sidebar_label: Backup und Mehrbenutzerbetrieb
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Bei größeren Shows ist es mitunter nötig, mit mehreren Programmierern
+gleichzeitig an der Show zu arbeiten. Titan ermöglicht dies für mehrere
+Pulte, sowie für jeden Benutzer unterschiedliche Einstellungen
+
+Mitunter ist es auch erforderlich, parallel ein Backup-Pult mitlaufen zu
+haben, um im Fehlerfall nahtlos weiterarbeiten zu können. Mit Titan kann
+ein zweites Pult per Netzwerk eingebunden werden und wird laufend mit
+dem Hauptpult synchronisiert. Im schlimmsten Falle lässt sich dann mit
+einem Tastendruck am Backup-Pult die Kontrolle übernehmen.
+
+>  Alle Pulte in einer Session müssen auf der gleichen Titan-Version 
+   laufen. Für die Titan PC-Suite (Simulator, Titan Go, Titan Mobile) 
+   kann es erforderlich sein, die Firewall zu deaktivieren.
+
+## Pulte für den Mehrbenutzerbetrieb einrichten
+
+Mehrere Titan-Pulte können zum Mehrbenutzerbetrieb miteinander vernetzt
+werden, Details siehe [Mehrbenutzer-Betrieb](../titan-basics/multi-user-operation.md).
+
+## Pulte für den Backup-Betrieb einrichten
+
+Jedes Titan-Pult kann als Backup für jedes andere Titan-Pult fungieren,
+es muss sich also nicht um das gleiche Modell handeln. So kann z.B. auch
+ein Laptop und T3 als Backup für ein größeres Pult verwendet werden.
+
+Dabei gilt es natürlich zu bedenken, auf welche Teile der Programmierung
+man im Zweifel Zugriff braucht, da manche Pulte weniger Fader/Knöpfe als
+andere haben. Gute Vorplanung ist dafür essentiell.
+
+1.  Verbinden Sie beide Pulte mit dem gleichen Netzwerk und geben Sie
+    passende IP-Adressen aus einem Bereich ein.<br/>
+    Details siehe [Netzwerk](../networking.md).
+2.  Auf dem Pult, welches als Backup verwendet werden soll, drücken 
+    Sie <Keys.HardKey>Disk</Keys.HardKey>, dann <Keys.SoftKey>TitanNet Sessions</Keys.SoftKey>, 
+    dann <Keys.SoftKey>Backup</Keys.SoftKey>.
+3.  Es werden nun die im Netzwerk gefundenen Titan-Pulte aufgelistet.
+4.  Wählt man eines der angezeigten Pulte aus, so wird das aktuelle Pult
+    zum Backup-Pult für das ausgewählte, und die Show von diesem wird
+    synchronisiert.
+5.  Auf dem Backup-Pult wird der Backup-Status sowie der Name der Show angezeigt.
+
+![TitanNet Backup Healthy](/docs/images/TitanNet-Backup-Healthy.png)
+
+Eine grüne Linie zwischen den Pulten markiert eine stabile Verbindung.
+Verbindungsprobleme werden durch eine rote Linie angezeigt. Während
+laufender Synchronisationsvorgänge erscheint die Linie in blau.
+
+![TitanNet Backup Faulted](/docs/images/TitanNet-Backup-Faulted.png)
+
+-   Showdaten werden automatisch synchronisiert, wenn auf dem Hauptpult
+    die Show gesichert wird, ebenso bei Autosave. Außerdem kann man auf
+    dem Backup-Pult jederzeit per <Keys.SoftKey>Sync Now</Keys.SoftKey> die Synchronisierung
+    veranlassen.
+
+-   Mit <Keys.SoftKey>Exit</Keys.SoftKey> wird der Backup-Modus beendet.
+
+-   Mit <Keys.SoftKey>Takeover</Keys.SoftKey> übernimmt das Backup-Pult die Kontrolle, und die
+    DMX-Ausgänge am Hauptpult werden deaktiviert. Dabei erscheint im
+    Infobereich (oben rechts auf dem Display) eine entsprechende
+    Meldung. Auf Geräten mit Touchscreen kann man darauf klicken und
+    gelangt in das Menü "Exit Safe Mode", in dem wiederum die Ausgänge
+    wieder aktiviert werden können. Auf dem Pearl Expert findet man
+    diese Funktion im <Keys.HardKey>Avo</Keys.HardKey>-Menü.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/linking-consoles-for-multi-user-or-backup.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/linking-consoles-for-multi-user-or-backup.md
@@ -19,7 +19,9 @@ einem Tastendruck am Backup-Pult die Kontrolle übernehmen.
 
 >  Alle Pulte in einer Session müssen auf der gleichen Titan-Version 
    laufen. Für die Titan PC-Suite (Simulator, Titan Go, Titan Mobile) 
-   kann es erforderlich sein, die Firewall zu deaktivieren.
+   kann es erforderlich sein, die Firewall zu deaktivieren. Pulte mit weniger
+   DMX-Linien als das Hauptpult können nicht als Backup-Pult verwendet werden. 
+   Siehe [DMX-Ausgänge einrichten](../system-settings/dmx-output-mapping.md) mit Details zu den Limits der einzelnen Pulte.
 
 ## Pulte für den Mehrbenutzerbetrieb einrichten
 
@@ -28,9 +30,9 @@ werden, Details siehe [Mehrbenutzer-Betrieb](../titan-basics/multi-user-operatio
 
 ## Pulte für den Backup-Betrieb einrichten
 
-Jedes Titan-Pult kann als Backup für jedes andere Titan-Pult fungieren,
-es muss sich also nicht um das gleiche Modell handeln. So kann z.B. auch
-ein Laptop und T3 als Backup für ein größeres Pult verwendet werden.
+Unterschiedliche Titan-Pulte können gegenseitig als Backup verwendet werden. Dabei ist jedoch zu beachten,
+dass das Backup-Pult mindestens genauso viele DMX-Linien ermöglichen muss wie das Hauptpult. Notfalls kann auch ein 
+TNP verwendet und über das Frontdisplay bedient werden.
 
 Dabei gilt es natürlich zu bedenken, auf welche Teile der Programmierung
 man im Zweifel Zugriff braucht, da manche Pulte weniger Fader/Knöpfe als

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/linking-pioneerdj-system-to-titan.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/linking-pioneerdj-system-to-titan.md
@@ -1,0 +1,150 @@
+---
+id: linking-pioneerdj-system-to-titan
+title: Pioneer ProDJ-Decks mit Titan verknüpfen
+sidebar_label: Pioneer ProDJ-Decks mit Titan verknüpfen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Mit der Software Pioneer Pro DJ Link Bridge können BPM-Master innerhalb
+von Titan durch geeignete Pioneer DJ-Systeme gesteuert werden. Die
+Bridge-Software kann dabei direkt auf dem Titan-Pult oder einem externen
+Laptop laufen.
+
+>   Dieses System ist aktuell mit folgenden Geräten verfügbar:<br/>
+    CDJ-TOUR1<br/>
+    DJM-TOUR1<br/>
+    CDJ-2000NXS2<br/>
+    DJM-900NXS2<br/>
+    CDJ-3000 (seit Titan v15.1) 
+
+<Video videoId="vwr1DBJjBbw" title="PioneerDJ Integration" />
+
+## Titan und das Pioneer-System verbinden
+
+Titan und das Pioneer-System müssen sich im gleichen Netzwerk befinden.
+Die Pioneer-Geräte gestatten keine explizite Netzwerk-Konfiguration. Es
+ist vielmehr ein DHCP-Server oder eine automatische Adressvergabe per
+mDNS erforderlich, zu erkennen an einer automatischen Adresse wie
+169.254.\*.\* Nutzt man gleichzeitig Art-Net oder sACN im gleichen
+Netzwerk, so kann die Einrichtung kompliziert werden, da viele externe
+Geräte auf bestimmte Adressbereiche festgelegt sind.
+
+### Pioneer Bridge auf dem Pult
+
+Verwendet man Art-Net/sACN nicht oder hat getrennte
+Netzwerkschnittstellen zur Verfügung, dann kann Pioneer Bridge direkt
+auf dem Pult laufen. Dabei sollte man unbedingt einen Netzwerk-Switch
+verwenden; hat das Pult keinen solchen eingebaut (wie etwa das Arena),
+so ist ein externer Switch erforderlich.
+
+Starten Sie die Pro DJ Link Bridge Software über das Menü **Tools \>
+Additional Programs**.
+
+-   Wenn erforderlich lässt sich dies mit **Tools \> Control Panel \> 
+    Run on Startup** automatisch starten, etwa in Clubs, wo das Programm immer benötigt wird.
+
+![Pro-DJ link bridge command on shell menu](/docs/images/Pro-DJ-link-bridge-command-on-shell-menu-2.png)
+
+Auf dem Reiter 'Interface' zeigt die Bridge-Software die
+Netzwerkadresse an, die von den Pioneer-Geräten verwendet wird. Das
+Pult muss im gleichen Adressbereich sein. Verwendet man DHCP, so
+kann man auch das Pult zur Verwendung von DHCP einrichten, oder man
+vergibt eine geeignete Adresse statisch. Verwendet das
+Pioneer-System z.B. 169.254.225.212, so kann man das Pult auch
+statisch auf 169.254.225.1 setzen (wenn diese Adresse nicht
+anderweitig verwendet wird).
+
+![Pro-DJ link bridge command on shell menu](/docs/images/Pro-DJ-link-bridge-command-on-shell-menu.png)
+
+-   Ist alles richtig eingerichtet und verbunden, so zeigt die
+    Bridge-Software grüne Symbole sowohl für das Pult als auch das/die
+    Pioneer-Geräte.
+-   Manche Art-Net/sACN-Geräte können auch im Adressbereich
+    169.254.\*.\* betrieben werden. In diesem Fall funktioniert auch
+    Art-Net/sACN und Pioneer DJ über das gleiche Netzwerk.
+-   Eventuell muss 'Node Mode' in den 'TCNet'-Einstellungen von 'Client' auf 'Auto' geändert werden.
+    Für weitere Informationen siehe das [PRO DJ LINK Bridge Manual](https://support.pioneerdj.com/hc/en-us/articles/4404665824153) (externer Link).
+
+### Pioneer Bridge auf einem separaten Computer
+
+Will oder muss man die Bridge-Software auf einem separaten Computer
+laufen lassen, so kann man die Software einzeln von der Pioneer-Website
+herunterladen und installieren.
+
+Sind getrennte Netzwerkbereiche erforderlich, so benötigt man einen
+Computer mit zwei Netzwerkanschlüssen.
+
+Ist alles richtig eingerichtet und verbunden, so zeigt die
+Bridge-Software grüne Symbole sowohl für das Pult als auch das/die
+Pioneer-Geräte.
+
+## Das PioneerDJ-Fenster
+
+Zum Öffnen des Fensters drücken Sie zweimal auf <Keys.HardKey>Open/View</Keys.HardKey> und klicken
+auf den Button <Keys.SoftKey>PioneerDJ</Keys.SoftKey>.
+
+![Pioneer Workspace window](/docs/images/Pioneer-Workspace-window.png)
+
+Im oberen Bereich wird das Signal des laufenden Tracks groß
+(detailliert) und klein (dafür der ganze Track) angezeigt. Mehrere
+Tracks können übereinander angezeigt werden.
+
+Darunter werden Details zur jedem gerade laufenden Track eingeblendet.
+
+Ganz unten werden die verbundenen Pioneer-Decks grün angezeigt.
+
+Um einen Track als Master auszuwählen, klickt man links oder unten auf
+die Tracknummer. Der aktuell als Master verwendete Track wird durch ein
+rotes M angezeigt; dieser kann zum Steuern der BPM-Master verwendet
+werden.
+
+Mittels Kontextfunktionen lässt sich die Anzeige der einzelnen Elemente
+jeweils aktivieren oder abschalten (große und kleine Signalanzeige,
+Track-Details und Statusleiste).
+
+![Pioneer context menu buttons](/docs/images/Pioneer-context-menu-buttons.png)
+
+- Mit <Keys.SoftKey>Zoom</Keys.SoftKey> wird die Vergrößerung der großen Signalanzeige eingestellt.
+- Mit <Keys.SoftKey>Change Layout</Keys.SoftKey> kann zwischen verschiedenen Layouts des Fensters
+umgeschaltet werden:
+  - &nbsp;<Keys.SoftKey>Full</Keys.SoftKey> -- Anzeige aller laufenden Tracks
+  - &nbsp;<Keys.SoftKey>Master</Keys.SoftKey> -- Anzeige nur des aktuellen Master-Tracks
+  - &nbsp;<Keys.SoftKey>Condensed</Keys.SoftKey> -- Details werden für alle Tracks angezeigt, die
+Signalkurve aber nur für den aktuellen Master-Track. Der Master-Track
+kann durch Anklicken der Tracknummer im Detail-Bereich (unten) gewählt
+werden. 
+
+## BPM-Master per Pioneer DJ triggern
+
+Dazu muss zunächst ein [BPM Master](../running-the-show/playback-controls.md#optionen-für-bpm-master) 
+definiert werden. Für diesen kann dann wie folgt PioneerDJ als Trigger
+eingerichtet werden.
+
+Öffnen Sie das **System**-Menü (per <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>) und wählen 
+&nbsp;<Keys.SoftKey>Triggers</Keys.SoftKey>. Darauf öffnet sich das Fenster 'Trigger'.
+
+1. Fügen Sie mit dem <Keys.ContextKey>+</Keys.ContextKey> *unten links* ein neues Trigger-Set hinzu
+und geben Sie diesem einen geeigneten Namen, z.B. ‚Pioneer'.
+2. Legen Sie nun mit dem <Keys.ContextKey>+</Keys.ContextKey> *unten rechts* oder mit der Menütaste
+&nbsp;<Keys.SoftKey>Add Trigger</Keys.SoftKey> einen neuen Trigger an.
+3. Setzen Sie <Keys.SoftKey>Trigger Type</Keys.SoftKey> auf <Keys.SoftKey>Item</Keys.SoftKey>.
+4. Wählen Sie den zu steuernden BPM-Master (Auswahltaste/Button
+betätigen).
+5. Bei <Keys.SoftKey>Action</Keys.SoftKey> steht nun <Keys.SoftKey>PioneerDJ</Keys.SoftKey>, da dies momentan die einzige
+Option für BPM-Master ist. Bestätigen Sie das mit <Keys.SoftKey>OK</Keys.SoftKey>.
+6. Wählen Sie nun mit <Keys.SoftKey>Deck = </Keys.SoftKey>, welches Pioneer-Deck als Trigger
+verwendet werden soll. Wählt man <Keys.SoftKey>Master</Keys.SoftKey>, so wird immer das im
+PioneerDJ als Master definierte Deck verwendet (rotes M), wählt man
+dagegen Deck 1, 2, 3 oder 4, so wird stets dieses verwendet.
+7. Mit <Keys.SoftKey>Add</Keys.SoftKey> wird schließlich der Trigger eingerichtet und sollte
+ähnlich wie auf dem folgenden Bild aussehen.
+
+![Trigger workspace with Pioneer trigger added](/docs/images/Trigger-workspace-with-Pioneer-trigger-added.png)
+
+Damit ändert sich der Wert des BPM-Masters automatisch bei Änderungen
+des steuernden Tracks.
+
+-	Um den BPM-Master wieder manuell zu steuern, kann man den Schalter
+    <Keys.SoftKey>BPM Triggers</Keys.SoftKey> im PioneerDJ-Fenster ausschalten.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/midi-dmx-or-audio-triggering.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/midi-dmx-or-audio-triggering.md
@@ -1,0 +1,233 @@
+---
+id: midi-dmx-or-audio-triggering
+title: Externe Trigger
+sidebar_label: Externe Trigger
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Die meisten Bedienvorgänge des Pultes können durch verschiedene externe
+Events ferngesteuert - getriggert - werden. Dies bietet sich z.B. bei sehr
+komplexen Shows oder bei Installationen an, bei denen etwas
+automatisiert ablaufen muss.
+
+Die folgenden Triggerarten (Signale) sind möglich:
+
+- Audio (nicht bei allen Pulten)
+- DMX
+- GPIO (nicht bei allen Pulten)
+- MIDI (außer T1)
+- Streaming ACN
+
+> Audiotrigger (Sound to Light) erfordern spezielle Hardware und sind 
+auf dem Sapphire Touch, Tiger Touch, Titan Mobile, T1, T3 und dem Pearl 
+Expert **nicht** verfügbar. Eine bei anderen Pulten
+eventuell verfügbare Line-In-Buchse kann nicht als Sound-to-Light-Eingang 
+verwendet werden. Dagegen kann der T2 als Sound-Eingang für andere Pulte 
+dienen.
+
+GPIO steht nur auf dem Diamond 9, Diamond 7, dem Arena, dem Tiger Touch II und dem Sapphire Touch zur Verfügung.
+
+## Anschließen externer Steuerungen
+
+Der Audio-Eingang funktioniert nur über die eigens dafür vorhandene
+Klinkenbuchse beim Quartz und beim Arena. Der Audio-Eingang des
+Motherboards ist dafür nicht geeignet Andere Konsolen können mit dem T2
+als Audio-Eingang verwendet werden, siehe oben.
+
+Zur Steuerung per DMX muss eine der DMX-Buchsen als Eingang verwendet
+werden; dazu benötigt man einen simplen Stecker-Stecker-Adapter ('gender
+changer', alle Pins 1:1 belegt, also 1-1, 2-2, 3-3 etc.).
+
+GPIO nutzt einen simplen Schließkontakt, der per Klinkenbuchse 
+angeschlossen wird (nur beim Diamond 9, Diamond 7, beim Arena, dem Tiger Touch II und dem Sapphire 
+Touch verfügbar). Beim Diamond 9 und Diamond 7 stehen die GPIO-Kontakte auch auf dem 15-poligen SubD-Stecker zur Verfügung. 
+Für den TNP kann GPIO als Option nachgerüstet werden; wenden Sie sich dazu an Avolites oder Ihren Avolites-Vertrieb.
+
+MIDI-Geräte werden einfach mit der MIDI-In-Buchse verbunden.
+USB-MIDI-Geräte, die den DirectX MIDI-Treiber unterstützen, können
+ebenfalls verwendet werden (nicht am T1/Titan One). Damit kann z.B. ein
+T2 mit einem MIDI-Faderboard gesteuert werden.
+
+sACN wird ganz einfach per Netzwerk (Ethercon) angeschlossen.
+
+PioneerDJ-Decks können per Netzwerk als Taktgeber für BPM-Master
+verwendet werden, siehe [folgender Abschnitt](./linking-pioneerdj-system-to-titan.md). Dies ersetzt die frühere
+'Pro DJ Tap'-Funktion.
+
+## Einrichten der externen Steuerung
+
+Öffnen Sie das **System**-Menü (mittels <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>)
+und wählen Sie <Keys.SoftKey>Triggers</Keys.SoftKey>; darauf wird das Fenster 'Triggers' angezeigt.
+
+![Triggers Window](/docs/images/Triggers-Window.png)
+
+Links werden die verschiedenen Trigger-Mappings, also Kombinationen von
+Triggern, angezeigt; dabei ist ein Mapping für MIDI Show Control mit den bei
+MSC üblichen Steuerbefehlen bereits vorhanden (siehe nächstes Kapitel).
+
+Jedes dieser Trigger-Mappings kann durch den stilisierten Einschalt-Button
+(links neben dem Namen des Mappings) aktiviert oder deaktiviert werden. 
+Damit lässt sich ganz schnell die Steuerung des Pultes umkonfigurieren.
+
+Trigger werden wie folgt eingerichtet:
+
+1.  Beginnen Sie ein neues Trigger-Mapping, indem Sie *links unten* auf die
+&nbsp;<Keys.ContextKey>+</Keys.ContextKey>-Schaltfläche klicken und einen Namen eingeben. 
+2.  Zum Hinzufügen eines Triggers, also der Zuordnung eines Steuersignals zu einem Pult-Ereignis, 
+klicken Sie auf die <Keys.ContextKey>+</Keys.ContextKey>-Schaltfläche *rechts unten* oder drücken 
+die Menü-Taste <Keys.SoftKey>Add Trigger</Keys.SoftKey>.
+3.  Wählen Sie nun die Art der Steuerung (Trigger Type). 
+    - &nbsp;<Keys.SoftKey>Hardware</Keys.SoftKey> ist die Steuerung einer konkreten Taste oder 
+      eines bestimmten Faders (z.B. „Fader 10", „Flash-Taste 4"), ganz so als würde diese(r) per Hand bedient.
+    - &nbsp;<Keys.SoftKey>Item</Keys.SoftKey> ist hingegen die softwareseitige/logische Zuordnung 
+      („Palette 43", „Playback 91"), wobei die konkrete Funktion separat zu wählen ist.
+4. Betätigen Sie nun das zu steuernde Element des Pultes (Fader, Taste, Schaltfläche); das gewählte Element wird am Bildschirm angezeigt. Wurde vorher <Keys.SoftKey>Item</Keys.SoftKey> gewählt, lassen sich mit <Keys.SoftKey>Action</Keys.SoftKey> noch verschiedene Aktionen bestimmen: 
+    - Set Level (Playback auf den Level des Triggers setzen - s.u. zur Erklärung von *Level Match*)
+    - Fire At Level (wie Set Level, aber ohne Level Match, sowie mit 'Kill at 0' bei Cuelisten)
+    - Re-Fire at Level (jede Pegeländerung sorgt für ein Aktualisieren/Neustarten der LTP-Werte)
+    - Flash (wie die Flash-Taste)
+    - Swop (wie die Swop-Taste)
+    - Preload (startet nur die LTP-Werte)
+    - Latch (schaltet das Playback ein/aus)
+    Die Option <Keys.SoftKey>Level Match</Keys.SoftKey> bestimmt, was passiert, wenn das Playback
+    vorher bereits gestartet ist. Ist sie eingeschaltet (**On**), so muss der
+    aktuelle Pegel per Trigger übernommen werden, damit er aktiv wird. Ist
+    die Option dagegen ausgeschaltet (**Off**), so wirkt der Trigger immer, 
+    auch bei anderen Pegeln.
+5.  Klicken Sie <Keys.SoftKey>OK</Keys.SoftKey>.
+6.  Nun muss der vorher definierten Pult-Aktion ein Steuerimpuls
+zugeordnet werden. Wählen Sie also die Art der Steuerung - Audio, DMX,
+GPIO, MIDI oder Streaming ACN - mit <Keys.SoftKey>Trigger Type</Keys.SoftKey>.
+7.  Senden Sie nun den gewünschten Steuerimpuls (Stimulus): drücken Sie z.B. die gewünschte Taste auf Ihrem MIDI-Keyboard, oder aktivieren Sie den entsprechenden Kanal auf dem externen DMX-Pult. Ist die Option <Keys.SoftKey>Learn</Keys.SoftKey> aktiviert, erkennt das Pult automatisch den Steuerimpuls und ordnet ihn zu. Alternativ lassen sich die Daten manuell eingeben,
+    - Für Audiotrigger gibt es die Option <Keys.SoftKey>Band</Keys.SoftKey>, mit der das 
+    Frequenzband bestimmt werden kann; siehe [Audio Control](./midi-dmx-or-audio-triggering.md#audio-trigger-sound-to-light)
+    - Falls Sie DMX verwenden möchten, stellen Sie mit <Keys.SoftKey>DMX Port</Keys.SoftKey> 
+    den verwendeten DMX-Anschluss ein. Sobald ein DMX-Anschluss zum
+    Triggern verwendet wird, wechselt er in die Betriebsart Rx 
+    (Empfangen). Soll er wieder als Ausgang benutzt	werden, so 
+    weisen sie ihn in den [DMX-Einstellungen](../system-settings/dmx-output-mapping.md) wieder entsprechend zu.
+    Auch die DMX-Adresse kann auch manuell eingestellt werden.
+    - Für GPIO kann mit <Keys.SoftKey>Invert</Keys.SoftKey> zwischen Öffnern und Schließern
+    umgeschaltet werden.
+    Mit <Keys.SoftKey>Pin</Keys.SoftKey> kann bei künftigen Pulten der Pin des GPIO-Anschlusses gewählt werden.
+    - Für MIDI-Trigger kann man den MIDI-Kanal, den MIDI-Befehl, den Wert sowie den Bereich für die Velocity wählen.
+    - Für sACN ist das <Keys.SoftKey>Universe</Keys.SoftKey> und die <Keys.SoftKey>Adresse</Keys.SoftKey> einzustellen.
+8.  Klicken Sie <Keys.SoftKey>Add</Keys.SoftKey>, um den Trigger hinzuzufügen.
+9.  Im Bildschirm wird die gewählte Zuordnung angezeigt.
+
+Fügen Sie auf die gleiche Weise weitere Trigger hinzu.
+
+![Triggers Window with MIDI triggers](/docs/images/Triggers-Window-with-MIDI-triggers.png)
+
+Zum Löschen eines Triggers aus der Zuordnung wählen Sie diesen und
+betätigen die Schaltfläche mit dem <Keys.ContextKey>Papierkorb</Keys.ContextKey> *rechts unten*.
+
+Zum Löschen einer kompletten Zuordnungs-Tabelle (Mapping) wählen Sie
+diese und betätigen die Schaltfläche mit dem <Keys.ContextKey>Papierkorb</Keys.ContextKey> *links
+unten*.
+
+Die Trigger-Aktion "Re-Fire At Level" sorgt dafür, dass das jeweilige
+Playback bei jeder Änderung des Trigger-Pegels neu gestartet wird und
+die LTP-Werte aktualisiert werden. Macht dieses Playback z.B. die Geräte
+rot und ein anderes diese weiß, so sorgt ein Triggern mit 'Re-Fire'
+dafür, dass die Geräte immer wieder rot werden, während ein Triggern
+ohne 'Re-Fire' nur den Pegel setzt, die Lampen aber weiß lässt.
+
+### Einrichten eines MIDI Faderboards mit dem T2
+
+Ein USB-MIDI-Faderboard wird wie folgt mit dem T2 verbunden: schließen
+Sie es per USB and den PC an, auf dem die Titan-Software läuft, und
+stellen Sie sicher, dass es ordnungsgemäß in Windows funktioniert (die
+MIDI-Werte kann man u.a. mit der Software MIDI-Ox überprüfen).
+
+1.  Öffnen Sie das **System**-Menü mit <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey> und 
+    wählen Sie <Keys.SoftKey>Triggers</Keys.SoftKey>.
+2.  Fügen Sie links mit dem Button <Keys.ContextKey>+</Keys.ContextKey> eine neue
+    Trigger-Zusammenstellung (Mapping) hinzu und geben Sie ihr einen
+    passenden Namen, z.B. 'T2 Playbacks'.
+3.  Fügen Sie nun rechts mit dem Button <Keys.ContextKey>+</Keys.ContextKey> oder mit der Menütaste
+    <Keys.SoftKey>Add Trigger</Keys.SoftKey> einen neuen Trigger hinzu -- dieser wird als Trigger
+    Type: Hardware angelegt.
+4.  Bewegen Sie den ersten Fader in Titan Go.
+5.  Klicken Sie auf <Keys.SoftKey>OK</Keys.SoftKey>.
+6.  Bewegen Sie nun den ersten Fader des MIDI-Controllers. Titan
+    empfängt die empfangenen Werte und zeigt das durch eine Pegelanzeige an.
+7.  Klicken Sie auf <Keys.SoftKey>Add</Keys.SoftKey>. In der rechten Spalte wird wird der neu
+    angelegte Trigger angezeigt.
+8.  Wiederholen Sie den Vorgang ab Schritt 3 für weitere Fader.
+
+## MIDI Show Control
+
+Folgende MIDI Show Control-Befehle werden unterstützt:
+
+  Befehl    | Wirkung
+  --------- | -------------------------------
+  GO        | Playback/Cue starten
+  STOP      | Playback/Cue stoppen
+  RESUME    | Playback/Cue fortsetzen
+  LOAD      | Playback-Wert auf 100% setzen
+  ALL OFF   | Alle Playbacks releasen
+  RESET     | Wie ALL OFF
+  GO OFF    | Wie RESUME
+
+Playbacks/Cues werden durch die Benutzernummer identifiziert, diese wird
+über <Keys.SoftKey>Set Legend</Keys.SoftKey><Keys.SoftKey>User Number</Keys.SoftKey> eingestellt.
+
+Geräte mit MIDI Show Control werden durch eine Geräte-ID (device id)
+identifiziert. Zum Einstellen der Geräte-ID des Titan-Pultes dient die
+[Benutzereinstellung <Keys.SoftKey>Timecode</Keys.SoftKey><Keys.SoftKey>MIDI Device Id</Keys.SoftKey>](../system-settings/user-settings.md#midi-device-id). Vorgabewert ist 0.
+
+## Audio-Trigger (Sound to Light)
+
+Bei Pulten, die das unterstützen (momentan: Quartz und Arena), gibt es
+einen separaten Audio-Eingang. Das dort anliegende Signal wird in
+verschiedene Frequenzbänder geteilt, die einzeln als Trigger verwendet
+werden können. Mit der Option <Keys.SoftKey>Band</Keys.SoftKey> lässt sich das verwendete
+Frequenzband bestimmen.
+
+  Band	| Sound frequency
+  ------|---------------------------
+	1	| 50Hz
+	2	| 140Hz
+	3	| 380Hz
+	4	| 875Hz
+	5	| 2400Hz
+	6	| 6200Hz
+	7	| 14000Hz
+
+Zur genauen Einstellung dient das Arbeitsfenster 'Audio Trigger', welches
+auch die einzelnen Pegel anzeigt.
+
+![Audio Window](/docs/images/Audio-Window.png)
+
+Ist die erforderliche Hardware nicht vorhanden, so wird eine entsprechende
+Warnung angezeigt, [siehe oben](./midi-dmx-or-audio-triggering.md#).
+
+-   Mit dem Schalter 'Enable' unter dem Gain-Regler lassen sich alle
+    Audio-Trigger abschalten.
+
+-   Der Gain-Regler (links) regelt die gesamte Empfindlichkeit.
+
+-   Aktiviert man den Schalter 'Auto', so wird die Empfindlichkeit
+    automatisch geregelt; der Fader ist in diesem Fall inaktiv.
+
+-   Der Schalter 'Enable' bei jedem einzelnen Band aktiviert und
+    deaktiviert dieses.
+
+-   Mit dem Trigger-Regler für jedes Band lässt sich jeweils die
+    Schaltschwelle einstellen. Ist die Schaltschwelle ausgelöst, dann
+    wird der Fader jeweils rot dargestellt.
+
+-   Der 'Auto'-Schalter bei jedem Band stellt die Schaltschwelle
+    automatisch auf einen in etwa brauchbaren Wert.
+
+Playbacks können schnell einzelnen Bändern zugewiesen werden, indem man
+auf die Schaltfläche <Keys.SoftKey>Band x</Keys.SoftKey> oben klickt und dann das zu triggernde
+Playback auswählt.
+
+Auf dem Arena und Quartz zeigt die Audio-LED beim Netzschalter etwa 
+anliegendes Audio-Signal durch Blinken an. Die Kopfhörer-Buchse ist 
+dagegen mit dem Kopfhörerausgang des Motherboards und nicht mit dem 
+Eingang verbunden, kann also nicht zur Kontrolle genutzt werden.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/midi-dmx-or-audio-triggering.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/midi-dmx-or-audio-triggering.md
@@ -14,25 +14,46 @@ automatisiert ablaufen muss.
 
 Die folgenden Triggerarten (Signale) sind möglich:
 
-- Audio (nicht bei allen Pulten)
-- DMX
-- GPIO (nicht bei allen Pulten)
+- Audio 
+- DMX In
+- GPIO 
 - MIDI (außer T1)
-- Streaming ACN
+- Streaming ACN In
+- HTTP (mittels WebAPI)
 
-> Audiotrigger (Sound to Light) erfordern spezielle Hardware und sind 
-auf dem Sapphire Touch, Tiger Touch, Titan Mobile, T1, T3 und dem Pearl 
-Expert **nicht** verfügbar. Eine bei anderen Pulten
-eventuell verfügbare Line-In-Buchse kann nicht als Sound-to-Light-Eingang 
-verwendet werden. Dagegen kann der T2 als Sound-Eingang für andere Pulte 
-dienen.
+Nicht alle Arten von Triggern stehen auf allen Pulten zur Verfügung, siehe nachstehende Tabelle.
 
-GPIO steht nur auf dem Diamond 9, Diamond 7, dem Arena, dem Tiger Touch II und dem Sapphire Touch zur Verfügung.
+Not all types of trigger are available on all consoles or hardware, see the table below.
+
+Pult | Audio | DMX | GPIO | MIDI 5-pin | MIDI USB | sACN | WebAPI | SMPTE/LTC
+---|---|---|---|---|---|---|---|---
+Simulator      |   |   |   |   |   | x | x |  
+T1             |   | x |   |   |   | x |   |  
+T2             | x | x |   |   | x | x | x | x
+T3             |   | x |   |   | x | x | x | x 
+D3-010         |   | x |   |   | x | x | x | x 
+D3-110         | x | x |   |   | x | x | x | x 
+D3-Core        | x | x |   |   | x | x | x | x 
+D7             | x |   | x | x | x | x | x | x 
+D9             | x | x | x | x | x | x | x | x 
+Titan Mobile   |   | x |   |   | x | x | x |  
+Quartz         |   | x |   |   | x | x | x |  
+Tiger Touch 2  |   | x | x | x | x | x | x | x 
+Arena          | x | x | x | x | x | x | x | x 
+Sapphire       |   | x | x | x | x | x | x | x
+
+
+
+> Audiotrigger (Sound to Light) erfordern spezielle Hardware und können mit dem T2 als Sound-Eingang
+realisiert werden, wenn das Pult nicht von Hause aus einen entsprechenden Eingang hat. 
+Eine bei manchen Pulten eventuell verfügbare Line-In-Buchse kann nicht als Sound-to-Light-Eingang 
+verwendet werden.
+
 
 ## Anschließen externer Steuerungen
 
 Der Audio-Eingang funktioniert nur über die eigens dafür vorhandene
-Klinkenbuchse beim Quartz und beim Arena. Der Audio-Eingang des
+Klinkenbuchse. Der Audio-Eingang des
 Motherboards ist dafür nicht geeignet Andere Konsolen können mit dem T2
 als Audio-Eingang verwendet werden, siehe oben.
 
@@ -41,16 +62,16 @@ werden; dazu benötigt man einen simplen Stecker-Stecker-Adapter ('gender
 changer', alle Pins 1:1 belegt, also 1-1, 2-2, 3-3 etc.).
 
 GPIO nutzt einen simplen Schließkontakt, der per Klinkenbuchse 
-angeschlossen wird (nur beim Diamond 9, Diamond 7, beim Arena, dem Tiger Touch II und dem Sapphire 
-Touch verfügbar). Beim Diamond 9 und Diamond 7 stehen die GPIO-Kontakte auch auf dem 15-poligen SubD-Stecker zur Verfügung. 
+angeschlossen wird (nur beim D9, D7, beim Arena, dem Tiger Touch II und dem Sapphire 
+Touch verfügbar). Beim D9 und D7 stehen die GPIO-Kontakte auch auf dem 15-poligen SubD-Stecker zur Verfügung. 
 Für den TNP kann GPIO als Option nachgerüstet werden; wenden Sie sich dazu an Avolites oder Ihren Avolites-Vertrieb.
 
-MIDI-Geräte werden einfach mit der MIDI-In-Buchse verbunden.
+MIDI-Geräte werden einfach mit der MIDI-In-Buchse verbunden soweit vorhanden.
 USB-MIDI-Geräte, die den DirectX MIDI-Treiber unterstützen, können
 ebenfalls verwendet werden (nicht am T1/Titan One). Damit kann z.B. ein
 T2 mit einem MIDI-Faderboard gesteuert werden.
 
-sACN wird ganz einfach per Netzwerk (Ethercon) angeschlossen.
+sACN und die WebAPI erfolgt einfach über Netzwerk (Ethercon).
 
 PioneerDJ-Decks können per Netzwerk als Taktgeber für BPM-Master
 verwendet werden, siehe [folgender Abschnitt](./linking-pioneerdj-system-to-titan.md). Dies ersetzt die frühere
@@ -231,3 +252,9 @@ Auf dem Arena und Quartz zeigt die Audio-LED beim Netzschalter etwa
 anliegendes Audio-Signal durch Blinken an. Die Kopfhörer-Buchse ist 
 dagegen mit dem Kopfhörerausgang des Motherboards und nicht mit dem 
 Eingang verbunden, kann also nicht zur Kontrolle genutzt werden.
+
+
+## WebAPI
+
+Nahezu jeder Aspekt von Titan lässt sich auch über Netzwerk per WebAPI steuern. Eine Dokumentation
+der Requests steht auf https://api.avolites.com zur Verfügung.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/playback-controls.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/playback-controls.md
@@ -1,0 +1,596 @@
+---
+id: playback-controls
+title: Steuern der Wiedergabe
+sidebar_label: Steuern der Wiedergabe
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Master-Fader
+
+Jeder Fader auf dem Pult kann auch als Masterfader für verschiedene
+Funktionsbereiche verwendet werden:
+
+-   Der **Grand Master** steuert die Dimmerpegel sämtlicher angeschlossenen
+    Geräte.
+
+-   **Swop/Flash-Master** steuern die Helligkeit für Kanäle bei Bedienung
+    mit den Swop-/Flash-Tasten.
+
+-   Der **Preset-Master** steuert die Helligkeit von Kanälen, die mittels
+    der Preset-Regler (für einzelne Geräte, auf dem Pearl Expert)
+    gesteuert werden.
+
+-   Der **Playback-Master** steuert die Gesamthelligkeit von
+    vorprogrammierten Playbacks.
+
+Um einzelne Regler mit einer Master-Funktion zu belegen, gehe Sie wie folgt vor:
+
+1. Drücken Sie die Taste <Keys.HardKey>Record</Keys.HardKey>.
+2. Drücken Sie im Menü <Keys.SoftKey>Create Master</Keys.SoftKey>. 
+3. Drücken Sie die **Select**-Taste des gewünschten Faders..
+
+> Normalerweise werden Master nur auf der Playback-Seite angezeigt, auf der sie angelegt wurden,
+nicht aber auf den anderen Seiten. Um das zu ändern, kann man einen Lock oder Transparent Lock setzen (siehe 
+[Handle Paging](../cues/playback-options.md#handle-paging)).
+
+Sie können Master auch im **System**-Menü anlegen: wählen Sie dazu <Keys.SoftKey>Assign Masters</Keys.SoftKey>. 
+
+- Wird eine Gerätegruppe auf einem Fader gespeichert, so wird der Fader der Gruppenmaster (Masterregler der Gruppe).
+
+- Auf dem Diamond 9 bieten sich zudem die Dreh-Encoder neben den Displays (beim Arena neben dem kleinen Display)
+z.B. als Speed- oder Gruppen-Master an. Um diese Fader anzuwählen,
+werden drücken sie gedrückt. Mit der Taste <Keys.HardKey>Display</Keys.HardKey> unterhalb der
+Encoder kann man die Anzeige so einstellen, dass die Belegung der
+Encoder angezeigt wird (mit dieser Taste wird durch vier Anzeigemodi 
+durchgeschaltet).
+
+![Arena Miniscreen](/docs/images/Arena-Miniscreen.png)
+
+>  Wird ein Master auf eine Taste mit LED gelegt, so blinkt diese, wenn der Master auf 0 steht -- als kleine Erinnerung, wenn man auf der Suche danach ist, warum gerade wieder alle Lampen aus sind...
+
+- Auf manchen Pulten gibt es einen eigenen Master-Fader, der
+insgesamt den Ausgang des Pultes (für Dimmerkanäle) regelt.
+In der Vorgabeeinstellung ist der Grandmaster deaktiviert und kann über
+die [Benutzereinstellungen](../system-settings.md/user-settings#handles) aktiviert werden.
+
+- Das Pearl Expert hat darüber hinaus getrennte Masterfader für Playbacks,
+Presets (die Fader oben), und für die Swop- und Flashtasten.
+
+
+## Speed- und Size-Master
+
+<Video videoId="e5rQAmTCfs0" title="Speed and Size Masters" />
+
+Die einzelnen Playbacks lassen sich verschiedenen **Speed- und
+Size-Masterreglern** zuweisen; damit kann man das Tempo und die Größe von
+enthaltenen Shapes und Effekten zentral steuern, oder - im Fall von
+Chasern - direkt das Chase-Tempo beeinflussen.
+
+Zur Verfügung stehen zwölf unterschiedliche Speedmaster (4 x Speed, 8 x
+BPM) sowie vier Size-Master. So kann man z.B. einen Ratemaster für
+Positions-Shapes und einen anderen für Dimmershapes verwenden.
+
+Zum Zuweisen eines Playbacks zu einem Speed- oder Size-Master drücken
+Sie <Keys.HardKey>Options</Keys.HardKey> oder <Keys.SoftKey>Options</Keys.SoftKey>, wählen das jeweilige Playback (blaue Taste
+oder Schaltfläche), und drücken dann <Keys.SoftKey>Effects</Keys.SoftKey> und <Keys.SoftKey>Speed Source</Keys.SoftKey>
+bzw. <Keys.SoftKey>Size Source</Keys.SoftKey>. Folgende Optionen sind verfügbar:
+
+-   Free Run (keine Steuerung über Speed-Master -- Effekte laufen so
+    schnell wie programmiert)
+
+-   BPM 1-8 (das lokal eingestellte Tempo wird durch das Master-Tempo
+    komplett überschrieben)
+
+-   Rate 1-4 (das lokal eingestellte Tempo wird durch den Master
+    proportional vergrößert/verringert)
+
+-   LocalClock (Steuerung per Tap Tempo, das ggf. per Tastenprofil auf
+    einen Button gelegt werden muss)
+
+Ferner gibt es einen **Rate Grand Master**, der alle Chaser und Effekte 
+proportional beeinflusst unabhängig davon, ob diese einem Rate- oder BPM-Master
+zugewiesen sind.
+
+Um die Speed- bzw. Size-Master verwenden zu können, müssen diese auch
+jeweils auf einen Fader gelegt werden:
+
+1.  Drücken Sie <Keys.HardKey>Record</Keys.HardKey>.
+2.  Drücken Sie <Keys.SoftKey>Create Master</Keys.SoftKey>. 
+3.  Wählen Sie mit den Menütasten den gewünschten Master.
+4.  Drücken Sie die **Auswahltaste** des Faders, auf den Sie die Masterfunktion legen wollen.
+
+-    Für Speedmaster stehen auch gesonderte Tastenprofile zur Verfügung; 
+BPM-Master haben als Vorgabewert die Takt-Taste (Tap Tempo).
+
+Speed- und Size-Master können verschiedene Skalen (Wertebereiche) haben:
+0-100%, 0-200% etc. So kann man z.B. mit der Skala 0-200% den Master auf
+Mittelstellung bringen (100%) und davon ausgehend die beeinflussten
+Effekte größer/schneller oder langsamer/kleiner machen. Die Skala wählt
+man mit den <Keys.HardKey>Options</Keys.HardKey> oder <Keys.SoftKey>Options</Keys.SoftKey> des Masterreglers.
+
+### Optionen für BPM-Master
+
+Für BPM-Master lassen sich Faktoren/Teiler einstellen, die bestimmen,
+wie das getappte Tempo auf die BPM-Rate konvertiert wird. Um dieses
+Verhältnis zu ändern, drücken Sie <Keys.HardKey>Options</Keys.HardKey> oder <Keys.SoftKey>Playback Options</Keys.SoftKey> 
+und wählen den Masterregler aus, den Sie ändern möchten.
+
+Normalerweise liegt die BPM-Rate auf dem Fader, eine der Tasten dient
+als Tap-Taste, und man kann die BPM-Rate numerisch eingeben und per
+Select-Taste anwenden.
+
+BPM-Master, Fader steuert BPM:<br/>
+![BPM Master on playback](/docs/images/BPM-Master-on-playback.png)   
+
+Mit der Option <Keys.SoftKey>BPM On Fader</Keys.SoftKey>/<Keys.SoftKey>Multiplier on Fader</Keys.SoftKey> steuert der
+Fader alternativ den Faktor/Teiler, und die BPM-Rate wird nur per Tap
+eingestellt. 
+
+BPM-Master, Fader steuert Teiler/Faktor:<br/>
+![BPM Master multiplier on fader](/docs/images/BPM-Master-multiplier-on-fader.png)
+
+Mit <Keys.SoftKey>Multiplier Scale</Keys.SoftKey> wird der Faderbereich für den Faktor/Teiler
+eingestellt (von x2\~/2 bis x32\~/32).
+
+Mit <Keys.SoftKey>Keep Multiplier On Tap</Keys.SoftKey>/<Keys.SoftKey>Reset Multiplier On Tap</Keys.SoftKey> lässt sich
+einstellen, dass beim erneuten Tappen der Faktor/Teiler wieder auf x1
+zurückgesetzt wird.
+
+Im Bereich 'Times' (Zeiten) der Benutzereinstellungen gibt es die Option
+"Compensate for Rate Grand Master": dies wird wirksam, sofern der Rate
+Grand Master aktiviert und auf weniger als 100% gestellt ist. Ist nun
+die Option aktiv und wird ein Tempo getappt, so wird genau dieses Tempo
+live übernommen und nicht durch den reduzierten Grand Master verringert.
+Ist die Option dagegen deaktiviert, so wird ein getapptes Tempo durch
+den Rate Grand Master beeinflusst.
+
+### Master mit den Encodern steuern
+
+Es ist möglich, die Encoder mit Intensity-, Size-, Rate- und BPM-Mastern
+zu verbinden (connecten). Drücken Sie <Keys.HardKey>Cue</Keys.HardKey> (bzw. <Keys.HardKey>Connect</Keys.HardKey>), gefolgt
+von dem betreffenden Master, so lässt sich dieser mit dem Encoder sehr 
+präzise steuern. Bei BPM-Mastern kann man außerdem noch den "Edge Sync" 
+(zum genauen Abgleich auf den Beat) mit den Encodern einstellen.
+
+Auch hierbei kann man die Werte durch Klicken im Attribut-Bereich des
+Displays verändern. Ebenso steht mit den <Keys.HardKey>@</Keys.HardKey>-Tasten bei den Encodern das
+@-Menü zur Verfügung, mit dem man den gewünschten Wert numerisch
+eingeben oder mit <Keys.SoftKey>Release</Keys.SoftKey> wieder auf den vorher eingestellten Wert
+zurücksetzen kann.
+
+>   Mittels [Tastenprofilen (Key Profiles)](../system-settings/key-profiles.md)
+    kann man eine der Tasten als 'Connect' zum Verbinden mit der Steuerung definieren.
+
+## Playback-Gruppen
+
+Playbacks können in Gruppen zusammengefasst werden. Dies ist sinnvoll,
+wenn von mehreren Playbacks immer nur eins als aktiv angezeigt werden
+soll; wird ein anderes Playback in dieser Gruppe gestartet, werden alle
+anderen deaktiviert. Damit wird vor allem das spontane Showfahren mit
+den Executor-Buttons deutlich vereinfacht.
+
+Auf Pulten mit Motorfadern fahren dabei auch die entsprechenden Fader
+auf 0; ansonsten gehen einfach die LEDs der Playbacks aus, und
+Schaltflächen erscheinen als inaktiv.
+
+### Erstellen einer Playback-Gruppe
+
+Drücken Sie zweimal auf [<Keys.HardKey>Open/View</Keys.HardKey>](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster) 
+und wählen das Fenster "Playback Groups".
+
+![Empty playback groups workspace](/docs/images/Empty-playback-groups-workspace.png)
+
+1.  Klicken Sie auf <Keys.ContextKey>+</Keys.ContextKey> (links unten). Damit wird eine neue Gruppe
+erstellt und in der linken Spalte angezeigt.
+2.  Klicken Sie auf die neu erstellte Gruppe links, also z.B. auf <Keys.SoftKey>Playback Group 1</Keys.SoftKey>.
+3.  Klicken Sie unten rechts auf den <Keys.ContextKey>Stift</Keys.ContextKey>-Button, um die Gruppe zu
+    editieren.
+4.  Klicken Sie die Playbacks an, die Sie in dieser Gruppe zusammenfassen wollen. Ausgewählte 
+    Playbacks erscheinen im Playback Groups-Fenster bei ihrer Gruppe.
+5.  Mit <Keys.HardKey>Exit</Keys.HardKey> können Sie das Menü verlassen, und die Playbacks
+    sind zu einer Gruppe zusammengefasst.
+
+![Empty playback groups workspace](/docs/images/Empty-playback-groups-workspace-2.png)
+
+-   Ist eine Playback-Gruppe im Editiermodus, so wirken die
+    Playback-Tasten als Umschalter für die Gruppenzugehörigkeit:
+    klickt man einmal, so gehört das Playback dazu, klickt man ein
+    zweites Mal (oder klickt auf den Playback-Button im Playback
+    Groups-Fenster), so wird das Playback wieder aus der Gruppe
+    entfernt.
+
+-   Playback-Gruppen können auch mit der <Keys.HardKey>Group</Keys.HardKey>-Taste erstellt werden:
+    &nbsp;<Keys.HardKey>Group</Keys.HardKey> drücken, dann im Menü <Keys.SoftKey>Playback Groups</Keys.SoftKey> 
+    sowie <Keys.SoftKey>Record playback group</Keys.SoftKey> wählen, die gewünschten Playbacks auswählen 
+    und <Keys.SoftKey>Store</Keys.SoftKey> drücken.
+
+-   Playback-Gruppen können per <Keys.SoftKey>Set Legend</Keys.SoftKey> eine Bezeichnung und ein
+    Halo bekommen.
+
+-   Ist man nicht im Editiermodus, so können Playbacks auch über ihre
+    Buttons im Playback Groups-Fenster gestartet/gestoppt werden.
+
+> Wenn ein Playback zu einer Gruppe gehört, so wird dies mit einem Stern \* bei der Playback-Legende angezeigt.
+
+### Ändern der Zugehörigkeit zu Playback-Gruppen
+
+Öffnen Sie das Playback Groups-Fenster, wählen Sie links die zu
+bearbeitende Gruppe und klicken Sie rechts unten auf den<Keys.ContextKey>Stift</Keys.ContextKey>.
+
+Die Playbacks in der Gruppe werden hervorgehoben und können jeweils ab-
+oder angewählt werden.
+
+Ebenso kann über die entsprechenden Menütasten die Nummer und die
+Legende (Bezeichnung) der Gruppe geändert werden.
+
+-   Zum Löschen einer Playback-Gruppe drücken Sie die Taste <Keys.HardKey>Delete</Keys.HardKey>,
+    wählen die zu löschende Gruppe aus und bestätigen dies mit
+    &nbsp;<Keys.SoftKey>Confirm</Keys.SoftKey> oder <Keys.HardKey>Enter</Keys.HardKey>.
+
+## Optionen für Playback-Gruppen
+
+Für jede Gruppe lässt sich einstellen, wie genau die enthaltenen
+Playbacks sich verhalten. Dazu wählt man im Fenster Playback Groups
+links die gewünschte Gruppe und klickt rechts unten auf den Reiter <Keys.SoftKey>Options</Keys.SoftKey>.
+
+![Playback groups options workspace](/docs/images/Playback-groups-options-workspace.png)
+
+-   **Mutually Exclusive** schaltet den Exklusiv-Modus ein oder aus. Damit
+    lässt sich diese Funktion vorübergehend deaktivieren, ohne die
+    Gruppe löschen zu müssen.
+
+-   Mit **Kill Point** lässt sich einstellen, wann ein neu gestartetes
+    Playback die anderen Playback in der Gruppe deaktiviert:<br/>
+    &nbsp;<Keys.SoftKey>Fired</Keys.SoftKey> - sobald das Playback gestartet ist<br/>
+    &nbsp;<Keys.SoftKey>Fade Completed</Keys.SoftKey> - sobald es gestartet und komplett eingefadet ist
+
+-   **Kill Action** legt fest, ob bei Deaktivieren Release zum Tragen
+    kommt oder nicht:<br/>
+    &nbsp;<Keys.SoftKey>Follow Playback</Keys.SoftKey> - es wird nach den Release-Einstellungen
+    jedes Playbacks vorgegangen<br/>
+    &nbsp;<Keys.SoftKey>Kill</Keys.SoftKey> - Playbacks werden immer sofort abgeschaltet (gekillt)<br/>
+    &nbsp;<Keys.SoftKey>Release</Keys.SoftKey> - Playbacks werden immer nach der unten vorgegebenen
+    Releasemaske und -zeit released<br/>
+    &nbsp;<Keys.SoftKey>Release HTP</Keys.SoftKey> - HTP-Kanäle werden released, alle anderen gekillt
+
+-   Mit **Release Mask** und **Release Time** lässt sich für das
+    gegenseitige Releasen eine eigene Maske und Zeit einstellen. Steht
+    dies auf <Keys.SoftKey>Playback</Keys.SoftKey>, so kommen die Einstellungen jedes einzelnen
+    Playbacks zum Tragen.
+
+## Anzeigeoptionen für das Playback Groups-Fenster
+
+Mit dem Fensteroptions-Menü (<Keys.ContextKey>Zahnrad</Keys.ContextKey>-Button in der Titelleiste des
+Fensters) lassen sich drei verschiedene Anzeigemodi wählen:
+
+&nbsp;<Keys.SoftKey>View Mode All</Keys.SoftKey> – zwei Spalten: links die Playback-Gruppen, rechts
+jeweils die zugehörigen Playbacks jeder Gruppe
+
+![Playback groups display mode 1](/docs/images/Playback-groups-display-mode-1.png)
+ 
+&nbsp;<Keys.SoftKey>View Mode Single</Keys.SoftKey> – zwei Spalten: links die Playback-Gruppen, aber
+rechts nur die Playbacks in der gerade angewählten Gruppe. Das erlaubt
+eine bessere Übersicht bei Gruppen mit vielen Playbacks.
+
+![Playback groups display mode 2](/docs/images/Playback-groups-display-mode-2.png)
+ 
+&nbsp;<Keys.SoftKey>View Mode Playbacks Only</Keys.SoftKey> – eine Spalte, es werden nur die Playbacks
+pro Gruppe angezeigt. Die Reiter <Keys.SoftKey>Playbacks</Keys.SoftKey>, <Keys.SoftKey>Options</Keys.SoftKey> und der
+Editier-Button stehen nicht zur Verfügung.
+
+![Playback groups display mode 3](/docs/images/Playback-groups-display-mode-3.png)
+
+
+## Gruppenmaster
+
+Jeder Gruppe von Geräten kann ein Fader als Masterregler zugewiesen
+werden, der dann die Helligkeit aller Geräte in der Gruppe beeinflusst.
+Dazu ist ganz einfach die Gruppe auf einen Speicherplatz mit Fader zu
+speichern (oder mit <Keys.HardKey>Move</Keys.HardKey> dorthin zu verschieben).
+
+Mittels <Keys.HardKey>Options</Keys.HardKey> oder <Keys.SoftKey>Options</Keys.SoftKey>, gefolgt von der entsprechenden
+Auswahltaste, kann man die genaue Arbeitsweise des
+Gruppenmasters wählen:
+-   **Scale master** (proportionale Steuerung). Dabei kann der Bereich auf
+    100%, 200%, 400%, 600% oder 1000% eingestellt werden. Damit lassen
+    sich also auch größere Werte als gerade mit den Playbacks
+    eingestellt erzielen.
+-   **HTP** (überschreibt den Pegel falls höher)
+-   **Limit** (absolutes Limit)
+-   **Take Over** (wenn mit dem Master die aktuellen Dimmerwerte getroffen
+    werden, werden die Geräte in den Programmierspeicher übernommen)
+-   **Disabled** (Master ist deaktiviert)
+
+Gibt es einen Bildschirmbereich für den als Gruppenmaster definierten
+Fader, so werden dort der aktuelle Wert und die Arbeitsweise angezeigt.
+
+![Group Master](/docs/images/Group-Master.png)
+
+Wird ein Gruppenmaster deaktiviert oder auf einen Speicherplatz ohne
+Fader verschoben, so wird der aktuelle Wert 'eingefroren'. Zum
+Reaktivieren verschieben Sie den Master zurück auf einen Fader.
+
+Mittels [Tastenprofilen (Key Profiles)](../system-settings/key-profiles.md) 
+ kann man den Tasten eines Gruppenmasters verschiedene Funktionen zuweisen:
+-   Flash Fixtures - blendet die Dimmer der in der Gruppe enthaltenen
+    Geräte auf, bis zum Pegel, der durch den Gruppenmaster vorgegeben ist.
+-   Timed Flash - wie vor, unter Berücksichtigung der eingestellten
+    Fadezeiten
+-   Flash Master - blendet den Gruppenmaster auf 100% auf
+-   Timed Flash Master - wie vor, unter Berücksichtigung der
+    eingestellten Fadezeiten
+-   Swop Fixtures - wie Flash Fixtures, aber alle anderen (nicht in der
+    Gruppe enthaltenen) Geräte werden auf 0 abgeblendet
+
+Ist ein Flash-Master definiert, so steuert dieser auch den Flash-Pegel
+für das Flashen der Gruppen-Master.
+
+>   Mit <Keys.HardKey>Release</Keys.HardKey>, <Keys.SoftKey>Release All Masters</Keys.SoftKey> lassen sich alle Master auf
+    einmal releasen. Das kann sinnvoll sein, wenn etwas durch einen Master gesteuert wird, aber unklar ist, durch welchen.
+
+## Scene Master
+
+<Video videoId="zn_jd1zba7E" title="Scene Masters" />
+
+Der Scene Master gestattet es, etwa unter Verwendung des Visualisers
+komplette Szenen vorzubereiten (unter Verwendung von Cues, Paletten
+verschiedenen Zeiten etc.) und diese dann alle auf einmal zu starten.
+
+Der Scene Master wird wie die anderen Master auch entweder per <Keys.SoftKey>Assign Masters</Keys.SoftKey>
+im **System**-Menü oder via <Keys.HardKey>Record</Keys.HardKey>, <Keys.SoftKey>Create Master</Keys.SoftKey> erstellt.
+
+Das Diamond 9 hat eigens einen Überblendregler mit T-Griff für den Scene Master sowie ein kleines Display zur Anzeige des Status.
+
+Der Scene Master befindet sich zunächst im Live-Modus, womit alle Steuerungen wie gewohnt 
+arbeiten (Geräte auswählen, Paletten anwenden, Playbacks starten etc.).
+
+![Scene Master (Live)](/docs/images/Scene-Master-Live.png)
+
+Zum Aktivieren des Preset-Modus drücken Sie die **Auswahltaste** des Scene
+Masters (oder <Keys.HardKey>Enter/B</Keys.HardKey> unter dem Regler beim Diamond 9). 
+Daraufhin wird im Display die Funktion "Preset" angezeigt, und das Display des Master wird 
+violett. Zum **Verlassen** des Preset-Modus drücken Sie wieder die **Auswahltaste** des Scene
+Masters (oder <Keys.HardKey>Exit/A</Keys.HardKey> unter dem Regler beim Diamond 9). 
+
+![Scene Master (Preset)](/docs/images/Scene-Master-Preset.png)
+
+Im Preset-Modus sind alle Steuerungen -- Starten von Playbacks, Go in
+Cuelisten, Anwenden von Paletten etc. -- nur im Visualiser sichtbar. Die
+dabei involvierten Playbacks, Paletten etc. werden ebenfalls violett
+hinterlegt.
+
+Bewegt man nun den Scene Master, so wird der Output auf den so eingestellten
+Zustand übergeblendet; dabei werden auch etwa mit einprogrammierte
+Zeiten (für Cues oder Paletten) berücksichtigt. Hat der Fader 100%
+erreicht, so ist der Preset-Status komplett live, also ‚committet'.
+Ebenso lässt sich das Commit manuell per Tastendruck erreichen 
+(<Keys.HardKey>Commit</Keys.HardKey> beim Diamond 9). Der Preset-Modus 
+bleibt aktiv, bis man diesen wie oben beschrieben verlässt.
+
+Normalerweise schaltet sich die Funktionsrichtung des Scene Masters um,
+sobald er einen Endpunkt (100% oder 0%) erreicht, so dass man einfach
+den nächsten Look einstellen, dann einfaden, und von neuem beginnen
+kann. Ebenso lässt sich einstellen, dass man den Fader jedes Mal erst
+wieder auf 0 bringen muss. Dies erreicht man über <Keys.HardKey>Options</Keys.HardKey> 
+oder <Keys.SoftKey>Options</Keys.SoftKey> und wählt den Scene Master. Es gibt folgende Optionen:
+
+-   &nbsp;<Keys.SoftKey>Auto Commit and Invert</Keys.SoftKey>: damit wird jeweils beim Erreichen von
+    100% und 0% Faderstellung die (nächste) vorbereitete Szene live
+    geschaltet und mit der nächsten Faderfahrt eingeblendet.
+
+-   &nbsp;<Keys.SoftKey>Auto Commit</Keys.SoftKey> ist ganz ähnlich, allerdings wird die nächste Szene
+    immer nur bei 0% Faderstellung aktiviert, so dass man auch von 100%
+    erst wieder herunterfaden muss.
+
+-   Bei <Keys.SoftKey>Manual Commit</Keys.SoftKey> schließlich wird die Szene gar nicht per Fader
+    aktiviert, sondern muss per Taste aktiviert werden, wozu eine entsprechende Funktion etwa mit 
+    der Flash-Taste verknüpft sein muss (über Tastenprofile, s.u.).
+
+Auf dem Diamond 9 gibt es weitere Buttons für den Scene Master: <Keys.HardKey>Reset</Keys.HardKey> löscht alle Preset-Änderungen und kehrt zum aktuellen Live-Status zurück, und <Keys.HardKey>Preload</Keys.HardKey> arbeitet 
+wie von Preload gewohnt, lädt also alle LTP-Werte vorab.
+
+Der Scene Master kann auch auf einer Taste oder einem Button im Display
+liegen. In diesem Fall dient die Kombination <Keys.HardKey>Avo</Keys.HardKey> + <Keys.SoftKey>Scene Master</Keys.SoftKey>
+bzw. <Keys.HardKey>Release</Keys.HardKey> + <Keys.SoftKey>Scene Master</Keys.SoftKey> zum Starten oder Verlassen des
+Preset Modus; einfaches Betätigen der Taste/des Buttons macht einen
+Commit. Der Status lässt sich im entsprechenden Fenster (z.B. Playbacks
+oder Static Playbacks) überwachen.
+
+Den Tasten des Scene Masters lassen sich verschiedene Funktionen per
+Tastenprofil zuweisen: Commit Changes (Szene aktivieren), Commit Changes and Exit scene Mode(Szene 
+aktivieren und Preset-Modus verlassen), und Enter or Commit scene Mode (Preset-Modus
+aktivieren oder Szene aktivieren).
+
+-   Beim Pearl Expert und beim Tiger Touch 1 drücken Sie zum Zuweisen des
+    Scene Masters <Keys.HardKey>Avo</Keys.HardKey> und <Keys.HardKey>Disk</Keys.HardKey>,
+    um ins System-Menü zu gelangen, und wählen dort <Keys.SoftKey> Assign Masters</Keys.SoftKey>.
+
+## Flash- und Swop-Tasten
+
+Die Flash- (Add) und Swop-Tasten bei jedem Regler dienen zum jederzeitigen
+Abruf von Cues und Chasern. Die <Keys.HardKey>Flash</Keys.HardKey>-Taste addiert dabei den
+jeweiligen Inhalt mit 100% zum sonstigen Output, während die
+<Keys.HardKey>Swop</Keys.HardKey>-Taste gleichzeitig alle anderen Cues/Chaser vorübergehend
+dunkeltastet (Solo-Funktion). Die <Keys.HardKey>Flash</Keys.HardKey>-Taste lässt sich auch in die
+Betriebsart 'Flash With Times' schalten: dann werden beim Flashen im Cue
+programmierte Zeiten berücksichtigt.
+
+Die Funktionsweise der Tasten lässt sich mit den [Key Profiles 
+(Tastenbelegungen)](../system-settings/key-profiles.md) - abändern. Eine
+sinnvolle Alternative wäre etwa 'Preload', womit die Kanäle der Geräte
+bereits auf die entsprechenden Werte gestellt werden, bevor der Regler
+selbst bewegt wird, so dass z.B. keine Bewegungen 'im On' stattfinden
+(das geht nur für Geräte, die nicht gerade in anderen aktiven
+Cues/Chasern verwendet sind). Ebenso lassen sich die Funktionen 'Stop'
+und 'Go' für Cuelisten und Chaser auf diese Tasten legen. Um die
+Tastenbelegung rasch zu ändern, halten Sie die <Keys.HardKey>AVO</Keys.HardKey>-Taste gedrückt
+und betätigen die Funktion <Keys.SoftKey>Edit Key Profile</Keys.SoftKey>. Das Sapphire Touch verfügt
+neben den grauen und blauen Tasten pro Fader auch über eine schwarze 
+Taste, deren Funktion ebenso eingestellt werden kann, und auch die virtuellen
+Fader können schwarze Tasten haben.
+
+![Playback Faders with key profiles applied](/docs/images/Playback-Faders-with-key-profiles-applied.png)
+
+Im Touchscreen direkt oberhalb der Regler wird die aktuelle
+Funktion der Tasten angezeigt.
+
+## Priorität der Playbacks
+
+Einzelnen Playbacks lässt sich eine [höhere Priorität](../cues/playback-options.md#priority) zuweisen, wenn sie
+nicht durch andere Playbacks, die die gleichen Geräte verwenden, überlagert
+werden sollen. Werden etwa ein paar Geräte als Spot für z.B. den Sänger
+eingesetzt, sind aber ebenso in einem anderen Cue verwendet, so kann man
+die Priorität für den Cue ‚Spot' heraufsetzen, so dass der andere Cue darauf
+ohne Auswirkung bleibt.
+
+## Virtuelle Fader
+
+Werden mehr Fader benötigt und reichen dafür Fader auf dem Bildschirm
+aus, so kann das Fenster ‚Virtual Faders' hilfreich sein. Zum Öffnen
+drücken Sie zweimal auf 
+[<Keys.HardKey>View / Open</Keys.HardKey>](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster) 
+und wählen <Keys.SoftKey>Virtual Faders</Keys.SoftKey>.
+
+Dieses Fenster zeigt 10 Fader, die genau wie die echten Fader verwendet werden
+können. Mit der Seitenumschaltung auf der linken Seite können auch diese
+Fader auf 60 Seiten umgeschaltet werden.
+
+![Virtual playbacks window](/docs/images/Virtual-Faders.png)
+
+Mit den Fenstereinstellungen (das kleine <Keys.ContextKey>Zahnrad</Keys.ContextKey> anklicken) lassen sich
+weitere Einstellungen vornehmen:
+
+-   Die Seitenumschaltung kann ein- oder ausgeblendet werden.
+
+-   Die blauen, grauen und schwarzen Tasten können ein- oder
+    ausgeblendet werden.
+
+-   Es kann zwischen 5, 10 oder 15 Fadern gewählt werden.
+
+## Feste Playbacks (Nur Tiger Touch)
+
+Zusätzlich zu den zehn Fadern am unteren Rand des Pultes finden sich auf dem
+Tiger Touch Pulten weitere zehn rechts oben. Diese haben normalerweise immer
+die gleiche Belegung, d.h. sie werden durch die Seitenwahl nicht
+umgeschaltet. Sie bieten sich somit an für häufig benötigte Cues, die
+Saalbeleuchtung, Blinder, oder die Nebelmaschine.
+
+Es ist aber auch möglich, diese Fader auf Seiten umzuschalten. Dazu
+müssen entsprechende Makros auf Tasten zugeordnet werden. Sollten diese
+Makros auf dem Pult nicht zur Verfügung stehen, so muss die
+Personality-Bibliothek aktualisiert werden.
+
+## Verriegeln der Seitenumschaltung
+
+Mitunter möchte man einen Fader 'fixieren', so dass er unabhängig vom
+Wechsel der Seiten stets verfügbar bleibt. Dies bietet sich z.B. an,
+wenn man ein paar allgemeine Cues hat, die auf jeder Seite benötigt
+werden, ohne dass man diese extra kopieren muss. Erreicht wird dies
+über die Einstellung <Keys.SoftKey>Handle Paging</Keys.SoftKey> in 
+den <Keys.HardKey>Options</Keys.HardKey> oder <Keys.SoftKey>Options</Keys.SoftKey>.
+
+-   &nbsp;<Keys.SoftKey>Locked</Keys.SoftKey> (Verriegelt) blendet das betreffenden Playback auf sämtlichen
+    anderen Seiten ein; was ggf. anderswo auf diesen Fader programmiert
+    ist, ist damit nicht erreichbar.
+
+-   Bei <Keys.SoftKey>Transparent Lock</Keys.SoftKey> erscheint das Playback an seinem Platz
+    nur auf den Seiten, auf denen der Fader nicht schon anderweitig 
+    belegt ist.
+
+Auch die Makrotasten, Executor-Tasten und festen Playbacks lassen sich
+verriegeln; dies bietet sich an, wenn man die Umschaltung per 'Page
+Change'-Makros verwendet.
+
+Auch Masterregler lassen sich auf diese Weise von der Seitenumschaltung 
+ausnehmen.
+
+## Anzeigen der aktiven Playbacks
+
+Im Fenster ‚Active Playbacks' werden die aktuell aktiven Playbacks/
+Speicherplätze angezeigt. Damit hat man einen schnellen Überblick,
+welche Cues gerade aktiv sind, wo sie gestartet wurden und welche
+Attribute dadurch gesteuert werden. Zum Aufrufen dieses Fensters 
+drücken Sie zweimal auf 
+[<Keys.HardKey>Open/View</Keys.HardKey>](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster) 
+und wählen <Keys.SoftKey>Active Playbacks</Keys.SoftKey>, oder Sie nutzen die 
+Tastenkombination <Keys.HardKey>Open/View</Keys.HardKey> + <Keys.HardKey>Off</Keys.HardKey>.
+
+In der ersten Zeile jedes Buttons steht dabei, wo (in welchem 
+Fenster/auf welchem Fader) das Playback zu finden ist. Die zweite 
+Zeile zeigt die Bezeichnung des Playbacks, die dritte schließlich 
+die gesteuerten Attribute.
+
+![Active Playbacks Window](/docs/images/Active-Playbacks-Window.png)
+
+Klickt man eine der Schaltflächen an, so wird das betreffende Playback
+sofort deaktiviert. Betätigt man <Keys.SoftKey>Playback Options</Keys.SoftKey>, gefolgt von einer
+der Playback-Schaltflächen, so kann man die jeweiligen Parameter ändern.
+
+## Improvisieren (Busking) mit Paletten
+
+Hatten Sie nicht genügend Zeit zum Programmieren, werden Sie vermutlich
+während der Show noch ein paar Effekte hinzufügen wollen. Damit wird das
+Ganze erst richtig interessant.
+
+Sehr schnell lassen sich Ergebnisse erzielen, wenn man Paletten
+verwendet. Dabei lassen sich in Paletten auch Fadezeiten speichern, oder
+man gibt beim Palettenabruf eine Zeit vor.
+
+1.  Wählen Sie einige der bereits verwendeten Geräte aus.
+2.  Geben Sie mit den Zifferntasten einen Wert wie z.B. <Keys.HardKey>2</Keys.HardKey> ein
+    (Überblendzeit, in Sekunden).
+3.  Drücken Sie die Schaltfläche einer Palette, um sie aufzurufen.
+4.  Die angewählten Geräte blenden nun in der angegebenen Zeit zu den
+    Einstellungen der gewählten Palette über.
+
+Enthält eine Palette Zeitvorgaben, so kann man mittels Tastenprofil der
+Palettenschaltflächen bestimmen, ob diese Zeiten beim Improvisieren
+berücksichtigt werden sollen oder nicht. Dazu drücken Sie <Keys.HardKey>Avo</Keys.HardKey>+<Keys.SoftKey>Key Profiles</Keys.SoftKey>, 
+dann <Keys.SoftKey>Palettes</Keys.SoftKey>. Die möglichen Optionen sind <Keys.SoftKey>Palette is fired ignoring its times</Keys.SoftKey> und <Keys.SoftKey>Palette is fired with its times</Keys.SoftKey>.
+Manuell eingegebene Zeiten überschreiben stets in der Palette 
+gespeicherte Zeiten.
+
+Wird manuell eine Überblendzeit eingegeben, lässt sich ebenso der
+'Geräteversatz' einstellen (mit Menütaste C <Keys.SoftKey>Overlap... </Keys.SoftKey>). Damit
+lassen sich etwa Effekte wie 'Rollen' oder 'Abziehen' realisieren. Bei
+'overlap'= 100% wechseln alle Geräte gleichzeitig; bei 'overlap'=50%
+beginnt das zweite Gerät mit dem Überblenden, sobald das erste zur
+Hälfte damit fertig ist. Die Reihenfolge, in der die Geräte wechseln,
+bestimmt sich aus der Reihenfolge, in der die Geräte ausgewählt wurden. 
+Siehe [Fixture Overlap](../cues/cue-timing.md#einstellen-von-überblendzeiten-und-geräteversatz) für weitere Details.
+
+Eine so eingegebene Paletten-Fadezeit und Overlap gelten nur einmalig 
+für den unmittelbar nächsten Palettenabruf. Sollen bis zur nächsten
+Änderung Fadezeit und Overlap festgelegt werden, so erfolgt dies im 
+&nbsp;**Paletten-Menü**: drücken Sie dazu die Taste <Keys.HardKey>Palette</Keys.HardKey> und geben Sie
+die gewünschten Werte mit den Menütasten <Keys.SoftKey>Master Time</Keys.SoftKey> 
+und <Keys.SoftKey>Master Overlap</Keys.SoftKey> ein. Es gibt ferner etliche Macros für die häufig genutzten
+Werte, um Master Time und Master Overlap mit nur einem Tastendruck zu
+ändern, siehe [Master-Zeit für Paletten](../palettes/timing-with-palettes.md#master-zeit-und-overlap-für-paletten).
+
+Wird eine Palette als 'Quick Palette', also ohne Auswahl von Fixtures
+oder Gruppen, aufgerufen, so wird sie wiederum durch den nächsten Cue
+überschrieben (wird etwa eine grüne Palette aufgerufen und danach ein
+blauer Cue gestartet, so werden die Geräte blau). Werden dagegen erst
+Geräte/Gruppen ausgewählt und dann eine Palette aufgerufen, so wird sie
+im Programmierspeicher abgelegt und überlagert alle folgenden Cues
+(wird also eine grüne Palette aufgerufen, so bleiben die Geräte grün,
+bis <Keys.HardKey>Clear</Keys.HardKey> gedrückt wird).
+
+Beim Programmieren der Paletten empfiehlt es sich, z.B. alle
+Farbpaletten in einem Bereich, alle Positionspaletten in einem anderen
+Bereich zu gruppieren etc. Damit findet man sich später besser zurecht.
+
+Gilt es, eine Band zu beleuchten, so ist es hilfreich, sich für jeden
+Musiker eine Positionspalette anzulegen, so dass man auch auf
+unangekündigte Solos schnell reagieren kann.
+
+Die [Off-Funktion](../controlling-fixtures.md#attribute-mit-off-deaktivieren) ist nützlich, um aus
+einem Cue z.B. nur die Position, aus einer anderen nur die Farbe etc. zu
+verwenden. Damit ergeben sich deutlich mehr Kombinationsmöglichkeiten,
+als wenn man stets sämtliche Attribute in einem Cue ablegt. Zu beachten
+ist dabei, dass man natürlich den Überblick über den tatsächlichen
+Inhalt behalten muss: startet man etwa zwei Cues, die jeder nur die Farbe
+gespeichert haben, so ergibt das noch kein Licht.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/playback-controls.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/playback-controls.md
@@ -171,6 +171,8 @@ soll; wird ein anderes Playback in dieser Gruppe gestartet, werden alle
 anderen deaktiviert. Damit wird vor allem das spontane Showfahren mit
 den Executor-Buttons deutlich vereinfacht.
 
+Playback-Gruppen bestimmen auch die zu steuernden Playbacks beim D3 Touch, siehe [Verwenden von Touch-Panels](../remote-control/programming-touch-panels).
+
 Auf Pulten mit Motorfadern fahren dabei auch die entsprechenden Fader
 auf 0; ansonsten gehen einfach die LEDs der Playbacks aus, und
 Schaltflächen erscheinen als inaktiv.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/set-list-window.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/running-the-show/set-list-window.md
@@ -1,0 +1,114 @@
+---
+id: set-list-window
+title: Das Fenster Set-Liste
+sidebar_label: Das Fenster Set-Liste
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Das Fenster Set List bietet eine einfache Möglichkeit, Playback-Seiten
+mit bestimmten Songs oder Szenen der Bühnenshow zu verknüpfen, so dass
+man jederzeit passend zum Ablauf die richtige Seite findet. Ebenso kann
+man Notizen speichern, so dass separate Papiere überflüssig sind. Eine
+Show kann mehrere Set-Listen enthalten.
+
+<Video videoId="VX5acUU-99M" title="Set Lists" />
+
+Um das Fenster aufzurufen, drücken Sie zweimal auf 
+[<Keys.HardKey>Open/View</Keys.HardKey>](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster) 
+und wählen <Keys.SoftKey>Set List</Keys.SoftKey>.
+
+Am besten eignet sich dies, wenn man für jeden Song bzw. jede Szene
+eine eigene Seite von Speicherplätzen verwendet.
+
+![Set List Window](/docs/images/Set-List-Window.png)
+
+Eine Set-Liste besteht aus sog. Tracks. Wird einer Setliste ein neuer
+Track hinzugefügt, so verweist dieser automatisch auf die gerade
+aktuelle Seite. Ein Klick auf die <Keys.SoftKey>**>**</Keys.SoftKey>-Schaltfläche neben einem
+Track schaltet sofort auf die passende Seite (auf dem Pearl Expert muss
+die Walze manuell betätigt werden).
+
+## Erstellen einer Set-Liste
+
+Zum Erstellen einer neuen Set-Liste klicken Sie auf die <Keys.ContextKey>+</Keys.ContextKey>-Schaltfläche
+ *oben rechts*, angeboten werden die Optionen **Empty** (leer), **Pages** (Seiten), und **Build**. 
+-   Mit der Option <Keys.SoftKey>Pages</Keys.SoftKey> wird eine Set-Liste mit den momentan 
+	verwendeten Seiten erstellt. 
+-	Wählt man <Keys.SoftKey>Build</Keys.SoftKey>, so kann man die momentan programmierten Seiten 
+	in beliebiger Reihenfolge in eine Set-Liste einfügen. 
+-   Mit <Keys.SoftKey>Empty</Keys.SoftKey> starten Sie mit einer leeren Set-Liste und fügen Track 
+	für Track hinzu, indem Sie unten auf die <Keys.ContextKey>+</Keys.ContextKey>-Schaltfläche klicken.
+
+## Die Tracks konfigurieren
+
+Enter notes by selecting a track and clicking the text entry button,
+bottom right, or the Edit Note context menu button.
+
+-   Mit dem Kontext-Menü 'Park Track' werden Tracks vorübergehend
+    deaktiviert.
+
+-   Möchten Sie lieber die Tasten <Keys.HardKey>Page+</Keys.HardKey>/<Keys.HardKey>Page-</Keys.HardKey> zum Durchschalten
+    der Tracks verwenden, so aktivieren Sie dies mit dem Kontext-Menü
+    'Page Mode'. Ist Page Mode auf 'Set List' gestellt, so können Sie
+    mit den Tasten <Keys.HardKey>Page+</Keys.HardKey>/<Keys.HardKey>Page-</Keys.HardKey> die Tracks durchschalten -- die
+    Seiten wechseln dann also in der mittels Set-Liste vorgegebenen
+    Reihenfolge. Steht Page Mode auf 'Normal', so wirken die Tasten wie
+    gewohnt auf die Seiten der Speicherplätze (nicht verfügbar auf dem
+    Pearl Expert).
+
+-   Das Kopieren, Verschieben und Löschen von Tracks erfolgt wie gewohnt
+    über die entsprechenden Befehlstasten des Pultes.
+
+-   Zum Ändern der Bezeichnung der Set-Liste oder einzelner Tracks
+    verwenden Sie <Keys.SoftKey>Set Legend</Keys.SoftKey>.
+
+## Tracks mit Workspace und Macros verknüpfen
+
+Macros und Workspaces lassen sich durch Tracks aufrufen: dazu dienen die
+Buttons <Keys.SoftKey>Workspace</Keys.SoftKey> und <Keys.SoftKey>Macro</Keys.SoftKey> rechts unten im 'Set List'-Fenster.
+
+Um eine Verknüpfung zu einem Workspace herzustellen, klicken Sie auf <Keys.SoftKey>Workspace</Keys.SoftKey> 
+und dann auf den gewünschten Workspace oder auf <Keys.SoftKey>Record Workspace</Keys.SoftKey>, um die aktuelle
+Arbeitsoberfläche zu speichern.
+
+Macros können sowohl von der gesamten Set-Liste als auch von einzelnen
+Tracks aufgerufen werden. Set-Listen-Macros werden dabei bei jedem neuen
+Track erneut getriggert. Damit kann man z.B. zu Beginn jedes neuen Songs
+einen einheitlichen Ausgangszustand herstellen. Track-Macros werden
+dagegen nur von dem jeweiligen Track aufgerufen.
+
+Um diese Macro- und Workspace-Verknüpfungen aufzurufen, klicken Sie
+rechts oben auf den Reiter 'Workspaces & Macros'. Daraufhin wird für
+jede Verknüpfung ein Button, nach Kategorien geordnet, angezeigt.
+
+![Workspace & Macros](/docs/images/Workspace-Macros.png)
+
+Klickt man auf so einen Button, so wird die entsprechende Aktion
+ausgelöst. Zum Löschen drückt man <Keys.HardKey>Delete</Keys.HardKey>, gefolgt von dem jeweiligen
+Button, und bestätigt das mit <Keys.SoftKey>Remove</Keys.SoftKey>.
+
+## Macros zur Playback-Steuerung
+
+[Macros](../titan-basics/front-panel-buttons.md#macros----tastenfolgen)
+gestatten es, häufig wiederkehrende Folgen von Tastendrücken zu
+automatisieren. So lassen sich auch lange oder komplizierte 
+Tastenkombinationen mit nur einem Knopfdruck wiederholen.
+
+Es gibt einige spezielle vorgefertigte Macros, die sich besonders zur
+Playback-Steuerung bei Verwendung von Set-Listen anbieten.
+
+Macro | Action
+------|-------
+<Keys.SoftKey>Fire First Playback</Keys.SoftKey> | Startet das erste Playback der aktuellen Seite.
+<Keys.SoftKey>Fire First Playback Page 1</Keys.SoftKey> | Startet das erste Playback auf Seite 1, unabhängig von der gerade aktuellen Seite.
+<Keys.SoftKey>Fire Playback 1</Keys.SoftKey> | Startet das Playback mit der Nummer 1.
+<Keys.SoftKey>Kill First Playback</Keys.SoftKey> | Stoppt/killt das erste Playback der aktuellen Seite.
+<Keys.SoftKey>Kill First Playback Page 1</Keys.SoftKey> | Stoppt/killt das erste Playback auf Seite 1, unabhängig von der gerade aktuellen Seite.
+<Keys.SoftKey>Kill Playback 1</Keys.SoftKey> | Stoppt/killt das Playback mit der Nummer 1.
+<Keys.SoftKey>Release First Playback</Keys.SoftKey> | Releast das erste Playback der aktuellen Seite.
+<Keys.SoftKey>Release First Playback Page 1</Keys.SoftKey> | Releast das erste Playback auf Seite 1, unabhängig von der gerade aktuellen Seite.
+<Keys.SoftKey>Release Playback 1</Keys.SoftKey> | Releast das Playback mit der Nummer 1.
+<Keys.SoftKey>Release Me</Keys.SoftKey> | Releast das momentan verbundene Playback (Cueliste).
+<Keys.SoftKey>Goto My Cue 1</Keys.SoftKey> | Geht zu Cue 1 der gerade verbundenen Cueliste.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/synergy.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/synergy.md
@@ -1,0 +1,24 @@
+---
+id: synergy
+title: Synergy und Verbinden mit Ai
+sidebar_label: Synergy und Verbinden mit Ai
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+<Video videoId="twfDqjNFasA" title="Synergy" />
+
+Titan enthält das Modul Synergy, mit dem sich einzelne
+oder mehrere Ai-Medienserver sowie Prism Zero komfortabel mit dem Pult steuern lassen.
+Das beschränkt sich nicht auf das Aufrufen von Clips oder Effekten.
+Vielmehr können Clips auch vom Pult aus hochgeladen und gleich
+umgerendert werden, es lassen sich auf dem Ai-Server neue Screen Fixtures und Layer
+anlegen, und sämtliche Outputs lassen sich bequem im Vorschaufenster
+überwachen.
+
+Shows mit Video-Content lassen sich damit deutlich einfacher und
+übersichtlicher programmieren und steuern.
+
+> Bei Ai werden Video-Outputs als "Screen Fixtures" bezeichnet. Um das hier nicht mit Fixtures im Sinne von Movinglights zu verwechseln, werden diese Outputs in Synergy/Titan als **"Screens"** (oder **"Surfaces"**) bezeichnet.
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/synergy/operating-synergy.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/synergy/operating-synergy.md
@@ -1,0 +1,252 @@
+---
+id: operating-synergy
+title: Arbeiten mit Synergy
+sidebar_label: Arbeiten mit Synergy
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Sind Titan und Ai-Server oder Prism Zero einmal [verbunden](setting-up.md), so lässt 
+sich Ai sehr einfach von Titan aus steuern.
+
+## Hochladen von Content mit dem Media Browser
+
+Mit dem Media Browser lassen sich direkt von Titan aus Clips auf den
+Ai-Server bzw. Prism Zero laden. Ebenso lassen sich neue Media-Bänke auf dem Server
+anlegen. Neuer Content wird dabei automatisch in den von Ai bevorzugten
+AiM-Codec gewandelt. Das vereinfacht das Verwenden von Medien, die erst
+im letzten Moment angeliefert werden, sehr.
+
+Zum Öffnen des Media Browsers drücken Sie zweimal <Keys.HardKey>Open/View</Keys.HardKey>
+und wählen den <Keys.SoftKey>Media Browser</Keys.SoftKey>.
+
+![Ai Media Browser Window](/docs/images/Ai-Media-Browser-Window.jpg)
+
+Links werden die am Pult/Titan-PC gefundenen Laufwerke angezeigt. Steckt
+man ein USB-Laufwerk an, erscheint dies ebenfalls. Es gibt auch
+Verknüpfungen zu üblicherweise verwendeten Ordnern.
+
+In der zweiten Spalte werden die Ordner und Medien-Dateien angezeigt,
+die im gewählten Ordner/Laufwerk vorhanden sind. Mit einem Klick auf
+einen Ordner wechselt man in diesen, ein Klick auf den Pfeil oben
+wechselt eine Verzeichnisebene höher.
+
+Rechts sind die Medien-Bänke des Ai-Servers aufgeführt. Wählt man eine
+Bank aus, so werden alle enthaltenen Dateien/Medien angezeigt. Klickt
+man auf das <Keys.ContextKey>+</Keys.ContextKey> neben der Liste der Bänke, so wird eine neue Bank 
+angelegt. Ganz oben in der rechten Spalte wird der auf dem Server 
+verfügbare Speicherplatz sowie der Pfad zum Medienverzeichnis angezeigt.
+
+Um Medien auf den Ai-Server bzw. Prism Zero zu laden, wählt man in der mittleren Spalte
+die gewünschten Dateien aus und klickt danach rechts auf die Bank, auf
+die der Upload erfolgen soll.
+
+Existieren bereits Dateien gleichen Namens auf dieser Bank, so werden
+die betreffenden Dateien rot angezeigt.
+
+![Ai Media Browser uploading content](/docs/images/Ai-Media-Browser-uploading-content.jpg)
+
+Die Dateien werden schnellstmöglich übertragen, und der
+Übertragungsfort­schritt wird angezeigt. Dabei kann das Netzwerk stark
+ausgelastet und damit verlangsamt werden. Um dies zu vermeiden, kann
+unten der Schalter **Bandwidth Saver** (Bandbreite sparen) aktiviert
+werden. Damit wird der Upload verlangsamt, und das Netzwerk wird weniger
+stark ausgelastet.
+
+Auch das automatische Umrendern (Auto Transcode) kann deaktiviert
+werden, was aber nicht zu empfehlen ist. Sobald die Dateien auf den
+Server geladen sind, erfolgt ggf. das Umrendern. Dessen Fortschritt
+zeigt sich in der Anzeige der Clips im [Attribut-Editor](#layer-steuern-mit-dem-attribut-editor), siehe folgender
+Abschnitt.
+
+## Vorschau mit dem Media Viewer
+
+Das Fenster **Video Multi View** kann alle Layer einzeln sowie jedes
+Surface (Screen) als Ergebnis der kombinierten Layer als Vorschau
+anzeigen. Ebenso lassen sich damit beliebige im Netzwerk vorhandene
+NDI-Streams anzeigen, etwa einzelne Kameras oder der Live-Output bei
+Fernsehaufzeichnungen.
+
+![Video Multi View Window](/docs/images/Video-Multi-View-Window.png)
+
+Zur Auswahl eines Streams für die Anzeige klickt man auf eine Vorschau
+im Media Viewer (leere Vorschauen zeigen ein großes +). Darauf öffnet
+sich eine Liste mit allen vorhandenen Streams, und man kann den
+gewünschten auswählen.
+
+![Video Multi View Window adding a stream](/docs/images/Video-Multi-View-Window-adding-a-stream.png)
+
+Mit der Kontext-Option <Keys.SoftKey>Change Layout</Keys.SoftKey> kann man die Anzahl und
+Anordnung der gezeigten Vorschaufenster wählen. <Keys.SoftKey>Titles Shown</Keys.SoftKey>/<Keys.SoftKey>Titles Hidden</Keys.SoftKey> bestimmt, ob die Namen der Streams als Titel
+der Vorschauen angezeigt werden.
+
+![Video Multi View Window layout options](/docs/images/Video-Multi-View-Window-laout-options.png)
+
+Dabei muss die Option **"Automatic NDI preview"** in den [Synergy Settings](setting-up.md#einrichten-von-synergy)
+aktiv sein, damit die Vorschauen angezeigt werden.
+
+Format | Datenrate
+---|---
+1920x1080p30 | 120Mbps
+1920x1080p60 | 200Mbps
+3840x2160p30 | 280Mbps
+3840x2160p60 | 480Mbps
+
+## Layer steuern mit dem Attribut-Editor
+
+Sobald ein oder mehrere Layer ausgewählt sind (im Fenster [Synergy
+Fixtures](setting-up.md#das-fenster-synergy-fixtures)), lassen sich die darauf abzuspielenden Medien im
+Attribut-Editor wählen und manipulieren (das geht auch wie gewohnt mit
+den Encodern und Attributbänken).
+
+> Die wichtigsten Attribute dabei sind **Intensity** zur Einstellung der
+Helligkeit sowie die **Media Selection** (Medienauswahl), um Bank und Clip
+zu wählen. Aber es lassen sich auch viele weitere Attribute einstellen,
+Effekte hinzufügen etc. Prism Zero hat dabei einen deutlich kleineren Funktionsumfang als Ai.
+
+![Clip tab of Attribute Editor for Synergy layer](/docs/images/Clip-tab-of-Attribute-Editor-for-Synergy-layer.png)
+
+Auf der Seite Media Selection bei den Clips kann man rechts oben durch
+einen Klick auf das <Keys.SoftKey>T</Keys.SoftKey> die Anzeige der Namen aktivieren oder
+deaktivieren - letzteres ist etwa bei sehr langen Namen empfehlenswert.
+
+Manche Attribute, z.B. Fx Select (Effekt-Auswahl) haben sehr viele
+mögliche Optionen. Diese werden zunächst in einer langen
+Scroll-Liste angezeigt. Klickt man auf die Titelleiste der
+Scroll-Liste, so wechselt die Anzeige in ein großes Fenster mit
+Raster, was ggf. übersichtlicher ist.
+
+![FX tab of Attribute Editor for Synergy layer](/docs/images/FX-tab-of-Attribute-Editor-for-Synergy-layer.png)
+
+Bei den Fx (Effekt)-Attributen werden die Namen der Effekte direkt
+vom Ai-Server bezogen, so dass man wirklich das sieht, was auf dem
+Server angewählt ist. Dies ist auch bei Plugins für generativen
+Content der Fall, deren Namen man selbst bestimmt.
+
+> Wird ein Layer ausgewählt und <Keys.HardKey>Locate</Keys.HardKey> gedrückt, so wird die Helligkeit
+auf 100% gesetzt, aber sämtliche Medien und Effekte werden gecleart. Damit 
+wird der Layer wieder in einen neutralen Ausgangszustand versetzt. **Um
+etwas am Output zu sehen, muss nur noch ein Clip gewählt werden.**
+
+Die Clips zeigen auch den Status des Umkodierens:
+
+Wird gerade umgerendert | Warten auf Umrendern | Umrendern fehlgeschlagen
+---|---|---
+![Video currently transcoding in Attribute Editor for Synergy layer](/docs/images/Video-currently-transcoding-in-Attribute-Editor-for-Synergy-layer.png) | ![Video queued for transcoding in Attribute Editor for Synergy layer](/docs/images/Video-queued-for-transcoding-in-Attribute-Editor-for-Synergy-layer.png) | ![Video failed to transcode in Attribute Editor for Synergy layer](/docs/images/Video-failed-to-transcode-in-Attribute-Editor-for-Synergy-layer.png)
+
+Für Ai-Layer lassen sich wie für andere Geräte auch [Paletten anlegen](../palettes/creating-palettes.md). So lassen sich z.B. Clip-Auswahl, 
+Farbe, Position und vieles mehr in Paletten speichern, schnell aufrufen 
+und verändern. Auch [Fadezeiten](../palettes/timing-with-palettes.md)
+funktionieren wie gewohnt.
+
+## Lightmap: Pixelmapping mit Video-Content
+
+Mitunter will man auf Lampen, die im Pult gepatcht sind, auch
+Video-Content wiedergeben, etwa wenn eine Wand aus vielen LED-Lampen
+zusammengesetzt ist. Der Titan-Pixelmapper kann direkt den Output von Ai bzw. Prism Zero
+verwenden - sowohl eines einzelnen Layers (nur bei Ai) als auch eines ganzen
+Surfaces. Dabei ist es nicht erforderlich, das Titan-Surface mit einem
+Output des Servers zu verbinden.
+
+> Im [Layout-Editor](../controlling-fixtures/fixture-groups.md#gerätereihenfolge-und--anordnung-in-den-gruppen) werden die Lampen/Zellen so positioniert, wie sie auch
+tatsächlich angeordnet sind, so dass jeweils der passende
+Videoausschnitt angezeigt wird, siehe [nächster Abschnitt](#verwendung-des-layout-editors-mit-ai).
+
+1.  **Starten Sie einen Clip** auf dem gewünschten Surface, etwa mit 
+    dem [Attribut-Editor](#layer-steuern-mit-dem-attribut-editor).
+2.  Wählen Sie nun das Menü <Keys.SoftKey>Shapes and Effects</Keys.SoftKey>, 
+    dann <Keys.SoftKey>Pixel Mapper</Keys.SoftKey>.
+3.  Wählen Sie die **[Gerätegruppe](../controlling-fixtures/fixture-groups.md)**, auf der 
+    das Video laufen soll. Daraufhin öffnet sich der Effekt-Editor.
+4.  Klicken Sie unten links auf das <Keys.ContextKey>+</Keys.ContextKey>, um einen Pixelmapper-Effekt
+    hinzuzufügen.
+5.  Klicken Sie oben rechts auf den <Keys.SoftKey>Synergy</Keys.SoftKey> - Button.<br/>
+  ![Effect Editor - Pixel Mapper - Adding an Element](/docs/images/Effect-Editor-Pixel-Mapper-Adding-an-Element.png)
+6.  Mit <Keys.SoftKey>Source Surface</Keys.SoftKey> kann die zu verwendende Quelle (Layer oder
+    Surface) gewählt werden; auch kann man mit den Red/Green/Blue-Reglern die Farbe einstellen.<br/>
+  ![Ai layer video overlay in Pixel Mapper Window](/docs/images/Ai-layer-video-overlay-in-Pixel-Mapper-Window.png)
+
+Der gewählte Clip wird nun auf den Lampen der gewählten Gruppe
+wiedergegeben. Dabei ist der Pixelmapper-Effekt mit dem Synergy-Surface
+verknüpft, und Änderungen in diesem haben unmittelbare Auswirkung auf
+die Wiedergabe auf den Lampen.
+
+![Pixel Mapped fixtures with Ai screen shown in Capture Visualiser](/docs/images/Pixel-Mapped-fixtures-with-Ai-screen-shown-in-Capture-Visualiser.png)
+
+## Verwendung des Layout-Editors mit Synergy
+
+Die grundsätzliche Funktionsweise des Layout-Editors ist im Abschnitt
+[Gerätereihenfolge und -anordnung in den Gruppen](../controlling-fixtures/fixture-groups.md#gerätereihenfolge-und--anordnung-in-den-gruppen) beschrieben.
+
+Bei der Verwendung mit Synergy gibt es mit dem Kontext-Menü <Keys.SoftKey>Media Options</Keys.SoftKey> einige sinnvolle Zusatzfunktionen zur Erstellung des Gruppenlayouts.
+
+### Show Video Overlay
+Hier lässt sich jeder beliebige Layer und jedes
+Surface über den anzuordnenden Lampen einblenden, um diese passend zu
+positionieren.
+
+![Show Video Overlay in Layout Editor for mapping fixtures to Ai Video layers](/docs/images/Show-Video-Overlay-in-Layout-Editor-for-mapping-fixtures-to-Ai-Video-layers.jpeg)
+
+### Sample Region Overlay
+Sind in Ai Sample Regions definiert (Wiedergabe-Ausschnitte), etwa bei der
+gemischten Verwendung von HiRes-LED-Screens und Lampen, so werden diese 
+Regionen eingeblendet.
+
+![Sample Region Overlay in Layout Editor for mapping fixtures to Ai Video layers](/docs/images/Sample-Region-Overlay-in-Layout-Editor-for-mapping-fixtures-to-Ai-Video-layers.png)
+
+### Position Overlay
+Ist diese Option aktiviert, so wird, sobald ein
+Gerät in Titan ausgewählt ist, dessen Position auf dem Output durch
+dünne Linien angezeigt, womit eine noch genauere Positionierung möglich
+ist.
+
+![Position Overlay in Layout Editor for mapping fixtures to Ai Video layers](/docs/images/Position-Overlay-in-Layout-Editor-for-mapping-fixtures-to-Ai-Video-layers.png)
+
+### Match Surface Resolution
+Gestattet es, das Layout-Raster an die
+Auflösung oder das Seitenverhältnis eines Surfaces (Ai-Outputs)
+anzupassen. Klickt man darauf, erscheint eine Auswahlliste der
+verfügbaren Surfaces. Wählt man eins davon aus, gibt es Buttons für
+<Keys.SoftKey>Width</Keys.SoftKey> (Breite) und <Keys.SoftKey>Height</Keys.SoftKey> (Höhe), die mit den Werten, die sich
+aus der Auflösung des Surfaces ergeben, vorbelegt sind. Normalerweise
+wird man nicht das Grid in voller Auslösung verwenden, da ja die Lampen
+deutlich größer sind. Ändert man aber Breite oder Höhe, so ändert sich
+der andere Wert entsprechend mit, damit das Seitenverhältnis erhalten
+bleibt.
+
+![Match Surface Resolution in Layout Editor for mapping fixtures to Ai Video layers](/docs/images/Match-Surface-Resolution-in-Layout-Editor-for-mapping-fixtures-to-Ai-Video-layers.png)
+
+Im Layout-Editor lassen sich Geräte auch skalieren, um die relative
+Größe an die tatsächlichen Größenverhältnisse anzupassen. Dazu klickt
+man auf den Kontext-Button <Keys.SoftKey>Position and Angle</Keys.SoftKey>, bis 
+dieser <Keys.SoftKey>Fixture Scale</Keys.SoftKey> zeigt. Skaliert man Geräte mit Zellen sehr klein, so
+verschwinden die einzelnen Zellen, und alle Zellen arbeiten synchron.
+
+## Phasensteuerung von Keyframe-Shapes durch Ai
+
+Die Phase von Keyframe-Shapes lässt sich durch die Helligkeit eines
+Ai-Videos steuern. Damit lassen sich sehr abgefahrene Effekte erzeugen,
+da praktisch sämtliche Aspekte der Lampen durch ein Video gesteuert
+werden können. Die Helligkeit von 0 bis 100% ist dabei mit der
+Phasenlage 0 bis 360° verknüpft.
+
+Ist der [Keyframe-Shape erstellt](../effects/key-frame-shapes.md#einen-keyframe-shape-erzeugen), so gibt 
+es unten im Effekt-Editor den Button [Phase Master](../effects/key-frame-shapes.md#steuerelemente-für-shape-und-layer), 
+mit dem man das gewünschte Surface als Master auswählt.
+
+![Phase Master using Ai screen in Keyframe Shape](/docs/images/Phase-Master-using-Ai-screen-in-Keyframe-Shape.png)
+
+## Bänke und Clips mit speziellen Funktionen
+
+Wählt man im Attribut-Editor Bänke und Clips aus, so haben einige
+Nummern spezielle Funktionen, um direkt den Output andererScreens und
+Layer zu verknüpfen. Damit kann man das Arbeiten deutlich vereinfachen
+und ggf. auch Rechenleistung sparen, wenn der gleiche Inhalt auf
+mehreren Outputs gezeigt werden soll.
+
+Bank/Clip | Function
+---|---
+&nbsp;**Bank 240 - 255** | Verlinkt auf Surface/Screen Fixture 1-16.
+&nbsp;**Clip 0 - 200** | Verlinkt auf Layer 1-201 auf diesem Surface.
+&nbsp;**Clip 255** | Verlinkt auf das Screen Fixture als Ganzes (alle Layer).

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/synergy/operating-synergy.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/synergy/operating-synergy.md
@@ -60,39 +60,6 @@ Server geladen sind, erfolgt ggf. das Umrendern. Dessen Fortschritt
 zeigt sich in der Anzeige der Clips im [Attribut-Editor](#layer-steuern-mit-dem-attribut-editor), siehe folgender
 Abschnitt.
 
-## Vorschau mit dem Media Viewer
-
-Das Fenster **Video Multi View** kann alle Layer einzeln sowie jedes
-Surface (Screen) als Ergebnis der kombinierten Layer als Vorschau
-anzeigen. Ebenso lassen sich damit beliebige im Netzwerk vorhandene
-NDI-Streams anzeigen, etwa einzelne Kameras oder der Live-Output bei
-Fernsehaufzeichnungen.
-
-![Video Multi View Window](/docs/images/Video-Multi-View-Window.png)
-
-Zur Auswahl eines Streams für die Anzeige klickt man auf eine Vorschau
-im Media Viewer (leere Vorschauen zeigen ein großes +). Darauf öffnet
-sich eine Liste mit allen vorhandenen Streams, und man kann den
-gewünschten auswählen.
-
-![Video Multi View Window adding a stream](/docs/images/Video-Multi-View-Window-adding-a-stream.png)
-
-Mit der Kontext-Option <Keys.SoftKey>Change Layout</Keys.SoftKey> kann man die Anzahl und
-Anordnung der gezeigten Vorschaufenster wählen. <Keys.SoftKey>Titles Shown</Keys.SoftKey>/<Keys.SoftKey>Titles Hidden</Keys.SoftKey> bestimmt, ob die Namen der Streams als Titel
-der Vorschauen angezeigt werden.
-
-![Video Multi View Window layout options](/docs/images/Video-Multi-View-Window-laout-options.png)
-
-Dabei muss die Option **"Automatic NDI preview"** in den [Synergy Settings](setting-up.md#einrichten-von-synergy)
-aktiv sein, damit die Vorschauen angezeigt werden.
-
-Format | Datenrate
----|---
-1920x1080p30 | 120Mbps
-1920x1080p60 | 200Mbps
-3840x2160p30 | 280Mbps
-3840x2160p60 | 480Mbps
-
 ## Layer steuern mit dem Attribut-Editor
 
 Sobald ein oder mehrere Layer ausgewählt sind (im Fenster [Synergy

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/synergy/setting-up.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/synergy/setting-up.md
@@ -1,0 +1,155 @@
+---
+id: setting-up
+title: Einrichtung
+sidebar_label: Einrichtung
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Verbinden mit einem Ai-Server
+
+Der/die Ai-Server und das Pult müssen per Ethernet miteinander verbunden
+sein. Vor allem für die [NDI-Vorschauen](operating-synergy.md#vorschau-mit-dem-media-viewer) und beim Hochladen von Clips
+kommt es zu einem erheblichen Datenaufkommen. Daher sollten möglichst
+folgende Hinweise beachtet werden, um ein zuverlässiges Arbeiten zu
+ermöglichen:
+
+-   Es sollte sich um ein Gigabit-Netzwerk handeln (1 Gbit/s).
+-   Nach Möglichkeit ein getrenntes Netzwerk für Synergy.
+-   Bei der Verwendung der PC-Suite sollte die Windows Firewall
+    deaktiviert sein.
+
+>   Beim Installieren und Upgraden ist darauf zu achten, dass Ai/Synergy 
+    die gleiche Version haben muss wie die Titan-Software des 
+    Pultes. Die Software steht auf der [Avolites Download-Seite](https://www.avolites.com/software/latest-version)
+    zum Download bereit. Für Synergy werden ggf. kleinere Update-Pakete 
+    zur Verfügung gestellt, um Ai auf die gleiche Version wie Titan zu bringen.
+
+Sollte es zu Problemen kommen, Titan und die Ai-Software miteinander zu
+verbinden, so ist insbesondere die Softwareversion (müssen identisch
+sein) sowie die Netzwerkkonfiguration (unterschiedliche IP-Adressen,
+aber im gleichen Bereich; gleiche Subnetz-Masken) zu überprüfen. Mehr dazu
+in [Einrichten des Netzwerkbetriebs](../networking.md).
+
+## Einrichten der Show in Ai
+
+Einfache Setups mit nur einem einzelnen Display oder Projektor können
+ganz einfach direkt vom Pult aus eingerichtet werden. Starten Sie in Ai
+ein leeres Projekt und folgen Sie den Anweisungen im [nächsten Abschnitt](#einrichten-von-synergy),
+um mittels Synergy Screens und Layer anzulegen.
+
+Für kompliziertere Setups ist dagegen die Einrichtung der Screens in Ai
+vorzunehmen (siehe Ai-Handbuch). Diese werden dann in Synergy in Titan
+angezeigt, und man kann wie beschrieben Layer hinzufügen oder
+umbenennen.
+
+## Verbinden mit Prism Zero 
+
+Prism Zero muss auf einem Computer im gleichen Netzwerk laufen.
+
+In den Einstellungen von Prism (File, Settings - oder per Klick auf das Menü oben links), navigiert man in den Bereich Synergy und aktiviert den Schalter **Enable Synergy**. Bei **Synergy Version** muss die gleiche Version ausgewählt werden wie Titan (Pult ode PC-Suite). Prism Zero startet den Titan Media Node, welcher die Verbindung zwischen Titan und Prism herstellt. Sobald der Titan Media Node läuft, wechselt der 'Connection Status' auf "Connected". Diese Einstellungen werden beim nächsten Programmstart automatisch geladen.
+
+![Prism Zero Settings Window](/docs/images/prism-zero.png)
+
+Sobald die Verbindung zwischen Prism und dem Titan Media Node hergestellt ist, kann der Node per TitanNet von Pulten im Netzwerk gefunden, verwendet und gesteuert werden, siehe nächster Abschnitt.
+
+- Wenn die Auswahlliste bei "Synergy Version" leer ist oder die richtige Version fehlt, so muss die richtige Version des Titan Media Nodes von www.avolites.com heruntergeladen und installiert werden.
+
+## Einrichten von Synergy
+
+In Titan öffnen Sie das Fenster **Synergy Settings**, entweder mit dem
+entsprechenden Workspace bei neuen Shows, oder über das Menü 'Open
+Workspace Window'.
+
+Dieses Fenster ähnelt entfernt dem der [DMX-Einstellungen](../system-settings/dmx-output-mapping.md#dmx-eigenschaften): hier stellt
+man ein, wie Titan Prism Zero bzw. die einzelnen Outputs von Ai ansteuert. Ebenso kann
+man hier für Ai Layer hinzufügen oder löschen sowie komplett neue Surfaces
+anlegen (müssen ggf. in Ai noch genauer eingestellt werden).
+
+![Synergy Settings Window](/docs/images/Synergy-Settings-Window-v15.jpg)
+
+Links sind die verfügbaren Ai-Server und Prism-Instanzen mit ihren Outputs aufgeführt. In
+der Mitte sind die in Titan angelegten Surfaces und Layer aufgeführt.
+Linien zwischen den Outputs und Surfaces zeigen die Zuordnung an. Unten
+tauchen die Surfaces auf, die zwar in Ai oder Prism Zero schon angelegt sind, aber noch
+nicht in Titan. Dieses sind die ‚unmatched' (nicht zugewiesenen)
+Surfaces.
+
+Klickt man auf das <Keys.ContextKey>+</Keys.ContextKey> unten und wählt aus der aufklappenden Liste
+'Surface', so wird ein neues Surface hinzugefügt. Dieses erscheint in
+der mittleren Spalte oben. Neue Ai-Surfaces haben zunächst immer zwei
+Layer, Prism Zero hat nur einen Layer.
+
+![Synergy Settings Window screen settings](/docs/images/Synergy-Settings-Window-screen-settings-v15.jpg)
+
+Klickt man in der mittleren Spalte oben auf die Titelleiste eines
+Surfaces, so werden rechts die entsprechenden Optionen angezeigt. Damit
+lässt sich die Auflösung einstellen, wahlweise per Auswahl aus einer
+Liste oder per numerischer Eingabe. Ganz rechts oben kann man mit dem
+farbigen Button das Halo des Surfaces ändern sowie mit dem <Keys.ContextKey>Stift</Keys.ContextKey>-Button
+die Legende (Bezeichnung) bearbeiten (beides ist auch wie gewohnt per <Keys.SoftKey>Set Legend</Keys.SoftKey> möglich).
+
+Klickt man innerhalb eines Surfaces auf einen Layer, so werden rechts
+die Optionen des Layers angezeigt. Damit kann man einen Speed- oder
+BPM-Master für den Layer zuweisen.
+
+Sind weder Surfaces noch Layer angewählt, so werden rechts allgemeine
+Informationen über das System angezeigt. Es gibt die Option 'Automatic
+NDI Previews', mit der NDI-Streams ein- bzw. ausgeschaltet werden.
+Verwendet man das Vorschaufenster (Media Preview), so müssen NDI
+Previews aktiviert sein - verwendet man das nicht, so empfiehlt es
+sich, die Option zu deaktivieren, um das Netzwerk zu entlasten.
+
+Ist in Titan ein Surface angelegt, so muss dies einem Ai-Surface (Ai 
+Screen Fixture, oder Prism Zero) zugewiesen werden. Dazu klickt man auf den Button <Keys.ContextKey>Link</Keys.ContextKey>
+des nicht zugewiesenen Ai-Surfaces unten und danach auf das
+Titan-Surface oben. Wählt man dagegen **Link to new Surface**, so wird ein
+neues Titan-Surface angelegt und verknüpft.
+
+![Synergy Settings Window linking a screen](/docs/images/Synergy-Settings-Window-linking-a-screen-v15.jpg)
+
+Sind die Surfaces verknüpft, so wird dies über eine farbige Linie zum
+Server angezeigt, und das nicht verknüpfte Surface unten verschwindet.
+
+![Synergy Settings Window with a linked screen](/docs/images/Synergy-Settings-Window-with-a-linked-screen-v15.jpg)
+
+Das Surface lässt sich auch mit mehreren Ai-Outputs verknüpfen, wenn man
+z.B. den gleichen Content auf mehreren Outputs verwenden will. Dazu
+klickt man auf das Surface in der Mitte und danach links auf den
+zusätzlichen Output.
+
+Ist ein Layer verknüpft, so wird das in Ai in den Layer Properties mit
+&nbsp;**Synergy Control: Enabled** angezeigt. Dieser Layer kann nun nicht von Ai
+direkt, sondern nur über Titan/Synergy gesteuert werden.
+
+![Avolites Ai Layer Adjustments](/docs/images/Avolites-Ai-Layer-Adjustments.png)
+
+Um auf einem Ai-Server einen weiteren Layer hinzuzufügen, klickt man auf das Surface, dann
+auf den <Keys.ContextKey>+</Keys.ContextKey> - Button unten, und wählt **Layer**.
+
+Um einen Layer oder ein Surface zu löschen, wählt man dieses aus und
+klickt unten auf den <Keys.ContextKey>Papierkorb</Keys.ContextKey>, oder man drückt <Keys.HardKey>Delete</Keys.HardKey> und
+klickt dann auf das zu löschende Element. Ist dabei Ai verbunden, so
+wird der Layer bzw. das Surface (Screen Fixture) auch in Ai gelöscht.
+
+## Das Fenster Synergy Fixtures
+
+Jeder Layer erscheint als Button im Fenster 'Synergy Fixtures'. Dies
+kann man entweder mit dem Button <Keys.SoftKey>View Synergy Fixtures</Keys.SoftKey> im [Synergy
+Settings-Fenster](#einrichten-von-synergy) öffnen, oder Sie drücken zweimal 
+&nbsp;<Keys.HardKey>Open/View</Keys.HardKey> und wählen es mit den Buttons zur Fensterauswahl.
+
+![Synergy Fixtures Workspace Window](/docs/images/Synergy-Fixtures-Workspace-Window.png)
+
+Durch Anklicken lassen sich einzelne oder mehrere Layer auswählen, wie
+man auch sonst Dimmer oder Movinglights zum Steuern auswählt. Sind Layer
+ausgewählt, so kann man im [Attribut-Editor](operating-synergy.md#layer-steuern-mit-dem-attribut-editor) oder einfach mit den
+Attributtasten und [Encodern](../controlling-fixtures/changing-fixture-attributes.md#einstellen-von-attributen-mit-den-encodern) Medien und Effekte steuern, die darauf
+angezeigt werden. Genauso lassen sich auch [Paletten](../palettes/creating-palettes.md) oder [Playbacks](../cues/creating-a-cue.md#anlegen-eines-cues)
+speichern, wie das mit anderen Fixtures gewohnt ist. Es wird im [folgenden Abschnitt](operating-synergy.md) näher erläutert.
+
+>   Die Synergy-Layer werden in einem eigenen Fenster angelegt, damit
+    man eine bessere Übersicht hat. Wenn gewünscht, kann man diese
+    aber in das normale Fixture (Geräte)-Fenster verschieben, um alles
+    an einem Platz zu haben.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/synergy/setting-up.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/synergy/setting-up.md
@@ -10,7 +10,7 @@ import Video from '@site/src/components/video.tsx';
 ## Verbinden mit einem Ai-Server
 
 Der/die Ai-Server und das Pult müssen per Ethernet miteinander verbunden
-sein. Vor allem für die [NDI-Vorschauen](operating-synergy.md#vorschau-mit-dem-media-viewer) und beim Hochladen von Clips
+sein. Vor allem beim Hochladen großer Clips
 kommt es zu einem erheblichen Datenaufkommen. Daher sollten möglichst
 folgende Hinweise beachtet werden, um ein zuverlässiges Arbeiten zu
 ermöglichen:
@@ -20,11 +20,14 @@ ermöglichen:
 -   Bei der Verwendung der PC-Suite sollte die Windows Firewall
     deaktiviert sein.
 
->   Beim Installieren und Upgraden ist darauf zu achten, dass Ai/Synergy 
+>   Beim Installieren und Upgraden ist darauf zu achten, dass der Titan Media Node in Ai bzw. Prism
     die gleiche Version haben muss wie die Titan-Software des 
     Pultes. Die Software steht auf der [Avolites Download-Seite](https://www.avolites.com/software/latest-version)
-    zum Download bereit. Für Synergy werden ggf. kleinere Update-Pakete 
-    zur Verfügung gestellt, um Ai auf die gleiche Version wie Titan zu bringen.
+    zum Download bereit. 
+
+Im Fenster 'System Settings' von Ai findet sich in den Art-Net/CITP-Optionen die Auswahlliste **Titan Media Node Version**. Dort ist die zur Titan-Version des Pultes passende Version auszuwählen und anschließend **Enable Synergy** zu aktivieren. Daraufhin startet Ai den Titan Media Node. Sobald dieser läuft, wird in der oberen Statusleiste von Ai "TitanNet Enabled" angezeigt. (In Ai-Versionen vor 12.2. ist stattdessen eine separates Synergy-Upgrade erforderlich).	
+
+![Ai Settings Window](/docs/images/Ai-Titan-Media-Node.png)
 
 Sollte es zu Problemen kommen, Titan und die Ai-Software miteinander zu
 verbinden, so ist insbesondere die Softwareversion (müssen identisch
@@ -67,7 +70,7 @@ man ein, wie Titan Prism Zero bzw. die einzelnen Outputs von Ai ansteuert. Ebens
 man hier für Ai Layer hinzufügen oder löschen sowie komplett neue Surfaces
 anlegen (müssen ggf. in Ai noch genauer eingestellt werden).
 
-![Synergy Settings Window](/docs/images/Synergy-Settings-Window-v15.jpg)
+![Synergy Settings Window](/docs/images/Synergy-Settings-Window-v19.png)
 
 Links sind die verfügbaren Ai-Server und Prism-Instanzen mit ihren Outputs aufgeführt. In
 der Mitte sind die in Titan angelegten Surfaces und Layer aufgeführt.
@@ -81,7 +84,7 @@ Klickt man auf das <Keys.ContextKey>+</Keys.ContextKey> unten und wählt aus der
 der mittleren Spalte oben. Neue Ai-Surfaces haben zunächst immer zwei
 Layer, Prism Zero hat nur einen Layer.
 
-![Synergy Settings Window screen settings](/docs/images/Synergy-Settings-Window-screen-settings-v15.jpg)
+![Synergy Settings Window screen settings](/docs/images/Synergy-Settings-Window-Screen-Settings-v19.png)
 
 Klickt man in der mittleren Spalte oben auf die Titelleiste eines
 Surfaces, so werden rechts die entsprechenden Optionen angezeigt. Damit
@@ -95,11 +98,7 @@ die Optionen des Layers angezeigt. Damit kann man einen Speed- oder
 BPM-Master für den Layer zuweisen.
 
 Sind weder Surfaces noch Layer angewählt, so werden rechts allgemeine
-Informationen über das System angezeigt. Es gibt die Option 'Automatic
-NDI Previews', mit der NDI-Streams ein- bzw. ausgeschaltet werden.
-Verwendet man das Vorschaufenster (Media Preview), so müssen NDI
-Previews aktiviert sein - verwendet man das nicht, so empfiehlt es
-sich, die Option zu deaktivieren, um das Netzwerk zu entlasten.
+Informationen über das System angezeigt. 
 
 Ist in Titan ein Surface angelegt, so muss dies einem Ai-Surface (Ai 
 Screen Fixture, oder Prism Zero) zugewiesen werden. Dazu klickt man auf den Button <Keys.ContextKey>Link</Keys.ContextKey>
@@ -107,12 +106,12 @@ des nicht zugewiesenen Ai-Surfaces unten und danach auf das
 Titan-Surface oben. Wählt man dagegen **Link to new Surface**, so wird ein
 neues Titan-Surface angelegt und verknüpft.
 
-![Synergy Settings Window linking a screen](/docs/images/Synergy-Settings-Window-linking-a-screen-v15.jpg)
+![Synergy Settings Window linking a screen](/docs/images/Synergy-Settings-Window-Linking-A-Screen-v19.png)
 
 Sind die Surfaces verknüpft, so wird dies über eine farbige Linie zum
 Server angezeigt, und das nicht verknüpfte Surface unten verschwindet.
 
-![Synergy Settings Window with a linked screen](/docs/images/Synergy-Settings-Window-with-a-linked-screen-v15.jpg)
+![Synergy Settings Window with a linked screen](/docs/images/Synergy-Settings-Window-With-A-Linked-Screen-v19.png)
 
 Das Surface lässt sich auch mit mehreren Ai-Outputs verknüpfen, wenn man
 z.B. den gleichen Content auf mehreren Outputs verwenden will. Dazu

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings.md
@@ -1,0 +1,19 @@
+---
+id: system-settings
+title: System und Benutzereinstellungen
+sidebar_label: System und Benutzereinstellungen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Titan bietet eine Vielzahl von Optionen, um es den jeweiligen
+Anforderungen entsprechend konfigurieren zu können. Auf häufig benötigte
+Optionen kann man mit der Menütaste 'User Settings'
+(Benutzereinstellungen) zugreifen -- drücken Sie dazu <Keys.HardKey>AVO</Keys.HardKey> + <Keys.SoftKey>User Settings</Keys.SoftKey>.
+
+Das System-Menü erlaubt es, grundsätzliche Parameter des Pultes zu ändern,
+etwa die Einrichtung der DMX-Anschlüsse, Netzwerkadressen und externe Displays.
+
+In diesem Kapitel wird außerdem das Vorgehen zur Aktualisierung der
+Software beschrieben.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/cleaning-the-console.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/cleaning-the-console.md
@@ -1,0 +1,25 @@
+---
+id: cleaning-the-console
+title: Das Pult reinigen
+sidebar_label: Das Pult reinigen
+---
+
+Trennen Sie als erstes das Pult vom Netz
+
+Zum Reinigen der laminierten Oberflächen verwenden Sie ein alkoholfreies Desinfektionsmittel:
+- wischen Sie die Oberflächen mit einem feuchten Tuch ab
+- vermeiden Sie das Eindringen von Flüssigkeit in Schalter und Fader
+
+> Wir empfehlen alkoholfreie Reinigungsmittel, weil Alkohol die lackierte Oberfläche
+  des Laminats angreifen und diese stumpf machen würde
+
+Zum Reinigen des Touchscreens verwenden Sie entweder ebenfalls ein alkoholfreies Desinfektionsmittel 
+oder eine Mischung aus 70% Alkohol und 30% Wasser.
+
+- entfernen sie sorgfältig alle Feuchtigkeitsrückstände von den Rändern des Touchscreens,
+  da diese die Funktion des Touch-Sensors beeinträchtigen könnten.
+- sollte dennoch der Touch-Sensor nach dem Reinigen fehlerhaft arbeiten, so schieben Sie ein
+  Stück trockenes Papier ca. 6mm weit zwischen Gehäuse/Dichtung und den Touchscreen und schieben dieses 
+  einmal rings um den ganzen Bildschirm. Eventuell muss dies mit einem weiteren Stück Papier wiederholt werden.
+
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/curves.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/curves.md
@@ -1,0 +1,32 @@
+---
+id: curves
+title: Curves - Kennlinien/Kurven
+sidebar_label: Curves - Kennlinien/Kurven
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Für verschiedene Zwecke lässt sich aus einer Vielzahl von Kennlinien
+wählen, mit denen festgelegt wird, wie die DMX-Werte den Reglerwerten
+folgen, etwa: komplett linear, oder anfangs und am Ende sanft mit
+größerer Beschleunigung in der Mitte, oder diverse andere Optionen. Das
+Zuweisen der Kennlinien erfolgt über die <Keys.SoftKey>Options</Keys.SoftKey> der Playbacks, 
+siehe [Playback Options](../cues/playback-options.md).
+
+![Curve - Linear](/docs/images/Curve-Linear.png)
+![Curve - Always On](/docs/images/Curve-Always-On.png)
+![Curve - Relay on > 50%](/docs/images/Curve-Relay-on-50.png)
+![Curve - Relay off > 50%](/docs/images/Curve-Relay-off-50.png)
+![Curve - Square](/docs/images/Curve-Square.png)
+![Curve - Logarithmic](/docs/images/Curve-Logarithmic.png)
+![Curve - Linear Lumens](/docs/images/Curve-Linear-Lumens.png)
+![Curve - Alt Linear](/docs/images/Curve-Alt-Linear.png)
+![Curve - S-Curve 1](/docs/images/Curve-S-Curve-1.png)
+![Curve - S-Curve 2](/docs/images/Curve-S-Curve-2.png)
+![Curve - Cubic 1](/docs/images/Curve-Cubic-1.png)
+![Curve - Cubic 2](/docs/images/Curve-Cubic-2.png)
+![Curve - Triangle](/docs/images/Curve-Triangle.png)
+![Curve - Bounce](/docs/images/Curve-Bounce.png)
+![Curve - 90% Linear](/docs/images/Curve-90-Linear.png)
+![Curve - 80% Linear](/docs/images/Curve-80-Linear.png)

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/dmx-output-mapping.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/dmx-output-mapping.md
@@ -1,0 +1,237 @@
+---
+id: dmx-output-mapping
+title: DMX-Ausgänge einrichten
+sidebar_label: DMX-Ausgänge einrichten
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Das Ausgangssignal kann per DMX über die XLR-Buchsen sowie per Art-Net und sACN über die Netzwerkanschlüsse ausgegeben werden.
+
+Alle Pulte können bis zu 64 DMX-Universen über DMX und Netzwerk (Art-Net
+oder sACN) ausgeben (der **T1** ist auf ein Universum, der **T2** auf zwei
+Universen und das **T3** auf 16 Universen beschränkt; für das T3 sind optional Lizenzerweiterungen erhältlich).
+
+Pulte selbst können bis 16 DMX-Universen ausgeben (32 beim D9 und D7), ist mehr erforderlich, so lässt sich 
+mit [Avolites TitanNet-Prozessoren (TNPs)](../titan-net.md) durch Verteilen der Rechenlast die 
+Gesamtzahl an Universen bis auf 64 erhöhen. (Für T1, T2 und T3 kann die Beschränkung nicht durch TNPs aufgehoben werden).
+
+>   Außer beim T1, T2 und T3 ist es möglich, in der Pult-Software mehr als 16 Universen
+    zuzuweisen. Abhängig von der Programmierung und vom Patch wirkt sich das aber negativ auf die Performance aus. In
+    der TitanNet-Übersicht wird daher bei der Anzeige der Rechenleistung
+    eine Warnung angezeigt.
+
+## Einrichten der DMX-Ausgänge
+
+Öffnen Sie das [System-Menü](the-system-menu.md) (normalerweise mit
+<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>) 
+und wählen <Keys.SoftKey>DMX Settings</Keys.SoftKey>.
+
+Das DMX-Fenster öffnet sich nun zunächst auf dem Tab mit dem Node
+(Knoten), den das Pult selbst darstellt. Es zeigt die vorhandenen
+*DMX-Knoten* (also möglichen Ausspielwege/Empfänger) auf der linken, sowie
+die pultinternen *DMX-Linien* auf der rechten Seite. Jede einzelne
+DMX-Linie kann an einen oder mehrere Empfänger gesendet werden. Wird
+einer Linie mehr als ein Empfänger zugeordnet, so erhalten alle diese
+Knoten das identische Signal. Wenn Geräte per Art-Net oder sACN verbunden
+sind oder TNPs im Netzwerk gefunden wurden, so erscheinen diese
+ebenfalls auf der linken Seite.
+
+Rechts werden für jede interne DMX-Linie die zugeordneten Knoten
+aufgeführt. In der Grundeinstellung sind die Linien von 1 aufsteigend
+auf die XLR-Buchsen des Pultes geroutet.
+
+![DMX Settings Window](/docs/images/DMX-Settings-Window.png)
+
+Um einen Node einer DMX-Linie zuzuordnen klicken Sie links auf den Node 
+(z.B. auf **Expert DMX A**) und danach rechts auf die gewünschte Linie, z.B. 
+&nbsp;**Line 1**. Der Node verschwindet daraufhin links und erscheint rechts bei der 
+zugewiesenen DMX-Linie.
+
+![Node in DMX Settings Window](/docs/images/Node-in-DMX-Settings-Window.png)
+
+Zum Löschen einer Zuordnung dienen die individuellen oder gruppenweisen
+<Keys.ContextKey>X</Keys.ContextKey>-Schaltflächen: pro Node, pro Linie, sowie ganz oben bei **Dmx Lines** für
+sämtliche DMX-Ausgänge.
+
+Um die Zuordnung zu ändern, also etwa einen Node einer anderen Linie 
+zuzuweisen, muss dieser zunächst mit dem <Keys.ContextKey>X</Keys.ContextKey> von der aktuellen Linie 
+gelöscht werden, erscheint daraufhin wieder links als nicht zugewiesen, und
+kann nun einer anderen Linie zugeordnet werden.
+
+Beim Patchen von Art-Net- und sACN-Nodes können mehrere Universen/Linien
+auf einmal zugeordnet werden. Wählen Sie dazu links den ersten Node, der 
+verwendet werden soll, geben dann mit den Menütasten <Keys.SoftKey>Universe</Keys.SoftKey> (das 
+erste Universum) sowie <Keys.SoftKey>Quantity</Keys.SoftKey> (Anzahl) ein, und klicken auf die 
+gewünschte erste Linie. Daraufhin wird die gewünschte Anzahl von Universen
+auf fortlaufende Linien zugewiesen.
+
+Mit dem kleinen <Keys.ContextKey>Zahnrad</Keys.ContextKey> können weitere Details und Einstellungen pro
+Knoten (sobald er zugewiesen ist) sowie pro DMX-Modul aufgerufen werden. 
+Hiermit lassen sich auch für Netzwerk-Knoten die Adresse und Subnetz-Maske
+eingeben.
+
+![DMX Output in DMX Settings Window](/docs/images/DMX-Output-in-DMX-Settings-Window.png)
+
+Haben Sie [TitanNet-Prozessoren](../titan-net.md) verbunden, so sind diese 
+jeweils über den entsprechenden Tab am oberen Rand aufrufbar und können 
+konfiguriert werden.
+
+>   Beim Übertragen von Shows zwischen verschiedenen Pulten sowie bei der 
+    Verwendung des Titan Simulators ist es wichtig, die DMX-Einstellungen 
+    jeweils zu überprüfen. Bei Shows, die im Simulator erstellt wurden, 
+    sind die DMX-Ausgänge nicht zugewiesen.
+
+
+## Modul-Eigenschaften der DMX-Ausgabe
+
+Als Modul wird hier die Art der Ausgabe des DMX-Signals bezeichnet, also
+z.B. Art-Net oder sACN - jedes Modul kann mehrere Nodes haben.
+
+Zum genauen Einstellen der DMX-Ausgängen sowie der Art-Net- und 
+sACN-Optionen öffnen Sie die DMX-Einstellungen (also <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey> 
+zum Öffnen des [System-Menüs](the-system-menu.md), dann <Keys.SoftKey>DMX Settings</Keys.SoftKey>). Links werden nun die verschiedenen Ausgabewege und Anschlüsse angezeigt. Zum Ändern der Einstellungen klicken Sie links auf das kleine <Keys.ContextKey>Zahnrad</Keys.ContextKey> neben dem betreffenden Modulnamen.
+
+Damit lassen sich pro Modul spezifische Einstellungen vornehmen und auch
+bestimmen, über welchen Netzwerkanschluss welches Protokoll ausgegeben
+wird. Aktuelle Pulte haben zwei Netzwerkanschlüsse, das Quartz hat einen, 
+und bei der PC-Suite (Titan Go/Simulator) hängt es von der Ausstattung des jeweiligen Computers 
+ab - viele Laptops verfügen z.B. auch über einen WLAN-Adapter, der, sofern 
+aktiviert, ebenfalls angezeigt wird.
+
+### DMX-Eigenschaften
+
+![DMX512 Module Properties](/docs/images/Dmx-Module-Properties.png)
+
+**DMX output:** Damit kann die Ausgabe für dieses Modul deaktiviert
+werden.
+
+**Merge Priority:** Wert von 0-200, Vorgabe 100, höherer Wert = höhere Priorität. 
+Bestimmt die Priorität des direkt von Titan zum DMX-Ausgang
+gesendeten Signals beim Verwenden von sACN/DMX-Merge. Dies muss separat eingerichtet werden, siehe [DMX Merge -- Network DMX Node Settings](dmx-output-mapping.md#dmx-merge----network-dmx-node-settings).
+
+**Break Length:** Zeitlicher Abstand zwischen den DMX-Paketen. Manche 
+Dimmer und Movinglights benötigen ein künstlich verlangsamtes Signal,
+um sauber zu arbeiten. Vorgabewert ist 968 µs, aber es wurden schon 
+Dimmer gefunden, bei denen dieser Wert auf 4000 µs erhöht werden musste,
+um ein sauberes Ergebnis zu erzielen.
+
+**Mark After Break Length:** Ebenfalls ein Timing-Aspekt des DMX-Signals.
+Muss normalerweise nicht verändert werden. Ist die Zeitspanne zwischen
+dem Beginn des DMX-Pakets und dem ersten Kanal. Vorgabe ist 76 µs.
+
+**Extra Stop Bit:** Weitere Möglichkeit, um das DMX-Signal etwas zu 
+verlangsamen und problematische Geräte sicherer zu betreiben.
+
+### sACN-Eigenschaften
+
+![sACN DMX Module Properties](/docs/images/sACN-DMX-Module-Properties.png)
+
+**DMX output:** Damit kann die Ausgabe für dieses Modul deaktiviert
+werden.
+
+**Merge Priority:** (0-200) Die sACN-Spezifikation erlaubt es, dass
+mehrere Pulte parallel an die gleichen Geräte DMX senden. Dabei wird das
+Signal des Pultes mit der höheren Priorität berücksichtigt und Signale
+mit niedrigerer Priorität verworfen. 
+
+>   Für Backup-Pulte sollte man folglich die Priorität auf einen niedrigeren Wert setzen als für das Master-Pult. 
+
+**Block RDM:** Damit wird RDM für dieses Modul deaktiviert.
+
+**Synchronization Address:** Steht dies auf einem anderen Wert als 0, so
+wird das damit bezeichnete sACN-Universum zum Synchronisieren verwendet:
+alle Geräte empfangen zwar DMX-Daten, speichern die aber zwischen und
+geben sie erst aus, wenn auf dem Sync-Universum ein Paket gesendet wird.
+Damit lassen sich Tearing-Effekte vermeiden (versetzte Ausgabe). Mit 0
+wird die Synchronisation deaktiviert.
+
+**Ethernet xxx:** Damit lässt sich pro Netzwerkanschluss bestimmen, ob
+sACN über diesen gesendet werden soll. Werden mehrere aktiviert, so wird
+das identische Signal parallel gesendet.
+
+### Art-Net-Eigenschaften
+
+![ArtNet DMX Module Properties](/docs/images/ArtNet-DMX-Module-Properties.png)
+
+**DMX output:** Damit kann die Ausgabe für dieses Modul deaktiviert
+werden.
+
+**Continuous Art-Net DMX:** Die Art-Net-Spezifikation sieht vor, dass das
+Pult Art-Net-Pakete nur sendet, wenn sich Werte/Kanäle geändert haben.
+Mit dieser Option lässt sich die kontinuierliche Ausgabe von Art-Net
+erzwingen, auch wenn sich keine Werte geändert haben.
+
+**Always Broadcast Art-Net DMX:** Damit werden alle Pakete per Broadcast
+gesendet, also an sämtliche Geräte im jeweiligen Netzwerkbereich.
+Ansonsten werden die Informationen Unicast gesendet, also nur an das
+jeweilige Gerät. Damit lässt sich die Netzwerkauslastung verringern,
+aber die Netzwerkeinrichtung ist ggf. aufwändiger.
+
+**Block RDM:** Damit wird RDM für dieses Modul deaktiviert.
+
+**DMX Overrun:** Einige Art-Net-Geräte ignorieren Änderungen, die nur
+einmalig gesendet werden. Mit dieser Einstellung werden auch solche
+Änderungen mit mindestens drei Netzwerkpaketen gesendet.
+
+**Legacy Mode:** Damit wird kontinuierlich und mit hoher Datenrate
+gesendet, was ebenfalls manche nicht-Art-Net-konforme Geräte erfordern.
+Dies kann die Performance von Netzwerk und Pult negativ beeinflussen.
+
+**Ethernet xxx:** Damit lässt sich pro Netzwerkanschluss bestimmen, ob
+Art-Net über diesen gesendet werden soll. Werden mehrere aktiviert, so
+wird das identische Signal parallel gesendet.
+
+> Über die Registry lässt sich ArtPoll deaktivieren. Das kann gelegentlich notwendig sein,
+wenn inkompatible Geräte verwendet werden. Wenn das erforderlich sein sollte, oder wenn 
+umgekehrt ArtPoll nicht funktioniert, obwohl es sollte, dann wenden Sie sich an Avolites,
+um nähere Informationen zu erhalten.
+
+## DMX-Overview
+
+Schaltet man am oberen Rand des Fensters auf den Tab 'DMX Overview' um, so werden
+sämtliche [TNPs](../titan-net.md) angezeigt, die momentan im Netzwerk verbunden sind.
+Dabei wird auch angezeigt, welche Linie auf welchem Knoten und Anschluss
+ausgegeben wird.
+
+![DMX Overview in DMX Settings](/docs/images/DMX-Overview-in-DMX-Settings.png)
+
+Links werden die max. 64 möglichen 'internen' Linien gezeigt. Rechts
+davon erscheinen die verbundenen Knoten/Nodes, wobei das Pult selbst
+ganz oben -- als erster Knoten -- erscheint. Für jeden Knoten wird
+angezeigt, welche Linie auf welchem Anschluss ausgegeben wird. Ein Klick
+auf den Ausgangsbereich des jeweiligen Knoten öffnet dessen
+Detailansicht.
+
+Ein Klick auf den Eingangsbereich eines Knotens zeigt hingegen dessen
+Details im rechten Bereich. Gezeigt wird u.a. die IP-Adresse, die Anzahl
+der verfügbaren Prozessorkanäle, die Anzahl der zugewiesenen DMX-Linien,
+der Status der Verbindung sowie die Auslastung des Geräts, Wurden mehr
+Linien zugewiesen als das Gerät Prozessorkanäle bereitstellt, so wird
+eine Warnung eingeblendet.
+
+Wird eine Show geladen, die Geräte und Linien auf Prozessor-Knoten
+enthält, die momentan nicht verbunden sind, so erscheint eine Meldung
+mit der genauen Aufstellung sowie der Möglichkeit, die einzelnen Linien
+anderen Ausgabeports zuzuordnen.
+
+## DMX Merge -- Network DMX Node Settings
+
+Im Fenster "Network DMX Node Settings" kann man das Mergen des DMX-Outputs des lokalen Pults mit sACN-Universen
+von anderen Pulten oder Nodes einrichten.
+Im **System**-Menü (<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>) wählen Sie <Keys.SoftKey>Network DMX Node Settings</Keys.SoftKey>.
+
+![Network DMX Node Settings Window](/docs/images/DMX-Merge-Window.png)
+
+Um ein Universum auf einen Ausgang zuzuweisen, klicken Sie auf **Patch Titan Lines** oder auf 
+**Patch External sACN Merge**, stellen <Keys.SoftKey>Universe</Keys.SoftKey>
+ein, und klicken auf den gewünschten Ausgang (Port A, Port B etc.).
+
+Um eine Zuweisung zu löschen, klicken Sie auf <Keys.SoftKey>Clear sACN Merge</Keys.SoftKey> und
+dann auf den gewünschten Port.
+
+-   Für das DMX-Signal des lokalen Pultes kann man die Priorität gegenüber den externen sACN-Quellen
+    einstellen, siehe [DMX-Eigenschaften](dmx-output-mapping.md#dmx-eigenschaften)
+
+-   Mit dem Schalter 'DMX Output' oben rechts können sämtliche DMX-Ausgänge deaktiviert werden.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/dmx-output-mapping.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/dmx-output-mapping.md
@@ -1,7 +1,7 @@
 ---
 id: dmx-output-mapping
-title: DMX-Ausgänge einrichten
-sidebar_label: DMX-Ausgänge einrichten
+title: DMX-Einstellungen
+sidebar_label: DMX-Einstellungen
 ---
 
 import Keys from '@site/src/components/key.ts';
@@ -9,23 +9,53 @@ import Video from '@site/src/components/video.tsx';
 
 Das Ausgangssignal kann per DMX über die XLR-Buchsen sowie per Art-Net und sACN über die Netzwerkanschlüsse ausgegeben werden.
 
-Alle Pulte können bis zu 64 DMX-Universen über DMX und Netzwerk (Art-Net
-oder sACN) ausgeben (der **T1** ist auf ein Universum, der **T2** auf zwei
-Universen und das **T3** auf 16 Universen beschränkt; für das T3 sind optional Lizenzerweiterungen erhältlich).
+Ebenso lassen sich sACN-Linien als Input definieren, um von anderen Pulten Cues und Paletten zu kopieren. Input-Linien werden purpur dargestellt.
 
-Pulte selbst können bis 16 DMX-Universen ausgeben (32 beim D9 und D7), ist mehr erforderlich, so lässt sich 
+Titan kann generell bis zu 64 DMX-Universen über DMX und Netzwerk (Art-Net
+oder sACN) ausgeben, aber verschiedene Pulte sind intern auf unterschiedliche Anzahlen von Linien beschränkt. Dabei können die Universen von 1-9999 nummeriert sein, 
+mehr als 64 sind insgesamt aber nicht möglich.
+
+Pult | Systemlimit | Maximum pro Pult
+--------|----------------|-------
+Simulator      | 64 (Anm. 1) | 
+T1             | 1   | 1
+T2             | 2   | 2
+T3             | 16 (Anm. 2) | 16 (Anm. 3)
+D3-010         | 8   | 8
+D3-110         | 24  | 24
+D3-Core        | 16  | 16
+D7             | 64  | 32 (Anm. 3)
+D9             | 64  | 32 (Anm. 3)
+Titan Mobile   | 64  | 16 (Anm. 3)
+Quartz         | 64  | 16 (Anm. 3)
+Tiger Touch 2  | 64  | 16 (Anm. 3)
+Arena          | 64  | 16 (Anm. 3)
+Sapphire       | 64  | 16 (Anm. 3)
+
+Anm. 1: Der Simulator gibt in unregelmäßigen Abständen ein DMX-Störsignal aus (DMX-Spoiler) <br/>
+Anm. 2: Das Systemlimit des T3 kann mit optionalen Lizenzen bis auf 64 Linien erweitert werden. Das Maximum pro Pult bleibt aber bei 16 Linien.<br/>
+Anm. 3: Die Rechenleistung für weitere Linien kann durch zusätzliche TNPs erweitert werden.
+
+Pulte selbst können die oben angegebene Anzahl von DMX-Universen ausgeben, ist mehr erforderlich, so lässt sich 
 mit [Avolites TitanNet-Prozessoren (TNPs)](../titan-net.md) durch Verteilen der Rechenlast die 
-Gesamtzahl an Universen bis auf 64 erhöhen. (Für T1, T2 und T3 kann die Beschränkung nicht durch TNPs aufgehoben werden).
+Gesamtzahl an Universen bis auf 64 erhöhen. (Das Systemlimit wird dadurch nicht erhöht. Eine Erweiterung durch mehrere einzelne kleinere Geräte - etwa T1 oder T2 - ist nicht möglich.)
 
->   Außer beim T1, T2 und T3 ist es möglich, in der Pult-Software mehr als 16 Universen
-    zuzuweisen. Abhängig von der Programmierung und vom Patch wirkt sich das aber negativ auf die Performance aus. In
-    der TitanNet-Übersicht wird daher bei der Anzeige der Rechenleistung
-    eine Warnung angezeigt.
+>  Wird eine Show geladen, in der mehr Linien verwendet wurden als auf dem Pult möglich sind, so werden nur die verfügbaren Linien von der 
+kleinsten Nummer aufwärts ausgegeben. Sämtliche Programmierung bleibt erhalten, auf den nicht verfügbaren Linien erfolgt aber keine Ausgabe.
+
+
+## Default-Ausgangskonfiguration
+
+Wird eine neue Show gestartet, so werden 16 Linien eingerichtet. Diese werden auf die vorhandenen DMX-Anschlüsse, auf Art-Net und auf sACN (jeweils Universum 1-16) geroutet.
+
+- Die Ausgabe per Art-Net ist in einer neuen Show deaktiviert. Zum Aktivieren klicken Sie auf das Icon mit dem 'Einschalter' des Art-Net-Nodes auf der linken Seite der DMX-Einstellungen.
+
+Sobald Fixtures auf Linien gepatcht werden, die noch nicht eingerichtet sind, wird die Linie automatisch angelegt und auf sACN und Art-Net geroutet (diese Automatik kann in den Optionen der Nodes deaktiviert werden).
+
 
 ## Einrichten der DMX-Ausgänge
 
-Öffnen Sie das [System-Menü](the-system-menu.md) (normalerweise mit
-<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>) 
+Öffnen Sie das [System-Menü](the-system-menu.md) (normalerweise mit <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>) 
 und wählen <Keys.SoftKey>DMX Settings</Keys.SoftKey>.
 
 Das DMX-Fenster öffnet sich nun zunächst auf dem Tab mit dem Node
@@ -36,23 +66,21 @@ DMX-Linie kann an einen oder mehrere Empfänger gesendet werden. Wird
 einer Linie mehr als ein Empfänger zugeordnet, so erhalten alle diese
 Knoten das identische Signal. Wenn Geräte per Art-Net oder sACN verbunden
 sind oder TNPs im Netzwerk gefunden wurden, so erscheinen diese
-ebenfalls auf der linken Seite.
+ebenfalls auf der linken Seite. (Bei sACN gibt es keine automatische Erkennung,
+daher werden im Netzwerk verfügbare sACN-Nodes nicht automatisch dargestellt).
 
 Rechts werden für jede interne DMX-Linie die zugeordneten Knoten
 aufgeführt. In der Grundeinstellung sind die Linien von 1 aufsteigend
 auf die XLR-Buchsen des Pultes geroutet.
 
-![DMX Settings Window](/docs/images/DMX-Settings-Window.png)
+![DMX Settings Window](/docs/images/DMX-Settings-Window-v19.png)
 
-Um einen Node einer DMX-Linie zuzuordnen klicken Sie links auf den Node 
-(z.B. auf **Expert DMX A**) und danach rechts auf die gewünschte Linie, z.B. 
+Um einen Node einer DMX-Linie zuzuordnen, klicken Sie links auf den Node 
+(z.B. auf **New Multicast Universe**) und danach rechts auf die gewünschte Linie, z.B. 
 &nbsp;**Line 1**. Der Node verschwindet daraufhin links und erscheint rechts bei der 
 zugewiesenen DMX-Linie.
 
-![Node in DMX Settings Window](/docs/images/Node-in-DMX-Settings-Window.png)
-
-Zum Löschen einer Zuordnung dienen die individuellen oder gruppenweisen
-<Keys.ContextKey>X</Keys.ContextKey>-Schaltflächen: pro Node, pro Linie, sowie ganz oben bei **Dmx Lines** für
+Zum Löschen einer Zuordnung dienen die individuellen oder gruppenweisen <Keys.ContextKey>X</Keys.ContextKey>-Schaltflächen: pro Node, pro Linie, sowie ganz oben bei **DMX Assignments** für
 sämtliche DMX-Ausgänge.
 
 Um die Zuordnung zu ändern, also etwa einen Node einer anderen Linie 
@@ -60,15 +88,14 @@ zuzuweisen, muss dieser zunächst mit dem <Keys.ContextKey>X</Keys.ContextKey> v
 gelöscht werden, erscheint daraufhin wieder links als nicht zugewiesen, und
 kann nun einer anderen Linie zugeordnet werden.
 
-Beim Patchen von Art-Net- und sACN-Nodes können mehrere Universen/Linien
-auf einmal zugeordnet werden. Wählen Sie dazu links den ersten Node, der 
-verwendet werden soll, geben dann mit den Menütasten <Keys.SoftKey>Universe</Keys.SoftKey> (das 
-erste Universum) sowie <Keys.SoftKey>Quantity</Keys.SoftKey> (Anzahl) ein, und klicken auf die 
-gewünschte erste Linie. Daraufhin wird die gewünschte Anzahl von Universen
-auf fortlaufende Linien zugewiesen.
+Art-Net- und sACN-Universen können automatisch zugewiesen werden, indem man links den gewünschten sACN- oder Art-Net-Node wählt
+und dann auf <Keys.SoftKey>Assign All By Line Number</Keys.SoftKey> klickt. Damit werden passende sACN- bzw. Art-Net-Universen angelegt und dem Ausgang zugewiesen.
+
+Wird ein Fixture auf eine noch nicht angelegte Linie gepatcht, so wird diese automatisch vom System angelegt. Mit der Einstellung **Auto Assign** bei 
+den sACN- und Art-Net-Nodes lässt sich bestimmen, ob automatisch die entsprechenden Universen ausgegeben werden sollen.
 
 Mit dem kleinen <Keys.ContextKey>Zahnrad</Keys.ContextKey> können weitere Details und Einstellungen pro
-Knoten (sobald er zugewiesen ist) sowie pro DMX-Modul aufgerufen werden. 
+Knoten (sobald er zugewiesen ist) sowie pro DMX-Modul (<Keys.ContextKey>Zahnrad</Keys.ContextKey> bei Art-Net bzw. sACN) aufgerufen werden. 
 Hiermit lassen sich auch für Netzwerk-Knoten die Adresse und Subnetz-Maske
 eingeben.
 
@@ -81,7 +108,7 @@ konfiguriert werden.
 >   Beim Übertragen von Shows zwischen verschiedenen Pulten sowie bei der 
     Verwendung des Titan Simulators ist es wichtig, die DMX-Einstellungen 
     jeweils zu überprüfen. Bei Shows, die im Simulator erstellt wurden, 
-    sind die DMX-Ausgänge nicht zugewiesen.
+    sind die physischen DMX-Ausgänge nicht zugewiesen.
 
 
 ## Modul-Eigenschaften der DMX-Ausgabe
@@ -100,12 +127,16 @@ und bei der PC-Suite (Titan Go/Simulator) hängt es von der Ausstattung des jewe
 ab - viele Laptops verfügen z.B. auch über einen WLAN-Adapter, der, sofern 
 aktiviert, ebenfalls angezeigt wird.
 
-### DMX-Eigenschaften
+### Physische DMX-Eigenschaften
 
-![DMX512 Module Properties](/docs/images/Dmx-Module-Properties.png)
+Diese Einstellungen betreffen alle 5pol-DMX-Anschlüsse des Pultes.
+
+![DMX512 Module Properties](/docs/images/Dmx-Module-Properties-v19.png)
 
 **DMX output:** Damit kann die Ausgabe für dieses Modul deaktiviert
-werden.
+werden. Gleiche Einstellung wie der 'Power'-Button des 'Physical DMX Output' Moduls. Sind die DMX-Buchsen deaktiviert, so erscheinen sie auf der rechten Seite ausgegraut.
+
+**Auto Assign** bestimmt, ob beim Patchen von Fixtures auf nicht eingerichtete Linien diese automatisch für die DMX-Ausgabe geroutet werden sollen, soweit noch unbelegte DMX-Anschlüsse vorhanden sind.
 
 **Merge Priority:** Wert von 0-200, Vorgabe 100, höherer Wert = höhere Priorität. 
 Bestimmt die Priorität des direkt von Titan zum DMX-Ausgang
@@ -126,10 +157,14 @@ verlangsamen und problematische Geräte sicherer zu betreiben.
 
 ### sACN-Eigenschaften
 
-![sACN DMX Module Properties](/docs/images/sACN-DMX-Module-Properties.png)
+Diese Einstellungen betreffen sämtliche per sACN ausgegebenen Universen.
+
+![sACN DMX Module Properties](/docs/images/sACN-module-properties-v19.png)
 
 **DMX output:** Damit kann die Ausgabe für dieses Modul deaktiviert
-werden.
+werden. Gleiche Einstellung wie der 'Power'-Button des 'Streaming ACN' Moduls. Ist sACN deaktiviert, so erscheinen die entsprechenden Universen auf der rechten Seite ausgegraut.
+
+**Auto Assign** bestimmt, ob beim Patchen von Fixtures auf nicht eingerichtete Linien diese automatisch für die Ausgabe per sACN geroutet werden sollen.
 
 **Merge Priority:** (0-200) Die sACN-Spezifikation erlaubt es, dass
 mehrere Pulte parallel an die gleichen Geräte DMX senden. Dabei wird das
@@ -148,15 +183,19 @@ Damit lassen sich Tearing-Effekte vermeiden (versetzte Ausgabe). Mit 0
 wird die Synchronisation deaktiviert.
 
 **Ethernet xxx:** Damit lässt sich pro Netzwerkanschluss bestimmen, ob
-sACN über diesen gesendet werden soll. Werden mehrere aktiviert, so wird
+sACN über diesen gesendet werden soll (Anzahl abhängig vom Pult). Werden mehrere aktiviert, so wird
 das identische Signal parallel gesendet.
 
 ### Art-Net-Eigenschaften
 
-![ArtNet DMX Module Properties](/docs/images/ArtNet-DMX-Module-Properties.png)
+Diese Einstellungen betreffen sämtliche per Art-Net ausgegebenen Universen.
+
+![ArtNet DMX Module Properties](/docs/images/ArtNet-Module-Properties-v19.png)
 
 **DMX output:** Damit kann die Ausgabe für dieses Modul deaktiviert
-werden.
+werden. Gleiche Einstellung wie der 'Power'-Button des 'Art-Net' Moduls. Ist Art-Net deaktiviert, so erscheinen die entsprechenden Universen auf der rechten Seite ausgegraut.
+
+**Auto Assign** bestimmt, ob beim Patchen von Fixtures auf nicht eingerichtete Linien diese automatisch für die Ausgabe per Art-Net geroutet werden sollen.
 
 **Continuous Art-Net DMX:** Die Art-Net-Spezifikation sieht vor, dass das
 Pult Art-Net-Pakete nur sendet, wenn sich Werte/Kanäle geändert haben.
@@ -167,7 +206,8 @@ erzwingen, auch wenn sich keine Werte geändert haben.
 gesendet, also an sämtliche Geräte im jeweiligen Netzwerkbereich.
 Ansonsten werden die Informationen Unicast gesendet, also nur an das
 jeweilige Gerät. Damit lässt sich die Netzwerkauslastung verringern,
-aber die Netzwerkeinrichtung ist ggf. aufwändiger.
+aber die Netzwerkeinrichtung ist ggf. aufwändiger. (Unabhängig von dieser 
+Einstellung können einzelne Universen zum Senden per Broadcast eingerichtet werden).
 
 **Block RDM:** Damit wird RDM für dieses Modul deaktiviert.
 
@@ -180,13 +220,34 @@ gesendet, was ebenfalls manche nicht-Art-Net-konforme Geräte erfordern.
 Dies kann die Performance von Netzwerk und Pult negativ beeinflussen.
 
 **Ethernet xxx:** Damit lässt sich pro Netzwerkanschluss bestimmen, ob
-Art-Net über diesen gesendet werden soll. Werden mehrere aktiviert, so
+Art-Net über diesen gesendet werden soll (Anzahl abhängig vom Pult). Werden mehrere aktiviert, so
 wird das identische Signal parallel gesendet.
 
 > Über die Registry lässt sich ArtPoll deaktivieren. Das kann gelegentlich notwendig sein,
 wenn inkompatible Geräte verwendet werden. Wenn das erforderlich sein sollte, oder wenn 
 umgekehrt ArtPoll nicht funktioniert, obwohl es sollte, dann wenden Sie sich an Avolites,
 um nähere Informationen zu erhalten.
+
+### Visualiser DMX
+
+Diese Einstellungen betreffen den integrierten Capture Visualiser. Extern angeschlossene Visualiser werden davon nicht beeinflusst.
+
+![Visualiser DMX Module Properties](/docs/images/Visualiser-module-properties-v19.png)
+
+**DMX output:** Damit kann die Ausgabe an den internen Visualiser deaktiviert
+werden. Gleiche Einstellung wie der 'Power'-Button des 'Visualiser' Moduls. 
+
+**Auto Assign:** Diese Option ist für den Visualiser ohne Funktion.
+
+### DMX /sACN Input
+
+Ein sACN-Input-Universum kann einer DMX-Linie zugeordnet werden, um das Signal eines externen Pultes zu verwenden. Solche Inputs werden purpur dargestellt.
+
+![sACN input](/docs/images/DMX-Settings-sACN-in.png)
+
+Ist einer Linie ein Input zugewiesen, so wird dies in der Zeile der Linie mit der sACN-Universe-Nummer und weiteren Details angezeigt; als Status wird grün (Daten werden empfangen), orange (Daten werden gehalten) und grau (keine Daten) verwendet. Gehaltene Daten können mit <Keys.ContextKey>Clear DMX Input Cache</Keys.ContextKey> im Kontextmenü gelöscht werden.
+
+Zu Details zur Verwendung von sACN-Input beim Programmieren siehe [Verwenden von DMX/sACN-Eingang](/controlling-fixtures/changing-fixture-attributes.md#verwenden-von-dmxsacn-eingang).
 
 ## DMX-Overview
 
@@ -195,14 +256,16 @@ sämtliche [TNPs](../titan-net.md) angezeigt, die momentan im Netzwerk verbunden
 Dabei wird auch angezeigt, welche Linie auf welchem Knoten und Anschluss
 ausgegeben wird.
 
-![DMX Overview in DMX Settings](/docs/images/DMX-Overview-in-DMX-Settings.png)
+![DMX Overview in DMX Settings](/docs/images/DMX-Overview-in-DMX-Settings-v19.png)
 
-Links werden die max. 64 möglichen 'internen' Linien gezeigt. Rechts
+Links werden die maximal möglichen 'internen' Linien gezeigt. Rechts
 davon erscheinen die verbundenen Knoten/Nodes, wobei das Pult selbst
 ganz oben -- als erster Knoten -- erscheint. Für jeden Knoten wird
 angezeigt, welche Linie auf welchem Anschluss ausgegeben wird. Ein Klick
 auf den Ausgangsbereich des jeweiligen Knoten öffnet dessen
 Detailansicht.
+
+Weitere Ausgangslinien (bis zum Limit des Pultes) können durch Klicken des Pluszeichens unter der Liste der Linien hinzugefügt werden.
 
 Ein Klick auf den Eingangsbereich eines Knotens zeigt hingegen dessen
 Details im rechten Bereich. Gezeigt wird u.a. die IP-Adresse, die Anzahl

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/external-displays.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/external-displays.md
@@ -1,0 +1,39 @@
+---
+id: external-displays
+title: Externe Displays
+sidebar_label: Externe Displays
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Für mehr Platz auf dem Bildschirm (für mehr Fenster und Buttons) lassen
+sich externe Bildschirme anschließen: per HDMI beim Diamond 9, per DisplayPort beim Diamond 7, 
+per DVI beim Sapphire Touch, Arena und Quartz, sowie per VGA beim Tiger Touch und Pearl Expert. 
+Beim Diamond 9, Diamond 7 und beim Sapphire Touch können zwei externe Bildschirme angeschlossen 
+werden, bei allen anderen Konsolen einer. Es lassen sich jeweils Touchscreens verwenden, wobei 
+empfohlen wird, 'Windows Touch'-kompatible Modelle zu verwenden.
+
+Titan PC-Suite (Titan Go, Titan Simulator) unterstützt bis zu drei 
+Bildschirme, wobei die konkrete Anschlussmöglichkeit vom verwendeten 
+Computer abhängt.
+
+Das externe Display ist zunächst deaktiviert und zeigt dies mit
+'disabled' an. Zum Aktivieren öffnen Sie das **System**-Menü 
+(<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>), 
+wählen <Keys.SoftKey>Display Setup</Keys.SoftKey> und klicken auf
+&nbsp;<Keys.SoftKey>External Display Disconnected</Keys.SoftKey>. Dies wechselt 
+auf <Keys.SoftKey>External Display Connected</Keys.SoftKey>, und das externe Display ist aktiviert.
+
+>   Ist kein externes Display vorhanden, empfiehlt es sich aus Performance-Gründen, den Anschluss zu deaktivieren.
+
+Es empfiehlt sich, alle Displays in ihrer hardwaremäßigen Auflösung zu
+betreiben. Normalerweise wird das von Titan korrekt erkannt. Sollte dies
+(bei einem Pult, nicht bei der PC-Suite) nicht der Fall sein, so klicken Sie 
+auf <Keys.SoftKey>Tools</Keys.SoftKey> in der Werkzeugleiste am oberen Bildschirmrand, 
+wählen <Keys.SoftKey>Control Panel</Keys.SoftKey> und dann <Keys.SoftKey>External Monitor</Keys.SoftKey>. 
+Damit kann die passende Auflösung eingestellt werden.
+
+![External Monitor Resolution](/docs/images/External-Monitor-Resolution.png)
+
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/key-profiles.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/key-profiles.md
@@ -1,0 +1,186 @@
+---
+id: key-profiles
+title: Key Profiles - Tastenbelegungen
+sidebar_label: Key Profiles - Tastenbelegungen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Die Belegung der Bedientasten des Pultes lässt sich sehr fein einstellen
+und auf die jeweilige Arbeitsweise abstimmen. Die Einstellungen lassen
+sich dann in einem sog. Profil ('Key Profile') speichern. Wird das Pult
+von mehreren Benutzern verwendet, so kann jeder, abhängig von der
+jeweiligen Aufgabe, mit einem Klick die Konfiguration ändern.
+
+Es gibt Standard-Profile 'Run', Takeover', 'Program', ‚Theatre' und
+‚Night Club'. Diese Standard-Profile können nicht verändert werden, so
+dass man stets eine sinnvolle Arbeitsgrundlage hat. Hingegen kann man
+sie als Grundlage zum Erstellen eigener Profile verwenden.
+
+Die aktuellen Einstellungen der Playback-Tasten werden direkt darüber im
+Touchscreen angezeigt.
+
+![Key Profiles on playback](/docs/images/Playback-Faders-with-key-profiles-applied.png)
+
+## Erstellen und Ändern von Tastenbelegungen
+
+<Video videoId="CxHQV4sP_sA" title="Key Profiles" />
+
+Zum Erstellen eines solchen Profils öffnen Sie mit <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey> 
+das **System**-Menü und drücken <Keys.SoftKey>Key Profiles</Keys.SoftKey>. Darauf 
+öffnet sich das Menü 'Manage Profiles', mit dem man die verschiedenen 
+Profile anzeigen ('View'), ändern ('Edit'), löschen ('Delete') oder 
+ein neues erstellen ('Add') kann.
+
+Key Profiles kann man ebenso in den Playback-Optionen neu anlegen sowie
+auswählen (Reiter ‚Handle').
+
+Key Profiles (Tastenbelegungen) können auch im Fenster '[Show Library](../titan-basics/show-library.md#der-reiter-key-profiles-tastenprofile)'
+angezeigt werden.
+
+Beim Erstellen eines neuen ('Add') lässt sich eines der bestehenden
+auswählen, das zunächst kopiert wird, um die Einstellungen von diesem zu
+übernehmen.
+
+Auch im normalen 'Program'-Modus lassen sich die Profile ändern: halten
+Sie dazu <Keys.HardKey>AVO</Keys.HardKey> gedrückt und wählen <Keys.SoftKey>Edit Current Key Profile</Keys.SoftKey>. Ist
+das aktuelle Profil eines der schreibgeschützten, so erscheint die
+Aufforderung zur Anlage eines neuen bzw. Auswahl eines anderen
+bestehenden Profiles.
+
+In Anlehnung an die Tastenlayouts der früheren Pulte werden die verschiedenen Tasten 
+als <Keys.SoftKey>schwarz</Keys.SoftKey>, <Keys.SoftKey>blau</Keys.SoftKey>, <Keys.SoftKey>grau</Keys.SoftKey>, 
+und - soweit zutreffend - <Keys.SoftKey>touch</Keys.SoftKey> (die Touchscreen-Schaltflächen 
+und Executor-Tasten) bezeichnet. Auf dem D7 und dem D9 sind die 'blauen' Tasten die Auswahltasten und 
+die 'grauen' Tasten die Flashtasten. Die aktuellen Funktionen der verschiedenen Tasten werden links 
+im Bildschirm angezeigt. Sobald ein Tastentyp angewählt wurde, werden die verschiedenen möglichen Aktionen 
+angezeigt. Über schwarze Tasten verfügt nur das Sapphire Touch, außerdem können bei den virtuellen Fadern 
+schwarze Tasten aktiviert werden.
+
+![Editing a Key Profile](/docs/images/Editing-a-Key-Profile.png)
+
+## Tastenfunktionen
+
+Es lassen sich folgende Tastengruppen einzeln einstellen (graue oder
+blaue Tasten für 'Fixtures' und ‚Palettes' gibt es nur bei Pearl Expert;
+auf den anderen Pulten sind diese Optionen ohne Funktion):
+
+### Fixtures
+Die blaue, graue sowie 'touch'-Taste lassen sich als
+&nbsp;**Disabled** (deaktiviert), **Select** (Auswahltaste), **Flash**, **Swop** und
+&nbsp;**Latch** (Einrasten) konfigurieren. 
+
+>   Die 'Latch'-Funktion wirkt wie das Stellen des Faders auf 100%, und auf 0% bei der zweiten Betätigung.
+
+### Groups
+Die blaue, graue sowie 'touch'-Taste lassen sich als **Disabled**,
+&nbsp;**Select Group**, **Flash Fixtures**, **Timed Flash**, **Flash Master**, **Timed Flash
+Master**, **Swop Fixtures** konfigurieren, siehe auch [Geräte-Gruppen](../controlling-fixtures/fixture-groups.md).
+
+>   Die Option **Group/Flash takes precedence** bezieht sich nur auf das Pearl Expert, bei 
+    dem es möglich ist, auf Fadern Playbacks zu speichern und auf den zugehörigen Flash-Tasten Gruppen abzulegen.
+
+### Palettes
+
+Paletten-Tasten/Schaltflächen können **Disabled** (deaktiviert) sein oder mit
+&nbsp;**Select Palette** die Palette anwählen.
+
+Mit **Palette is fired ignoring/with its times** wird festgelegt, ob beim
+Aufrufen von Paletten gespeicherte Zeiten berücksichtigt werden oder nicht, 
+siehe [Paletten mit Zeiten](../palettes/timing-with-palettes).
+Dies ist besonders interessant beim [Improvisieren (Busking) mit Paletten](../running-the-show/playback-controls.md#improvisieren-busking-mit-paletten).
+
+>   Die Option **Palette/Flash takes precedence** bezieht sich nur auf das 
+    Pearl Expert, bei dem es möglich ist, auf Fadern Playbacks zu speichern
+    und auf den zugehörigen Flash-Tasten Paletten abzulegen.
+
+### Cues
+
+Die Tasten und Schaltflächen können belegt werden mit **Disabled**, **Flash**,
+&nbsp;**Timed Flash**, **Swop**, **Latch**, **Preload**, **Go**, **Tap Tempo**, 
+&nbsp;**Release** und **Select If**.
+
+### Chases
+
+Die Tasten und Schaltflächen können belegt werden mit **Disabled**, **Flash**,
+&nbsp;**Timed Flash**, **Swop**, **Latch**, **Go**, **Stop**, **Preload**, **Connect**, 
+&nbsp;**Tap Tempo**, **Release**, **Select If**.
+
+### Cue Lists
+
+Dies betrifft das [Abrufen von Cuelisten](../cue-lists/cue-list-playback.md), und
+es stehen folgende Einstellungen für die Tasten und den Button zur Verfügung:
+
+Einstellung | Funktion
+---|---
+Disabled | Die Taste hat keine Funktion.
+Flash | Alle Dimmerkanäle des Cues springen auf den programmierten Pegel und kehren danach zum vorherigen Wert zurück.
+Flash and Go | Wie Flash, aber mit Loslassen der Taste wird der nächste Cue aufgerufen.
+Timed Flash | Wie Flash, aber unter Berücksichtigung der eingestellten Fadezeiten.
+Timed Flash and Go | Flash mit Berücksichtigung der Fadezeiten sowie Weiterschalten bei Loslassen.
+Swop | Wie Flash, aber alle anderen Geräte werden solange dunkelgeschaltet.
+Latch | Wie Flash, aber Dimmerkanäle bleiben nach dem Loslassen bis zum erneuten Betätigen aktiv.
+Go | Der nächste Cue wird unter Berücksichtigung der eingestellten Zeit aktiviert.
+Stop | Alle Überblendvorgänge werden angehalten.
+Preload | LTP-Kanäle von Geräten, die gerade dunkel sind, werden auf den als nächstes aktiven Wert eingestellt.
+Connect | Verbindet die Cueliste mit der Ablaufsteuerung (ebenso wie die Taste <Keys.HardKey>Connect / Cue</Keys.HardKey> gefolgt von der Anwahl der Cueliste).
+Tap Tempo | Geschwindigkeitssteuerung durch Tippen im Takt.
+Next Cue - | Geht einen Cue zurück.
+Next Cue + | Geht einen Cue vorwärts.
+Review Live Cue | Aktuellen Cue nochmals mit Fadezeiten einblenden.
+Cut Next Cue to Live | Nächsten Cue ohne Fadezeiten aktivieren.
+Snap Back | Einen Cue zurückgehen, ohne Fadezeiten zu berücksichtigen.
+Go Back | Einen Cue zurück, mit Fadezeiten.
+Release | Playback releasen, unter Berücksichtigung der eingestellten Release-Zeit.
+Select If | Alle Geräte im aktuellen Cue auswählen.
+
+### Macros
+Kann gesetzt werden auf **Select** (Auswahl) oder **Disabled**.
+
+>   Die Option **Macro/Flash takes precedence** bezieht sich nur auf das 
+    Pearl Expert, bei dem es möglich ist, auf Fadern Playbacks zu speichern
+    und auf den zugehörigen Flash-Tasten Macros abzulegen.
+
+### Options
+
+Damit lässt sich die Schnellspeicherfunktion ('Quick
+Record') beim Doppelklick auf freie Schaltflächen deaktivieren.
+
+### Masters
+
+Es gibt unterschiedliche Einstellungen für <Keys.SoftKey>Standard Masters</Keys.SoftKey> und 
+den <Keys.SoftKey>Scene Master</Keys.SoftKey>.
+
+Für normale Master gibt es die Optionen **Disabled**, **Selection**, **Flash**, 
+&nbsp;**Latch**, **Connect**, **Tap Tempo**, **Nudge Up**, **Nudge Down**, **Release**, **Reset Multiplier**, **Multiplier x2**, **Freeze**.
+
+Manche davon gelten nur für bestimmte Master, z.B. gibt es Multiplier 
+nur für BPM-Master, siehe [Optionen für BPM-Master](../running-the-show/playback-controls.md#optionen-für-bpm-master). Mit
+Freeze können Shapes und Chaser vorübergehend angehalten werden; bei
+einem Intensity-Master wirkt Freeze als Blackout.
+
+Für den Scene Master gibt es die Optionen **Disabled**, **Preload Scene Mode**, 
+&nbsp;**Exit Scene Mode**, **Enter Scene Mode**, **Commit Changes**, 
+&nbsp;**Commit Changes and Exit Scene Mode**, **Enter or Exit Scene Mode**, 
+&nbsp;**Enter or Commit Scene Mode**,**Reset Scene Mode**. Siehe 
+[Scene Master](../running-the-show/playback-controls.md#scene-master).
+
+## Die Tastenbelegung wechseln
+
+Zur Auswahl einer Tastenbelegung halten Sie die <Keys.HardKey>AVO</Keys.HardKey>-Taste gedrückt
+und drücken dazu <Keys.SoftKey>Select Key Profile</Keys.SoftKey>. Damit wird das Key Profile für 
+alle Tasten geändert, für die nicht individuell eins ausgewählt ist.
+
+## Tastenbelegungen für einzelne Speicherplätze
+
+Jedem Speicherplatz lässt sich eine gesonderte Tastenbelegung zuordnen.
+Damit können die einzelnen Tasten für jeden Speicherplatz anders
+konfiguriert werden. Dazu wählt man <Keys.HardKey>Options</Keys.HardKey> oder <Keys.SoftKey>Options</Keys.SoftKey>, dann das 
+Playback, die Option <Keys.SoftKey>Handle</Keys.SoftKey> und dann <Keys.SoftKey>Key Profile</Keys.SoftKey>. Steht die 
+Auswahl auf <Keys.SoftKey>Global</Keys.SoftKey>, so werden die allgemeinen
+Tasteneinstellungen verwendet.
+
+Das Tastenprofil für einzelne Playbacks lässt sich wie folgt schnell ändern:
+halten Sie die Taste <Keys.HardKey>Options</Keys.HardKey> gedrückt und wählen Sie das Playback. Sie 
+können nun das gewünschte Profil wählen, und die Auswahl wird sofort wirksam.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/recovering-reinstalling-the-console.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/recovering-reinstalling-the-console.md
@@ -1,0 +1,101 @@
+---
+id: recovering-reinstalling-the-console
+title: Wiederherstellen/Neuinstallation
+sidebar_label: Wiederherstellen/Neuinstallation
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+**Dieser Abschnitt gilt nicht für die Titan PC Suite, sondern nur für
+alle größeren Titan-Pulte.**
+
+Das Pult läuft auf einer 'Embedded PC'-Plattform, und wie bei allen
+Computern lassen sich auch hier Systemfehler nicht komplett
+ausschließen. Sollte es erforderlich sein, das System neu zu
+installieren, so gehen Sie wie folgt vor:
+
+Zur Neuinstallation ist ein USB-Wiederherstellungs-Stick erforderlich,
+ein USB-Stick, von dem das System gebootet und installiert werden kann.
+Ein solcher Stick ist normalerweise mit der zum Auslieferungszeitpunkt
+aktuellen Software im Pult vorhanden. Mit dem im [Downloadbereich 
+der Avolites-Website](https://www.avolites.com/software/latest-version)
+herunterzuladenden jeweiligen Recovery Creator kann ein normaler
+USB-Stick als Recovery Stick vorbereitet werden.
+
+>   Für eine Neuinstallation sollte genügend Zeit sein: planen Sie
+    mindestens eine Stunde dafür ein!
+
+Es gibt drei Arten der Wiederherstellung; dabei werden unterschiedlich
+viele Daten gelöscht:
+
+Recovery | Installierte Version | Shows | Personalities | Lizenz 
+---|---|---|---|---
+Standard Recovery | Die beiden neuesten | Bleiben erhalten | Bleiben erhalten | Bleibt erhalten
+Factory Restore | Die Recovery-Version und die neueste davor | Werden gelöscht | Die der Recovery-Version | Bleibt erhalten
+Full Erase | Nur die Recovery-Version | Werden gelöscht | Die der Recovery-Version| bis v11: gelöscht; <br/>ab v12/Avokey: bleibt erhalten
+
+>   Ab Titan Version 12 wird die Lizenz auf dem AvoKey dauerhaft gespeichert
+    und auch bei einem Full Erase Recovery nicht gelöscht, [siehe unten](#software-lizenzierung).
+
+>   Bei Verwendung von **Factory Restore** sowie **Full Erase** werden 
+    sämtliche Einstellungen und Shows gelöscht. Es empfiehlt sich also, 
+    die Shows vorher auf einem anderen Stick zu speichern.
+
+Genauere Hinweise zum Anfertigen und zur Verwendung eines
+Recovery-Sticks sind mit auf der [Download-Seite](https://www.avolites.com/software/)
+ des Recovery Creators enthalten. Je nach Pultversion und dessen Alter sind ggf.
+unterschiedliche Schritte erforderlich. Allgemein ist das Vorgehen aber
+wie folgt:
+
+## Installationshinweise
+
+1.  **Bei Pulten, die älter als Titan Version 11.1 sind**, muss das Pult
+    im BIOS so eingestellt werden, dass es vom USB-Stick bootet.
+    Genaueres dazu steht auf der [Avolites-Website.](https://www.avolites.com/software/).
+
+2.  Starten Sie nun das Pult mit angestecktem Recovery-Stick.
+    Warten Sie, bis der Bootvorgang abgeschlossen ist; das kann bis zu 3 
+    Minuten dauern.
+
+3.  Nach Abschluss des Bootvorgangs wird im Bildschirm 'Welcome
+    to...' und der Name des Pultes angezeigt: klicken Sie auf <Keys.SoftKey>Next</Keys.SoftKey>, 
+    um den Vorgang fortzusetzen.
+
+4.  Lesen Sie den Lizenzvertrag ganz durch, und klicken Sie auf
+    &nbsp;<Keys.SoftKey>Agree</Keys.SoftKey>, um diesen anzunehmen.
+
+5.  Wählen Sie die gewünschte Wiederherstellungsart *(siehe Tabelle
+    oben)*.
+
+6.  Auf der nächsten Bildschirmseite geben Sie nun mit den Zifferntasten die
+    Seriennummer des Pultes ein; diese befindet sich auf der Rückseite
+    des Pultes (die Ziffernfolge nach dem 'TT-', 'PE-', 'AR-'‚
+    etc.). Normalerweise ist der Eintrag bereits korrekt vorbelegt.
+
+7.  Dann klicken Sie auf <Keys.SoftKey>Install</Keys.SoftKey>, um den Wiederherstellungsprozess
+    zu starten.
+
+8.  Nach dem Abschluss der Installation entfernen Sie den USB-Stick
+    und starten das Pult neu (mit der Schaltfläche <Keys.SoftKey>Restart</Keys.SoftKey>).
+
+Nach dem Neustart des Pultes werden alle erforderlichen Programme und
+Treiber installiert. Dies dauert ca. 30 Minuten. Währenddessen wird das
+Pult mehrfach neu gestartet. Schalten Sie das Pult während der
+Installation nicht aus!
+
+## Software-Lizenzierung
+
+Ab Titan Version 12 erfolgt die Lizenzierung mit dem AvoKey genannten
+USB-Lizenzdongle.
+
+Beim ersten Start öffnet sich der Authenticator, ein Hilfsprogramm, das
+Schritt für Schritt durch den Lizenzierungsprozess führt. Sobald die
+Lizenz auf dem AvoKey gespeichert ist, ist keine neue Lizenzierung mehr
+erforderlich. Für die Titan PC-Suite (Titan Mobile, T1, T2, T3) bedeutet dies,
+dass diese an beliebigen Computern ohne neue Lizenzierung verwendet
+werden können, solange sich an der Avolites-Hardware nichts ändert.
+
+Für weitere Details siehe https://www.avolites.com/avokey.
+
+<Video videoId="86PcC0OzL7E" title="Licensing" />

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/release-notes.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/release-notes.md
@@ -1,0 +1,18 @@
+---
+id: release-notes
+title: Release Notes
+sidebar_label: Release Notes
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Die Release Notes sind eine Übersicht über neu hinzugefügte Features,
+Verbesserungen, behobene Fehler sowie bekannte Probleme der jeweiligen
+Software-Version.
+
+Die Release Notes der auf dem Pult installierten Softwareversion findet
+man mit Klick auf <Keys.SoftKey>Tools</Keys.SoftKey> (oben links) <Keys.SoftKey>Help</Keys.SoftKey> <Keys.SoftKey>Release Notes</Keys.SoftKey>.
+
+Die aktuellsten Release Notes findet man außerdem im Downloadbereich der
+[Avolites-Website](https://www.avolites.com/software).

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/the-system-menu.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/the-system-menu.md
@@ -1,0 +1,96 @@
+---
+id: the-system-menu
+title: Das System-Menü
+sidebar_label: Das System-Menü
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Das System-Menü erreicht man durch Drücken von <Keys.HardKey>Avo</Keys.HardKey> und (gleichzeitig) 
+<Keys.HardKey>Disk</Keys.HardKey> bzw. bei älteren Pulten durch Umschalten des Betriebsarten-Schalters 
+in den Modus 'System'. Beim Titan Go gibt es extra den Button <Keys.HardKey>System</Keys.HardKey>.
+
+Die hier verfügbaren Optionen sind von den normalen Betriebsfunktionen 
+getrennt, da sie entweder nur selten benötigt werden, oder aber große 
+Auswirkungen auf die Funktion des Pultes haben, so dass ein versehentliches 
+Verstellen tunlichst vermieden werden sollte.
+
+## Network Settings - Netzwerkeinstellungen
+
+Hier werden die Parameter der Netzwerk(Ethernet)- Anschlüsse eingestellt, 
+siehe [Steuern von Geräten über Netzwerk](../networking/controlling-fixtures-over-a-network.md).
+
+## DMX Settings
+
+Hier wird die DMX-Ausgabe des Pultes eingerichtet. Details zu diesem
+Menü finden sich in Abschnitt [Einrichten der DMX-Ausgänge](dmx-output-mapping.md#einrichten-der-dmx-ausgänge).
+
+## Network DMX Node Settings
+
+Hier stellt man ein, wie DMX über mehrere Pulte bzw. Netzwerk-Knoten
+hinweg ausgegeben werden soll. Siehe [DMX Merge -- Network DMX Node Settings](dmx-output-mapping.md#dmx-merge----network-dmx-node-settings).
+
+## Synergy Settings
+
+Einstellungen zum Verbinden mit Ai-Servern, siehe [Einrichten von Synergy](../synergy/setting-up.md#einrichten-von-synergy).
+
+## TitanNet Security - Netzwerksicherheit
+
+Mit dieser Einstellung wird bestimmt, wie das Pult mit anderen
+Titan-Geräten im Backup-Betrieb kommuniziert. Details zum Backup finden
+sich in Abschnitt [Backup und Mehrbenutzerbetrieb](../running-the-show/linking-consoles-for-multi-user-or-backup.md).
+
+## User Settings - Benutzereinstellungen
+
+Das Menü 'User Settings' (Benutzereinstellungen) lässt sich auch im
+'Program'-Modus aufrufen; dazu halten Sie die <Keys.HardKey>AVO</Keys.HardKey>-Taste gedrückt und
+betätigen die Taste <Keys.SoftKey>User Settings</Keys.SoftKey>. Näheres zu den Einstellungen
+siehe Abschnitt [User Settings](user-settings.md).
+
+## Key Profiles - Tastenprofile
+
+Damit lässt sich die Funktion verschiedener Tasten festlegen; siehe
+Abschnitt [Key Profiles](key-profiles.md).
+
+## Wipe (Löschen)
+
+Die Funktion 'Wipe' löscht die aktuelle Show. Das Ergebnis ist das
+gleiche wie bei der Wahl der Option <Keys.SoftKey>New Show</Keys.SoftKey> aus dem Menü <Keys.HardKey>Disk</Keys.HardKey>.
+('Wipe' war bereits bei früheren Avolites-Pulten im System-Menü zu
+finden und ist deshalb hier eingeblendet).
+
+## Triggers
+
+Hier richtet man die Steuerung des Pultes z.B. über DMX oder MIDI ein.
+Details dazu finden sich in Abschnitt [Externe Trigger](../running-the-show/midi-dmx-or-audio-triggering.md).
+
+## Assign Masters
+
+In diesem Menü lassen sich einzelne Fader bestimmten Master­funktionen
+zuweisen; verschiedene Funktionen stehen dafür zur Verfügung und sind in
+Abschnitt [Master-Fader](../running-the-show/playback-controls.md#master-fader) 
+näher beschrieben.
+
+## Console Legend
+
+Hier kann man den Namen des Pultes verändern, der im Netzwerkbetrieb auf
+anderen Pulten angezeigt wird.
+
+## Titan Telemetry
+
+Um Avolites eine bessere Qualitätskontrolle und stetige Verbesserungen
+zu ermöglichen, wurde ein automatisches Rückmeldesystem integriert.
+Damit sendet Titan automatisch Informationen, um die Fehlersuche und
+weitere Verbesserungen zu ermöglichen. Diese enthalten aufgetretene
+Fehler, Statistiken über die Zeit, die die verwendeten Funktionen
+benötigen, und Ähnliches. Damit wird die weitere Softwareentwicklung
+sehr unterstützt. Ist dies aber unerwünscht, kann dies 
+mit <Keys.SoftKey>Telemetry Disabled</Keys.SoftKey> deaktiviert werden. Daten können nur übertragen werden, wenn
+das Pult einen Internetzugang hat.
+
+## Display Setup - Bildschirmeinrichtung
+
+Hier lässt sich der [externe Bildschirm](external-displays.md)
+aktivieren/deaktivieren. Ist kein solcher vorhanden, empfiehlt es sich aus 
+Performance-Gründen, den Anschluss zu deaktivieren.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/upgrading-the-software.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/upgrading-the-software.md
@@ -1,0 +1,93 @@
+---
+id: upgrading-the-software
+title: Aktualisieren der Software
+sidebar_label: Aktualisieren der Software
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Die Software der Avo-Pulte wird fortwährend weiterentwickelt. Die
+neueste Version ist jeweils über die Internetseite
+https://www.avolites.com zum Download erhältlich.
+
+
+>   Ab Titan Version 10 ist es möglich, auf den Pulten vorher installierte 
+    Versionen zu behalten, so dass man auch Shows aus älteren Versionen 
+    in der Version laden kann, mit der sie programmiert wurden. Der Wechsel 
+    zwischen den Versionen erfolgt im Tools-Menü per <Keys.SoftKey>Switch Software</Keys.SoftKey>.
+
+-   Die Software für das Titan Mobile, Titan Go und Simulator ist die
+    Titan PC Suite und wird wie ein gewöhnliches Windows-Programm
+    installiert, indem Sie das Installationsprogramm herunterladen und
+    ausführen. Beim Aktualisieren stellen Sie bitte sicher, dass die
+    bereits installierte Version nicht gerade ausgeführt wird. "Titan Go" ist nun 
+    die Software für alles USB-Hardware, also das T1, T2, T3 und das Titan Mobile.
+
+-   Erfolgt das Update ausgehend von einer früheren Version als v12, so
+    ist ab v12 ein AvoKey genannter USB-Lizenzdongle erforderlich und
+    muss entsprechend lizenziert werden. Dies ist im Abschnitt [Software-Lizenzierung](recovering-reinstalling-the-console.md#software-lizenzierung) 
+    näher erläutert. Bei neueren Geräten ist der AvoKey bereits integriert. Ist ein 
+    AvoKey einmal lizenziert, ist keine erneute Lizenzierung erforderlich.
+
+-   Die Aktualisierung/Installation der Software kann einige Zeit dauern, vor allem, 
+    wenn es sich um eine Wiederherstellung (Recovery) handelt. Das sollte man nicht machen, wenn 
+    am gleichen Abend eine Show gefahren werden muss! 
+
+-   Vor dem Updaten der Software ist ein Backup der Shows zu machen.
+
+Software-Updates für Pulte müssen mit einem USB-Stick installiert werden. Je nach vorhandener und neu zu installierender Version ist eventuell ein separater PC erforderlich, um mittels "Recovery Installer" einen Recovery-Stick zu erzeugen. Auf der Avolites-Website gibt es genaue Anweisungen, ob es sich um ein kleines **Upgrade** handelt oder aber der **Recovery installer** erforderlich ist. Bei Rückfragen dazu wenden Sie sich bitte an den Avolites Support. Auf der Downloadseite gibt es unten auch einen Link zum **Recovery Creator Guide**. 
+
+## Updaten eine Pultes mit dem Recovery Installer
+
+1. Laden Sie den Recovery Creator für Ihr Pult von der Avolites Downloads-Website herunter.
+2. Schließen Sie einen leeren 16GB USB-Stick an und starten Sie den Recovery Creator, um einen Recovery Stick (Wiederherstellungs-Stick) zu erzeugen. Weitere Details dazu siehe der auf der Website verlinkte **Recovery Creator Guide**.
+3. Schließen Sie nun den Stick an das Pult an und starten Sie dieses. Das Pult sollte nun mit der Recovery (Systemwiederherstellung) beginnen.
+4. Wählen Sie auf dem Display "Standard Recovery" und folgen Sie den weiteren angezeigten Anweisungen. 
+
+## Updaten eines Pultes per Upgrade-Datei
+
+1. Prüfen Sie auf der Avolites Website, ob eine Upgrade-Datei für Ihr Pult verfügbar ist, und laden Sie diese herunter. Wenn nicht, verwenden Sie den Recovery Creator (s.o.).
+2. Kopieren Sie das Installationsprogramm auf einen USB-Stick und verbinden diesen mit dem Pult.
+3. Öffnen Sie das **Tools**-Menü in der Werkzeugleiste, klicken auf **Control Panel**, dann auf **Titan Installers**. Nun werden alle auf dem USB-Stick vorhandenen Installationsprogramme - Software und Personalities - aufgelistet. Dazu müssen diese im Stammverzeichnis des USB-Sticks liegen und der Dateiname darf nicht verändert worden sein.
+4. Klicken Sie auf das zu installierende Programm und folgen Sie den Anweisungen.
+   
+   Sollte einmal ein auf dem USB-Stick vorhandenes Programm nicht im *Titan Installers*-Untermenü auftauchen, so kann man mit Tools -> Folders einen Dateibrowser öffnen, in das richtige Verzeichnis navigieren und die Datei per Doppelklick starten.
+5. Nach Abschluss der Installation wird eine Meldung angezeigt; bestätigt man diese, startet das Pult neu, und ab sofort läuft die neue Softwareversion.
+
+## Updaten der Titan PC-Suite (Titan Go und Titan Simulator)
+
+1. Beenden Sie die Titan-Software, falls sie noch läuft
+2. Navigieren Sie zu der heruntergeladenen Datei **Avolites Titan PC Suite Setup** und starten Sie das Programm per Doppelklick.
+3. Bestätigen Sie die Rückfrage der Benutzerkontensteuerung (Windows User Account Control) mit **OK**.
+4. Nach Abschluss der Installation wird eine Meldung angezeigt, Bestätigt man diese, wird der Computer neu gestartet, und ab sofort läuft die neue Softwareversion.
+
+## Upgraden der Panel-Firmware per USB Expert
+
+Mach dem Updaten der Software ist es mitunter erforderlich, die Firmware der verschiedenen Panels zu aktualisieren. Dazu ist die Software 'Avolites USB Expert Console' auf allen Pulten und auch mit der PC-Suite mitgeliefert und installiert.
+
+> Es kann sein, dass nach dem Softwareupdate automatisch die USB Expert Console geöffnet wird, wenn das Upgrade der Firmware erforderlich ist.
+
+Zum Upgrade der Panel-Firmware gehen Sie wie folgt vor:
+
+1. Bei Pulten öffnen Sie das **Tools**-Menü in der Werkzeugleiste, klicken auf **Control Panel** und dann auf  **USB Expert Console**. Auf einem Computer für das Titan Mobile, T1, T2 oder T3 öffnen Sie die **USB Expert Console** über das Startmenü.<br/>
+![Tools Menu](/docs/images/Tools-Menu-Control-Panel.png)
+
+2. Links unter **Connected Panels** wird eine Liste der vorhandenen Panels angezeigt (die vorhandenen Panels sind je nach Pult andere).
+![USB Expert Panel Update](/docs/images/USB-Expert-Panel-Update.png)
+
+3. Klicken Sie nun rechts oben auf den Tab **Service**.
+
+4. In der Box **Auto Update** auf der rechten Seite werden alle Panels aufgeführt, die ein Firmware-Update benötigen. Auch hier hängen die angezeigten Panels vom jeweiligen Pult und vom Softwarestand ab.
+
+5. Sind Updates erforderlich, so klicken Sie auf **Update Now**. Daraufhin werden nacheinander die einzelnen Panels mit neuer Firmware versehen. Im rechten unteren Teil wird der Fortschritt des Updatevorgangs mit einem grünen Balken angezeigt.
+
+6. Sobald die Auto Update-Box leer ist und also alle Panels aktualisiert wurden, schließen Sie die USB Expert-Console und starten Sie das Pult neu.
+
+- In der Box **Connected Panels** wird der Status der Panels angezeigt. 
+
+- Wenn auf PC-Systemen (Titan Mobile, T1, T2) die Box leer ist, klicken Sie im Menü auf 'Tools', dann auf 'Acw Service', dann auf 'Start'.
+
+- Die mittlere Box ('**Item Events**') dient zur Überprüfung der Funktion der verschiedenen Panels. Sobald ein Fader bewegt oder eine Taste gedrückt wird, wird dies hier angezeigt.
+
+- Sollte der Updateprozess der Firmware nach 10 Minuten noch immer nicht abgeschlossen sein, drücken Sie auf **Exit Boot** und warten, bis wieder alle Panels bei **Connected Panels** angezeigt werden. Wiederholen Sie nun den Vorgang ab Schritt 3. (Es kann sein, dass die Panels erfolgreich ugedatet wurden, und nur die USB Expert Console das nicht mitbekommen hat. Das wird auf diese Weise überprüft).

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/user-settings.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/user-settings.md
@@ -1,0 +1,201 @@
+---
+id: user-settings
+title: User Settings - Benutzereinstellungen
+sidebar_label: User Settings - Benutzereinstellungen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Das Menü 'User Settings' (Benutzereinstellungen) lässt sich sowohl im
+**System**-Menü (<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>) 
+als auch im 'Program'-Modus aufrufen; dazu halten Sie die <Keys.HardKey>AVO</Keys.HardKey>
+-Taste gedrückt und betätigen die Taste <Keys.SoftKey>User Settings</Keys.SoftKey>.
+
+![User Settings Window](/docs/images/User-Settings-Window.png)
+
+Es öffnet sich ein Fenster, in dem alle verfügbaren
+Benutzereinstellungen angezeigt werden und verändert werden können;
+ebenso kann man sie mit den Menütasten verändern. Die
+Benutzereinstellungen gelten jeweils pro Benutzer.
+
+
+>   Ein Klick auf das Symbol <Keys.ContextKey>i</Keys.ContextKey> öffnet einen kleinen Hinweistext 
+    zu der jeweiligen Einstellung.
+
+Die möglichen Einstellungen sind nach verschiedenen Kategorien sortiert.
+Diese Kategorien sind links eingeblendet. Wählen Sie dort die Kategorie,
+in der Sie eine Einstellung ändern wollen.
+
+## General (Allgemein)
+
+Option | Wirkung
+-------|--------
+Chase Snap | *On*: mit den Tasten <Keys.HardKey>Next Step</Keys.HardKey>/<Keys.HardKey>Prev Step</Keys.HardKey> wird bei Chasern hart auf den nächsten Schritt umgeschaltet. <br/>***Off***: Fadezeiten und X-Over werden berücksichtigt. <br/>Diese Option wird auch mit der Taste <Keys.HardKey>Snap</Keys.HardKey> umgeschaltet, die auf einigen Pulten vorhanden ist.
+Cue List Snap | *On*: mit den Tasten <Keys.HardKey>Next Step</Keys.HardKey>/<Keys.HardKey>Prev Step</Keys.HardKey> wird bei Cuelisten hart auf den nächsten Schritt umgeschaltet.<br/>***Off***: programmierte Fadezeiten werden berücksichtigt.
+Clear Record Mask | ***On***: die Speichermaske (Record Mask) wird nach jedem Speichervorgang auf 'Alle Attribute' zurückgesetzt<br/>*Off*: die eingestellte Maske wird beibehalten.
+Copy Cues | ***Copy Tracked Values:*** beim Kopieren von Cues aus Cuelisten werden getrackte Werte kopiert<br/> *Don't Copy Tracked Values:* getrackte Werte werden nicht kopiert, nur die Werte, die direkt in diesem Cue gespeichert sind, werden kopiert.
+Run Startup Playbacks   | ***On:*** Playbacks, die in den Optionen auf 'Run on Startup' gestellt sind, werden beim Laden der Show/Systemstart automatisch gestartet.<br/> *Off*: Beim Laden der Show/Systemstart werden keine Playbacks automatisch gestartet.
+System Render Rate (Hz) | ***40 Hz*** Dient zum Einstellen der generellen Systemgeschwindigkeit. Der Wert kann je nach Bedarf auf Werte von 1 bis 44Hz gestellt werden. Mit kleineren Werten wird der Prozessor bei Shows mit sehr vielen gesteuerten Geräten ggf. entlastet.
+
+## Display
+
+Option | Wirkung
+-------|--------
+External Display | ***On:*** Externes Display ist aktiviert. <br/> *Off:* Externes Display ist deaktiviert.
+External Screen Workspace Shortcuts | ***On:*** Auf jedem Display wird ein separater Workspaces-Bereich angezeigt. Damit lassen sich auf einfache Weise für jeden Bildschirm getrennte Einstellungen vornehmen. <br/>*Off:* Die Workspace-Buttons auf dem Hauptdisplay steuern die Anzeige aller Bildschirme.
+Virtual Hardware | Die Anzeige mit den kompakten Bedienelementen für T1 und T2.<br/>***Auto:*** Titan Go verbirgt die Kompaktanzeige automatisch, wenn ein T3 oder Titan Mobile verbunden ist. <br/> *Enabled:* Die Bedienelemente werden immer angezeigt.<br/> *Disabled:* Die Kompaktanzeige wird nie verwendet..
+Fullscreen Mode                     | *On:* Titan Go wird im Vollbild-Modus angezeigt. <br/> ***Off:*** Titan Go wird als normales Programmfenster angezeigt.
+
+-  Die beiden letzten Optionen stehen nur bei Titan Go zur Verfügung.
+-  Diese Optionen stehen auch im **System**-Menü bei **Display Setup** zur Verfügung.
+-  Der Vollbild-Modus kann auch durch Drücken der Taste F11 aktiviert/deaktiviert werden.
+
+## Lock
+
+Option | Wirkung
+-------|--------
+Lock Screen Background | Einstellen eines Hintergrundbildes bei gesperrtem Pult.
+Venue Mode Workspace | Auswahl des Workspaces (mit den Menütasten), der im Venue-Mode verwendet wird.
+Venue Mode Password | Passwort zum Entsperren des Pultes in den Venue-Mode.
+Programmer Password | Passwort zum kompletten Entsperren des Pultes. Das Passwort "68340" entsperrt das Pult ebenfalls komplett.
+Lock on Startup | ***Shutdown state:*** Pult bzw. Software startet gesperrt oder ungesperrt, so wie es/sie heruntergefahren wurde.<br/> *Locked:* Pult bzw. Software startet gesperrt. <br/> *Venue Mode Workspace:* Pult bzw. Software startet im Venue-Mode.<br/>(Um 'Lock on Startup' zu verwenden, muss ein Programmer Passwort gesetzt sein)
+
+## Handles
+
+Option | Wirkung
+-------|--------
+Grand Master Fader | *On:* Grand Master aktiviert (nicht bei allen Pulten vorhanden).<br/>***Off:*** Grand Master deaktiviert. Hilfreich insbesondere, wenn der Fader nicht korrekt funktionieren sollte. oder um unbeabsichtigtes Betätigen zu vermeiden
+Delete Default | ***Delete:*** Elemente werden mit <Keys.HardKey>Delete</Keys.HardKey> + Doppelklick gelöscht.<br/>*Unassign:* Elemente werden nicht gelöscht, sondern nur von der Taste/Schaltfläche entfernt, und sind über die Show Library weiterhin verfügbar.
+Prompt Replace | Bestimmt, wie sich das Pult verhält, wenn man etwas auf einen bereits belegten Speicherplatz speichern will.<br/>***Always Ask:*** Es erscheint jedes Mal eine Rückfrage.<br/>*Always Merge:* Es erscheint nie eine Rückfrage, es wird immer gemergt.<br/>*Palettes Always Merge:* Die Rückfrage erscheint nur, wenn es sich nicht um das Speichern von Paletten handelt.
+Display Halo | ***On:*** Die Buttons werden mit farbigen Halos dargestellt.<br/>*Off:* Es werden keine farbigen Halos angezeigt.
+Fixture Halos | *Custom:* Bei Geräte-Buttons werden nur benutzerdefinierte Halos angezeigt. <br/>***Auto:*** Es werden automatisch farbige Halos für alle Fixtures angezeigt siehe [Halo](../patching/changing-the-patch.md#fixture-button-halo)
+Handle Buttons | Erlaubt das Ändern der Größe der Schaltflächen auf dem Touchscreen: *Small* (klein), ***Normal*** (normal), *Large* (groß) oder *Super Size* (sehr groß). <br/>Kann jeweils pro Fenster abgeändert werden.
+Text Size | Bestimmt die Schriftgröße auf den Schaltflächen. *Small* (klein), ***Normal*** (normal), *Large* (groß) oder *Super Size* (sehr groß). <br/>Kann jeweils pro Fenster abgeändert werden.
+Playback Paging | Das Verhalten aktiver Playbacks beim Seitenwechsel.<br/> *Always Hold:* - ist die traditionelle Funktionsweise, bei der das Playback aktiv und mit dem Regler verbunden bleibt, bis dieser - und damit das Playback - auf 0 gebracht wird.<br/> *Never Hold:* - ist die Funktionsweise bei Pulten mit Motorfadern: beim Seitenwechsel bleiben aktive Playbacks aktiv, aber die Fader sind auf der neuen Seite. Um aktive Playbacks von einer anderen Seite wieder zu steuern, muss man erst auf diese Seite wechseln und den Fader auf den passenden Wert bringen. <br/> ***Normal:*** ist die für das jeweilige Pult normale Arbeitsweise. <br/>Ist ein Playback von einer anderen Seite aktiv, so wird dies violett dargestellt; die Seitenzahl wird in hellblau angezeigt.
+Current Handle World | Wahl der aktuellen Handle World. Siehe Abschnitt [Handle Worlds](../titan-basics/multi-user-operation.md#handle-worlds).
+
+## Key Profiles (Tastenprofile)
+
+Auswahl/Editieren des aktuellen Tastenprofils. Siehe [Key Profiles](key-profiles.md).
+
+## Patching (Patch-Optionen)
+
+Option | Wirkung
+-------|--------
+Warn Before Parking Fixtures | Bestimmt das Verhalten beim Patchen von Geräten mit sich überschneidenden DMX-Adressen; dabei werden die anderen Geräte jeweils 'geparkt'.<br/> ***Always:*** es erscheint stets eine Warnmeldung.<br/>*Never:* keine Warnung beim Parken von Geräten. Siehe [Parked fixtures](../patching/patching-new-fixtures-or-dimmers.md#geparkte-geräte)
+DMX Address | Anzeige der DMX-Adresse auf den Fixture-Buttons aktivieren oder deaktivieren.
+Auto Groups | Bestimmt, ob beim Patchen von Geräten automatisch Gruppen angelegt werden sollen. Siehe [Auto Groups](../controlling-fixtures/fixture-groups.md#auto-groups).
+Preset Palettes | Bestimmt, ob beim Patchen von Geräten automatisch Paletten angelegt werden sollen. Kann auch beim Patchen im Patch-Optionsmenü mit <Keys.SoftKey>Preset Palettes on Workspaces</Keys.SoftKey> aktiviert werden.<br/>***Do Not Create:*** es werden keine Paletten angelegt.<br/>*Create On Workspaces:* es werden Paletten in den jeweiligen Paletten-Fenstern angelegt.<br/>*Create On Presets:* es werden Paletten auf den Preset-Tasten (Pearl Expert) angelegt.
+
+## Times (Zeiten)
+
+Option | Wirkung
+-------|--------
+Tempo Units | Stellt die Einheiten für die Geschwindigkeit (etwa von Chasern) ein: entweder ***Beats per Minute*** (BPM) oder *Seconds* (Sekunden). 
+Connected View Sets | Bestimmt das Verhalten beim Ändern der Geschwindigkeit eines 'verbundenen' (connected) Chasers.<br/> ***Speed:*** Das eingestellte Tempo wird gespeichert und das vorher programmierte damit überschrieben<br/>*Temporary Speed:* Das eingestellte Tempo gilt nur momentan, und wird beim nächsten Laden des Chasers wieder auf den programmierten Wert zurückgesetzt.
+Preload Time | Bestimmt die Überblendzeit der 'Preload'(Vorlade-) Funktion, der Standardwert sind 2 Sekunden. Dieser Wert sorgt für eine sanfte Bewegung der Geräte.
+Times Format | Wahl des Anzeige- und Eingabeformats von Zeiten. Mögliche Optionen: ***HH:MM:SS*** und Sekunden. Bei Wahl von *HH:MM:SS* wird automatisch jede Eingabe entsprechend umgewandelt.
+Compensate for Rate Grand Master | ***On:*** ein getapptes Tempo wird von einem unter 100% gesetzten Rate Grand Master nicht beeinflusst.<br/>*Off:* Das Tempo wird immer vom Rate Grand Master beeinflusst.
+
+## Palettes
+
+Option | Wirkung
+-------|--------
+Quick Palettes | ***On:*** Palettenaufruf ohne ausgewählte Geräte aktiviert, siehe [Abrufen von Paletten](../palettes/using-palettes.md).<br/> *Off:* Quick Palettes sind deaktiviert. Ohne angewählte Geräte kann keine Palette aufgerufen werden.
+Minimum Palette Mode | Wahl des Vorgabewertes für den Palettenmodus. Damit kann festgelegt werden, dass Paletten stets als Shared oder Normal gespeichert werden sollen.<br/>***Global:*** Alle Paletten werden als globale Paletten gespeichert.<br/>*Shared:* Alle Paletten werden als shared (gemeinsam genutzte) Paletten gespeichert.<br/>*Normal:* Alle Paletten werden als normale Paletten gespeichert.
+Add New Palette Channels | ***On:*** Kanäle, die bereits verwendeten Paletten hinzugefügt werden, werden automatisch in die betreffenden Playbacks übernommen.<br/>*Off:* neu hinzugefügte Kanäle werden nicht übernommen. Damit wird sichergestellt, dass Änderungen an den Paletten keine unerwartete Auswirkungen auf die Playbacks haben.
+Auto Legend | ***On:*** neue Elemente erhalten automatisch Legenden.<br/>*Off:* Keine automatischen Legenden.
+Highlight Active Palettes | ***On:*** Gerade im Programmer aktive Paletten werden markiert.<br/>*Off:* Aktive Paletten werden nicht markiert.
+Filter Relevant Palettes  | ***On:*** Paletten, die auf die gerade angewählten Geräte nicht anwendbar sind, werden ausgegraut.<br/>*Off:* Nicht anwendbare Paletten werden nicht ausgegraut.
+Master Palette Time | Die Vorgabe-Überblendzeit beim Live-Aufruf von Paletten, siehe [Master-Zeit für Paletten](../palettes/timing-with-palettes.md#master-zeit-für-paletten).
+Master Palette Overlap | Der Vorgabewert für die Überlappung beim Live-Aufruf von Paletten.
+Record Nested Palettes | ***On:*** Updaten von verknüpften Paletten, wenn die eingebetteten Paletten verändert werden.<br/>*Off:* Verknüpfte Paletten werden nicht aktualisiert.<br/>Siehe [Nested Palettes](../palettes/creating-palettes.md#nested-palettes----verknüpfte-paletten).
+Preset Palettes | Gleiche Funktion wie im Abschnitt Patching, [siehe oben](#patching-patch-optionen).
+
+## Timeline
+
+Option | Wirkung
+-------|--------
+Default Playback Length | Vorgabewert für die Dauer eines Playbacks, wenn es zu einer Timeline hinzugefügt wird.
+Timeline Skip Length | Vorgabewert, wie weit mit "skip forward" und "skip back" gesprungen wird.
+Display Frame Rate | Framerate für den angezeigten Timecode. Mit ***"Follow Source"*** folgt die Anzeige der Framerate des am Eingang anliegenden Timecodes.
+Auto-Simplify | ***On:*** Trigger für Faderpegel werden automatisch vereinfacht (geglättet).<br/>*Off:* Triggers werden nicht vereinfacht/geglättet. <br/>Siehe [Auto Simplify](../timelines/creating-a-timeline.md#auto-simplify).
+Auto-Open View | *None:* Beim Anlegen einer neuen Timeline wird kein Fenster geöffnet.<br/> ***Timeline:*** Beim Anlegen einer neuen Timeline wird die grafische Timeline-Anzeige geöffnet. <br/>*Timeline and Table:* Sowohl die grafische als auch die Tabellenanzeige werden geöffnet.
+
+## Formatting (Formate)
+
+Option | Wirkung
+-------|--------
+Channel Levels | Definiert, wie die gewünschten Pegel über die Zifferntasten eingegeben werden.<br/> *Set In Tens:*  ('Eingabe in Zehnern') - man gibt nur eine Ziffer ein, z.B. *5 = 50%*<br/>***Set in Units:*** die Eingabe erfolgt zweistellig, z.B.*50 = 50%*.
+Number Style   | Stellt die Darstellung von Zahlen in der Cue- und Palettenansicht ein. <br/> *Precise:* zeigt alle Dezimalstellen.<br/>*Rounded:* rundet auf die nächste Ganzzahl.<br/>***Dynamic:*** zeigt Dezimalstellen wenn erforderlich und unterdrückt Nullen.
+
+## Release
+
+Option | Wirkung
+-------|--------
+Release To Home | ***On:*** das Release erfolgt nach und nach bis zum Einschaltzustand des Pultes.<br/>*Off:* LTP-Werte des letzten Playbacks bleiben aktiv.
+Master Release Time | Vorgabewert für die Release-Zeit.
+Release Priority | Die Playback-Priorität, die per Default im Release-Menü sowie bei Release-Macros herangezogen wird. - *Low* (niedrig), *Normal* (normal), *High* (hoch), ***Programmer*** (Programmer), *Very High* (sehr hoch). Playbacks mit geringerer Priorität werden per *Release All* (Doppelklick auf <Keys.HardKey>Release</Keys.HardKey>) released.
+
+- Stellt man die Release Priority auf **Low**, so kann man nicht versehentlich alle Playbacks mit <Keys.HardKey>Release</Keys.HardKey><Keys.HardKey>Release</Keys.HardKey> deaktivieren, denn so würden nur die mit Priorität *Low* released.
+
+- Diese Einstellungen können auch im Release-Menü vorgenommen werden.
+
+## Clear
+
+Option | Wirkung
+-------|--------
+Auto Reset Mask | ***On:*** Setzt die Maskierung bei jedem Betätigen der 'Clear'-Taste automatisch zurück.<br/>*Off:* Die Clear-Maske wird nicht zurückgesetzt.
+Zero Preset Fader Levels   | ***On:***  Faderwerte von Geräten, die direkt auf Fader gepatcht sind, werden mit <Keys.HardKey>Clear</Keys.HardKey> auf 0 gesetzt.<br/> *Off:*  Die Werte werden aus dem Programmer gelöscht, bleiben aber aktiv.
+Release to Playback Values | *On:* LTP-Kanäle releasen auf das zuletzt aktive Playback.<br/>***Off:*** LTP-Kanäle releasen bei Clear nicht.
+Clear Cue Times | ***On:*** Zeiten im Programmer werden bei Clear gelöscht.<br/>*Off:* Zeiten im Programmer werden bei Clear beibehalten.
+Clear Rate Settings | ***On:*** Speed-Einstellungen im Programmer werden bei Clear zurückgesetzt. <br/>*Off:* Speed-Einstellungen im Programmer bleiben bei Clear erhalten.
+Clear Direction | ***On:*** Direction-Einstellungen im Programmer werden bei Clear zurückgesetzt. <br/>*Off:* Direction-Einstellungen im Programmer bleiben bei Clear erhalten.
+Clear Selected Fixtures | *On:* bei Betätigen der Clear-Taste werden nur die gerade angewählten Geräte aus dem Programmer gelöscht, während die anderen im Programmer verbleiben. Sind keine Geräte angewählt, so wird der Programmer komplett gelöscht.<br/> ***Off:*** der Programmer wird immer komplett gelöscht.
+Clear Action Precedence | Einstellungen zum mehrstufigen Clear:<br/>***Selection With Programmer***: beim Betätigen der Clear-Taste wird der Programmer und die Geräteauswahl gelöscht<br/>*Selection Then Programmer*: sind Geräte angewählt, so wird mit Clear die Geräteauswahl gelöscht. Sind keine Geräte vorhanden, so wird der Programmer gelöscht.<br/>*Programmer Then Selection*: Befinden sich Werte im Programmer, so werden mit Clear diese gelöscht. Wenn der Programmer leer ist, wird die Geräteauswahl gelöscht.
+
+- Diese Einstellungen können auch im Clear-Menü vorgenommen werden.
+
+## LEDs
+
+Option | Wirkung
+-------|--------
+Fixture LEDs | Dient zum Einstellen des Verhaltens der LEDs in den 'Select'-Tasten, wenn direkt auf Fader/Tasten gepatcht wurde. <br/>***Show Occupation:*** Anzeige der Belegung (frei/belegt). <br/>*Mimic Intensity:* Anzeige der Intensität/Dimmerlevel.<br/>**Die nachfolgenden Optionen beziehen sich nur auf die Einstellung *Show Occupation* **
+LED Empty Level      | Helligkeit freier Tasten.
+LED Occupied Level   | Helligkeit belegter, aber nicht ausgewählter Gerätetasten.
+LED Programmer Level | Helligkeit, wenn das Gerät im Programmer ist.
+LED Selected Level   | Helligkeit für ausgewählte Geräte (nicht im Programmer).
+
+## Effects (Effekte)
+
+Option | Wirkung
+-------|--------
+Swop Shapes | Verhalten von Shapes bei Swop.<br/>***All Shapes:*** Alle laufenden Shapes von anderen Playbacks werden unterbrochen.<br/>*Intensity Shapes:* Nur Intensity-Shapes von anderen Playbacks werden unterbrochen, andere Shapes laufen weiter.
+Shape Behaviour | Steuert, ob Shapes und Keyframe-Shapes eher LTP wirken (und von anderen Playbacks überschrieben werden können) oder nicht. Siehe [Speichern eines Keyframe-Shapes in einem Cue](../effects/key-frame-shapes.md#einen-keyframe-shape-in-einen-cue-speichern).
+
+## Timecode
+
+Option | Wirkung
+-------|--------
+Kill Out of Range Playbacks | *On:* Playbacks werden automatisch deaktiviert, sobald der letzte im Playback programmierte Timecode abgelaufen ist.<br/> ***Off:*** Das Playback bleibt aktiv.
+MIDI Device ID              | Einstellen der Device-ID bei Verwendung von MIDI Show Control.
+MIDI Glitch Detection       | ***On:*** Aktiviert die folgenden zwei Optionen.<br/>*Off:* Deaktiviert die folgenden zwei Optionen.
+MIDI Glitch Tolerance       | Max. Zeitsprünge im MIDI-Timecode, die nicht als Fehler erkannt werden.
+MIDI Glitch Timeout         | Zeit nach Erkennen eines Fehlers, in der MIDI-Timecode ignoriert wird.
+
+> Weitere Informationen zu [MIDI Triggern](../running-the-show/midi-dmx-or-audio-triggering.md)
+
+---
+
+## Wheels
+
+Option | Wirkung
+-------|--------
+Wheel Sensitivity     | Empfindlichkeit der Encoder. Die Empfindlichkeit der Encoder lässt sich mit **Encoder A** einstellen, der aktuelle Wert wird im Display angezeigt. Vorgabe ***50%***.
+Pan & Tilt Threshold  | Aktiviert/deaktiviert die nachfolgenden beiden Optionen.
+Pan Threshold         | Empfindlichkeit für Pan (wenn aktiviert). Größere Werte lassen Pan träger reagieren. Vorgabe ***5s***.
+Tilt Threshold        | Empfindlichkeit für Tilt (wenn aktiviert). Größere Werte lassen Tilt träger reagieren. Vorgabe ***4s***.
+Auto Connect          | Bestimmt, ob Chaser und Cuelisten bei ihrem Aufruf automatisch mit der Ablaufsteuerung (Encoder und Tasten) verbunden werden.<br/>*Off:* Chaser und Cuelisten werden nicht automatisch connected.<br/>*Chases:* Chaser werden automatisch connected.<br/>*Cue Lists:* Cuelisten  werden automatisch connected.<br/>***Chases and Lists:*** Chaser und Cuelisten werden automatisch connected.
+Auto View on Connect  | Wenn aktiviert, wird beim Connecten von Chasern und/oder Cuelisten automatisch das entsprechende Playback-Fenster angezeigt.<br/>***Off:*** Deaktiviert.<br/>*Chases:* Chaser öffnen beim Connecten das jeweilige Playback-Fenster.<br/>*Cue Lists:* Cuelisten öffnen beim Connecten das jeweilige Playback-Fenster.<br/>*Chases and Lists:* Chaser und Cuelisten öffnen beim Connecten das jeweilige Playback-Fenster..
+Press and Hold Fan    | *On:* Ändert das Verhalten der <Keys.HardKey>Fan</Keys.HardKey>-Taste, so dass sie gedrückt gehalten werden muss. Damit wird das versehentliche Aktivieren dieser Funktion vermieden.<br/>***Off:*** Die Fan-Taste rastet wie bei älteren Pulten ein und muss extra wieder deaktiviert werden.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/user-settings.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/system-settings/user-settings.md
@@ -72,7 +72,7 @@ Display Halo | ***On:*** Die Buttons werden mit farbigen Halos dargestellt.<br/>
 Fixture Halos | *Custom:* Bei Geräte-Buttons werden nur benutzerdefinierte Halos angezeigt. <br/>***Auto:*** Es werden automatisch farbige Halos für alle Fixtures angezeigt siehe [Halo](../patching/changing-the-patch.md#fixture-button-halo)
 Handle Buttons | Erlaubt das Ändern der Größe der Schaltflächen auf dem Touchscreen: *Small* (klein), ***Normal*** (normal), *Large* (groß) oder *Super Size* (sehr groß). <br/>Kann jeweils pro Fenster abgeändert werden.
 Text Size | Bestimmt die Schriftgröße auf den Schaltflächen. *Small* (klein), ***Normal*** (normal), *Large* (groß) oder *Super Size* (sehr groß). <br/>Kann jeweils pro Fenster abgeändert werden.
-Playback Paging | Das Verhalten aktiver Playbacks beim Seitenwechsel.<br/> *Always Hold:* - ist die traditionelle Funktionsweise, bei der das Playback aktiv und mit dem Regler verbunden bleibt, bis dieser - und damit das Playback - auf 0 gebracht wird.<br/> *Never Hold:* - ist die Funktionsweise bei Pulten mit Motorfadern: beim Seitenwechsel bleiben aktive Playbacks aktiv, aber die Fader sind auf der neuen Seite. Um aktive Playbacks von einer anderen Seite wieder zu steuern, muss man erst auf diese Seite wechseln und den Fader auf den passenden Wert bringen. <br/> ***Normal:*** ist die für das jeweilige Pult normale Arbeitsweise. <br/>Ist ein Playback von einer anderen Seite aktiv, so wird dies violett dargestellt; die Seitenzahl wird in hellblau angezeigt.
+Playback Paging | Das Verhalten aktiver Playbacks beim Seitenwechsel.<br/> *Always Hold:* - ist die traditionelle Funktionsweise, bei der das Playback aktiv und mit dem Regler verbunden bleibt, bis dieser - und damit das Playback - auf 0 gebracht wird (diese Einstellung betrifft auch die Playbacks im Playbacks-Fenster/Speicherplätze: aktive Playbacks von anderen Seiten bleiben aktiv und müssen erst deaktiviert werden, um nach dem Seitenwechsel Playbacks der neuen Seite anzuzeigen).<br/> *Never Hold:* - ist die Funktionsweise bei Pulten mit Motorfadern: beim Seitenwechsel bleiben aktive Playbacks aktiv, aber die Fader sind auf der neuen Seite. Um aktive Playbacks von einer anderen Seite wieder zu steuern, muss man erst auf diese Seite wechseln und den Fader auf den passenden Wert bringen. <br/> ***Normal:*** ist die für das jeweilige Pult normale Arbeitsweise. <br/>Ist ein Playback von einer anderen Seite aktiv, so wird dies violett dargestellt; die Seitenzahl wird in hellblau angezeigt.
 Current Handle World | Wahl der aktuellen Handle World. Siehe Abschnitt [Handle Worlds](../titan-basics/multi-user-operation.md#handle-worlds).
 
 ## Key Profiles (Tastenprofile)
@@ -134,7 +134,8 @@ Number Style   | Stellt die Darstellung von Zahlen in der Cue- und Palettenansic
 
 Option | Wirkung
 -------|--------
-Release To Home | ***On:*** das Release erfolgt nach und nach bis zum Einschaltzustand des Pultes.<br/>*Off:* LTP-Werte des letzten Playbacks bleiben aktiv.
+Release To Home | ***On:*** Das Release erfolgt nach und nach bis zum Einschaltzustand des Pultes.<br/>*Off:* LTP-Werte des letzten Playbacks bleiben aktiv.
+Release To Quick Palette    | ***On:*** Das Release erfolgt auf vorher gestartete Quick Palettes (soweit vorhanden).<br/>*Off:* LTP-Werte des letzten Playbacks bleiben aktiv.
 Master Release Time | Vorgabewert für die Release-Zeit.
 Release Priority | Die Playback-Priorität, die per Default im Release-Menü sowie bei Release-Macros herangezogen wird. - *Low* (niedrig), *Normal* (normal), *High* (hoch), ***Programmer*** (Programmer), *Very High* (sehr hoch). Playbacks mit geringerer Priorität werden per *Release All* (Doppelklick auf <Keys.HardKey>Release</Keys.HardKey>) released.
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/timelines.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/timelines.md
@@ -1,0 +1,138 @@
+---
+id: timelines
+title: Einführung in Timelines
+sidebar_label: Einführung in Timelines
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Mit Timelines lassen sich zeitlich exakt gesteuerte Abläufe programmieren, die synchron zu einem 
+externen Timecode oder mit dem internen Timecode ablaufen. Das könnte z.B. die Eröffnungs-Sequenz
+einer Veranstaltung sein, die Lichtshow zu einem Song, oder etwa eine Multimedia-Show mit Video-Zuspieler. 
+Genauso kann man [aufwändige Lichteffekte](./timelines/timeline-options.md#fader-tab) programmieren und 
+diese später beim Busking verwenden.
+
+> Timecode-gesteuerte Shows können auch mit [Cuelisten](./cue-lists/cue-list-timing.md#steuern-einer-cueliste-per-timecode)
+programmiert werden. Aber Timelines lassen sich wesentlich einfacher erstellen und editieren.
+
+Timelines werden genau wie z.B. Cues oder Cuelisten per <Keys.HardKey>Record</Keys.HardKey>-Taste auf Fader oder 
+Buttons gespeichert. Verwendet werden können bereits programmierte Playbacks, es können aber auch beim Erstellen der 
+Timeline neue Playbacks hinzugefügt werden. Man kann die Bedienung des Pultes in Echtzeit aufzeichnen, oder man 
+fügt die einzelnen Bedienvorgänge manuell hinzu und vergibt Zeiten dafür. Eine Timeline ist wie die Aufnahme der 
+Bedienung des Pultes über eine bestimmte Zeit. Die aufgezeichneten Aktionen - Tastendrücke und Faderbewegungen - 
+werden dabei **Trigger** genannt.
+
+Sobald eine Timeline gespeichert ist, kann man in der **Timeline-Ansicht** die Trigger hinzufügen und bearbeiten. 
+Drücken Sie dazu  <Keys.HardKey>Open/View</Keys.HardKey> und dann die **Auswahltaste** der Timeline, oder klicken Sie
+im Display oberhalb des betreffenden Faders auf die Legende. Beim Speichern einer neuen Timeline wird diese Ansicht 
+automatisch geöffnet.
+
+![Playback View of Timeline](/docs/images/Timeline-Window.png)
+
+## Trigger
+
+Beim Programmieren einer Timeline werden bestimmte Aktionen aufgezeichnet und beim Abspielen der 
+Timeline in der gleichen Reihenfolge und mit den gleichen Zeiten wiedergegeben. Diese aufgezeichneten
+Aktonen werden **Trigger** genannt.
+
+Die folgenden Trigger können in einer Timeline gespeichert werden. Dabei können sie sowohl **Live** 
+aufgezeichnet als auch manuell gespeichert und editiert werden.
+
+Trigger             | Beschreibung
+---|-----
+Set Level           | Fade über eine bestimmte Zeit. Hat den gleichen Effekt wie das manuelle Schieben eines Faders. Wenn für das Playback Fadezeiten programmiert wurden, so werden diese ebenfalls berücksichtigt.
+Go to cue           | Starten eines bestimmten Cues einer Cueliste. Dabei kann entweder ein Cue angegeben werden, zu dem gesprungen werden soll, oder es wird nur *Go* aufgezeichnet, womit der folgenden Cue gestartet wird. Wurden in der Cueliste Zeiten programmiert, so finden diese Berücksichtigung.
+Flash               | Flashen eines Playbacks (siehe [Flash und Swop](./running-the-show/playback-controls.md#flash--und-swop-tasten))
+Timed Flash         | Flashen eines Playbacks unter Berücksichtigung der Fadezeit
+Timed Flash and Go  | Flashen eines Playbacks unter Berücksichtigung der Fadezeit gefolgt von Go (bei Cuelisten)
+Swop                | Swoppen eines Playbacks (siehe [Flash und Swop](./running-the-show/playback-controls.md#flash--und-swop-tasten))
+Preload             | Vorladen der LTP-Werte eines Playbacks in einer bestimmten Zeit (siehe [Preload](./running-the-show/playback-controls.md#flash--und-swop-tasten))
+Marker              | Markierung zu einer bestimmten Timecode-Zeit, für Informationen
+Wait for go         | Die Timeline pausiert, bis die <Keys.HardKey>Go</Keys.HardKey>-Taste gedrückt wird (nur bei internem Timecode)
+
+- **Wait for go** bietet sich z.B. an, wenn auf ein bestimmtes Ereignis gewartet werden muss, etwa bis der Gewinner 
+einer Preisverleihung auf die Bühne gekommen ist. Shapes laufen weiter, solange die Timeline pausiert. Die Timeline 
+muss mit der Steuerung verbunden sein, damit die <Keys.HardKey>Go</Keys.HardKey>-Taste funktioniert. Ansonsten kann 
+man auch den Button <Keys.ContextKey>Play</Keys.ContextKey> in der Timeline-Ansicht anklicken.
+
+## Tracks
+
+Die Timeline ist in einzelne **Tracks** (Spuren) aufgeteilt. Jedes getriggerte Playback erhält eine eigene Zeile innerhalb des Tracks.
+- Tracks können mit dem Button <Keys.ContextKey>Mute</Keys.ContextKey> gemutet (stummgeschaltet) werden.
+- Tracks können mit dem Button <Keys.ContextKey>Lock</Keys.ContextKey> gelockt (gesperrt) werden, um unbeabsichtigte 
+Veränderungen zu verhindern.
+- Tracks können mit dem Pfeil links neben der TRack-Anzeige verkleinert dargestellt werden, so dass mehr Tracks auf die Anzeige passen. Siehe [Kompakte Track-Ansicht](./timelines/running-and-editing-timelines.md#kompakte-track-ansicht).
+
+## Timecode-Quelle wählen
+
+In den [Timeline-Optionen](./timelines/timeline-options.md#tab-timecode) wählt man einen der vier Timecodes als Quelle aus.
+
+Um jeweils zwischen Internal, MIDI, Clock und SMPTE zu wählen, klickt man im Hauptmenü auf <Keys.SoftKey>Timecode</Keys.SoftKey>, oder man klickt 2 x auf <Keys.HardKey>Open/View</Keys.HardKey> und wählt das gewünschte **Timecode-Fenster**.
+
+## Timecode verbinden und steuern
+
+Mit dem Button <Keys.ContextKey>Link</Keys.ContextKey> unten links in der Timeline-Ansicht wird der Timecode mit der Timeline verbunden bzw. kann vorübergehend getrennt werden.
+
+Wird externer Timecode verwendet, dann kommt der oft von einer Quelle, auf die Sie keinen Einfluss haben. In diesem Fall ist es hilfreich, den Timecode vorübergehend von der Timeline zu trennen, vor allem wenn man gerade etwas programmiert oder ändern will. Ist der Timecode getrennt, dann kann man die Timeline mit den Steuerbuttons abfahren, wie man es von einem Audioplayer gewohnt ist.
+
+- Verwendet man den internen Timecode oder Winamp als Quelle, so wird damit auch der interne Timecode oder eben auch Winamp gesteuert (Start/Stop/Pause...).
+
+![Timeline transport controls](/docs/images/Timeline-Timecode-Transport.png)
+
+- <Keys.ContextKey>Rewind</Keys.ContextKey>: zurück auf Anfang (00:00:00:00).
+- <Keys.ContextKey>Play from cursor</Keys.ContextKey>: Start ab Cursorposition (oder ab Start, wenn der Cursor außerhalb der festgelegten Start/End-Zeit ist).
+- <Keys.ContextKey>Play</Keys.ContextKey> und <Keys.ContextKey>Pause</Keys.ContextKey>:Play und Pause.
+- <Keys.ContextKey>Stop</Keys.ContextKey>: Stop und zurück auf Anfang.
+- <Keys.ContextKey>Record</Keys.ContextKey>: Record/Aufzeichnung. Damit wird der Timecode aber nicht gestartet.
+
+ist ein externer Timecode verbunden (also keine interner Timecode oder Winamp), so wird an Stelle der ersten vier Buttons die Timecode-Quelle angezeigt. Nur der Record-Button bleibt.
+
+![Timeline external timecode controls](/docs/images/Timeline-Timecode-ExternalTransport.png)
+
+Ist der Timecode im **Timecode-Menü** deaktiviert, so wird die Zeit rot angezeigt.
+
+Ist der Timecode aktiv und auch in dem gültigen Zeitraum (siehe [Start und Duration](./timelines/timeline-options.md#tab-times)), so wird die Zeit orange angezeigt.
+
+![Timeline disabled](/docs/images/Timeline-Timecode-Disabled.png)
+
+- Ist der Timecode sehr verschoben, z.B. um ganze Stunden versetzt, so kann man mittels Offset die 0-basierte Timeline entsprechend anpassen. Ebenso können auch kleine Versätze von einigen Frames ausgeglichen werden, siehe [Offset einstellen](./timelines/timeline-options.md#offset-einstellen).
+
+## Die Übersichtsleiste
+
+Die Balkenanzeige unten in der Timeline-Ansicht bietet einen Überblick über die Timeline von Anfang bis Ende. Trigger und Marker sind verkleinert dargestellt. Indem die Enden der Leiste angeklickt und verschoben werden, kann man im Hauptbereich der Tracks passend zoomen, um einen kleinen Bereich genau angezeigt zu bekommen. Auf diese Weise lässt sich schnell in der Timeline navigieren. Siehe [Die Übersichts-Leiste](./timelines/running-and-editing-timelines.md#die-übersichts-leiste).
+
+![Timeline overview bar](/docs/images/Timeline-Overview-Bar-Cropped.png)
+
+## Navigieren in der Timeline mit den Encodern
+
+Aktiviert man die Kontext-Option <Keys.ContextKey>Timeline Wheels</Keys.ContextKey>so kann man mit den Encodern in der Timeline navigieren, solange keine Trigger angewählt sind. Die Encoder funktionieren dann wie folgt:
+- Encoder A: Horizontal
+- Encoder B: Vertikal
+- Encoder C: Zoom
+
+Sind dagegen Trigger angewählt, so Steuern die Encoder Zeit, Pegel und Fade der ausgewählten Trigger.
+
+## Cursor
+
+Neue Trigger werden an der Stelle eingefügt, an der sich gerade die graue Zeitmarke - der Cursor - befindet. Dies dient 
+auch als "Play Head", um zum Testen die aktuelle Position frei zu verschieben. Zum Verschieben klickt man ober in der Timeline-Ansicht auf die Zeile mit den Zeiten.
+
+Klickt man auf das Dreieck oben am Cursor oder aktiviert man die Kontext-Option <Keys.ContextKey>Select Cursor</Keys.ContextKey>, so kann man die Cursorposition mit **Encoder A** genau einstellen.
+
+## Werkzeugbuttons
+
+Mit den Buttons <Keys.ContextKey>Select</Keys.ContextKey> und <Keys.ContextKey>Pan</Keys.ContextKey> stehen verschiedene Werkzeuge zum Editieren zur Verfügung.
+- <Keys.ContextKey>Select</Keys.ContextKey> dient zur Auswahl über eine Auswahl-Box: ziehen Sie um die auszuwählenden Trigger einen Rahmen (oder klicken Sie einen einzelnen Trigger direkt an).
+- Mit <Keys.ContextKey>Pan</Keys.ContextKey> kann man dagegen die ganze Timeline nach links und rechts verschieben.
+
+Die Werkzeuge können auch über den Kontext-Button <Keys.ContextKey>Tool Pan</Keys.ContextKey>
+/<Keys.ContextKey>Tool Select</Keys.ContextKey> ausgewählt werden.
+
+## Tabellenansicht
+
+Mit dem Kontextbutton <Keys.ContextKey>Open Table View</Keys.ContextKey> kann man die Timeline als **Tabelle** öffnen, wobei alle Trigger in zeitlicher Abfolge angezeigt werden wie bei einer Cueliste. Die Anzeige einzelner Tracks kann mit Buttons auf der linken Seite gesteuert werden. Siehe [Tabellen-Ansicht](./timelines/running-and-editing-timelines.md#tabellen-ansicht).
+
+![Timeline table view](/docs/images/Timeline-Table-View.png)
+
+- Timelines können auch gleichzeitig grafisch und als Tabelle angezeigt werden.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/timelines/creating-a-timeline.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/timelines/creating-a-timeline.md
@@ -1,0 +1,123 @@
+---
+id: creating-a-timeline
+title: Eine Timeline speichern
+sidebar_label: Eine Timeline speichern
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Eine Timeline kann man live aufzeichnen, manuell programmieren, oder beides miteinander kombinieren.
+
+
+
+## Aufzeichnen eine Timeline im Live-Betrieb
+
+Das Aufzeichnen einer Timeline im Live-Betrieb entspricht dem Aufzeichnen einer live gedrückten Show. Dabei werden z.B. Faderstarts und das Betätigen der Go-Taste passend zur Musik aufgenommen. Bei Bedarf kann man dies Aufzeichnung mehrfach wiederholen, um noch komplexere Timelines zu erstellen.
+
+>   Beim Aufzeichnen im Live-Betrieb werden folgende Elemente **nicht** mit aufgezeichnet:<br/>
+    **Palettenaufrufe** werden nicht in der Timeline gespeichert - es müssen also Playbacks verwendet werden (Cues/Chaser/Cuelisten)<br/>
+    **Werte von Mastern** werden im Live-Betrieb nicht gespeichert; alle Master (Group, BPM, Scale, Rate, Intensity) haben also bei der Wiedergabe ihre Default-Einstellung. Am besten released man also vor der Aufzeichnung alle Master, um später das gewünschte Ergebnis zu erzielen, siehe [Releasen von Mastern](../cues/cue-playback.md#einen-master-releasen).<br/>
+    Aktionen mit dem **Scene Master** werden nicht mit aufgezeichnet. 
+
+Zum Aufzeichnen einer Timeline im Live-Betrieb geht man wie folgt vor:
+
+1. Ist ein externer Timecode verbunden, möchte man aber die Timeline von diesem unabhängig aufzeichnen, so 
+klickt man auf "Timecode Disconnect" <Keys.ContextKey>Link</Keys.ContextKey>, so dass eine unterbrochene 
+Verbindung angezeigt wird.
+2. Drücken Sie <Keys.HardKey>Record</Keys.HardKey>, <Keys.SoftKey>Timeline</Keys.SoftKey>, dann 
+die **Auswahltaste** des gewünschten Speicherplatzes. Darauf öffnet sich die Timeline-Ansicht.
+3. Klicken Sie auf <Keys.ContextKey>Record</Keys.ContextKey> links oben in der Timeline-Ansicht.
+4. Wählen Sie, welchen Track sie aufzeichnen wollen. Klicken Sie dazu auf den Button <Keys.SoftKey>Track</Keys.SoftKey> 
+oder auf den von einer blinkenden gestrichelten Linie umgebenen Bereich.<br/>
+Man kann Trigger zu einem bestehenden Track hinzufügen, oder einen neuen Track erstellen, indem man auf den 
+Bereich unterhalb der bereits existierenden Tracks klickt. Klickt man nochmals 
+auf <Keys.ContextKey>Record</Keys.ContextKey>, so erfolgt die Aufzeichnung auf dem gerade angewählten Track.<br/>
+ ![Timeline quick record dotted tracks](/docs/images/Timeline-Quickrecord-Dotted.png)
+5. Zum Start der Aufnahme klicken Sie nochmals auf den Track, oder klicken Sie auf <Keys.SoftKey>Start Live Record</Keys.SoftKey>. Das Timeline-Fenster erhält nun einen roten Rahmen ('Aufnahme läuft!'), die Aufnahme beginnt, sobald der Timecode startet.
+6. Verwendet man den internen Timecode als Quelle, so klickt man auf <Keys.ContextKey>Play</Keys.ContextKey> links oben im Timeline-Fenster, um den Timecode zu starten. Verwendet man dagegen einen externen Timecode, so muss der an der jeweiligen Quelle gestartet werden.
+7. Werden nun Aktionen ausgeführt wie das Starten von Playbacks, Ändern von Fadern oder Betätigen der Go-Taste, so tauchen diese jetzt als Trigger in der Timeline auf. Der aufgezeichnete Zeitbereich wird dabei rot angezeigt.
+8. Zum Beenden der Aufzeichnung klickt man wieder auf <Keys.ContextKey>Record</Keys.ContextKey> und stoppt dann den Timecode.
+
+Jetzt werden alle gerade erstellten Trigger in der Timeline angezeigt.
+
+- Um weitere Trigger zu einer bestehenden Timeline hinzuzufügen, wiederholen Sie den Vorgang. Drücken Sie 
+dazu <Keys.HardKey>Record</Keys.HardKey> und dann die **Auswahltaste** der Timeline.
+
+- Verwendet man den internen Timecode, so wird mit <Keys.ContextKey>Record</Keys.ContextKey> gefolgt 
+von <Keys.ContextKey>Play</Keys.ContextKey> automatisch die Live-Aufzeichnung gestartet.
+
+- Um direkt weitere Trigger zu einem bestimmten Track hinzuzufügen, klicken Sie 
+auf <Keys.ContextKey>Record</Keys.ContextKey> und dann auf den gewünschten Track in der Timeline-Ansicht.
+
+- Während der Aufzeichnung im Live-Betrieb gelten die Release-Einstellungen der 
+Timeline [Timeline-Optionen, Tab "Release"](../timelines/timeline-options.md#tab-release). 
+Ggf. reagieren manche Playbacks damit anders als gewohnt. Im System-Bereich wird eine entsprechende Meldung angezeigt.
+Das kommt daher, weil die globalen Release-Einstellungen benutzerabhängig sind und die Timeline für Titan als 
+separater Benutzer gilt, also über eigene Einstellungen verfügt.
+
+### Automatisches Vereinfachen
+
+Normalerweise ist während der Aufzeichnung die Option <Keys.SoftKey>Auto Simplify</Keys.SoftKey> aktiviert. Damit 
+werden nach Ende der Aufzeichnung Faderbewegungen zu linearen Fades vereinfacht. Sind dagegen wirklich nichtlineare 
+Faderbewegungen erforderlich, deaktiviert man diese Option, hat dann aber deutlich mehr einzelne Triggerpunkte 
+zu editieren.
+
+Viele einzelne Triggerpunkte während der Live-Aufzeichnung:
+
+![Timeline before auto simplify](/docs/images/Timeline-Live-Record.png)
+
+Die gleiche Aufzeichnung nach Auto Simplify:
+
+![Timeline after auto simplify](/docs/images/Timeline-Live-Record-Simplified.png)
+
+- Trigger lassen sich nach der Aufzeichnung vereinfachen. Wählen Sie die Trigger per Auswahlbox aus und verwenden Sie die 
+Kontext-Funktion <Keys.ContextKey>Tools</Keys.ContextKey> - <Keys.ContextKey>Simplify Selected Triggers</Keys.ContextKey>.
+
+- Ebenso kann man das Faden zwischen einzelnen Triggerpunkten nachträglich aktivieren: wählen Sie die Trigger aus, 
+und wählen Sie aus dem Kontext-Menü <Keys.ContextKey>Tools</Keys.ContextKey> - <Keys.ContextKey>Smooth Selected Triggers</Keys.ContextKey>. Im nachfolgenden Bild werden die Trigger vor und nach dieser Aktion dargestellt.
+
+![Timeline fade smoothing](/docs/images/Timeline-Smooth.png)
+
+
+## Trigger manuell hinzufügen
+
+Programmiert man dagegen eine Show, bei der die Timecode-Marken bereits feststehen, so lassen sich die 
+Trigger gezielt manuell festlegen.
+
+1. Drücken Sie <Keys.HardKey>Record</Keys.HardKey>, <Keys.SoftKey>Timeline</Keys.SoftKey>, dann 
+die **Auswahltaste** des gewünschten Speicherplatzes. Darauf öffnet sich die Timeline-Ansicht.
+2. Klicken Sie auf den Button <Keys.ContextKey>+</Keys.ContextKey> unterhalb der Timeline-Tracks.
+   ![Timeline add trigger window](/docs/images/Timeline-Add-Item.png)
+3. Wählen Sie, welche Art von Trigger Sie hinzufügen möchten:
+    - **New Playback** speichert aus dem aktuellen Programmer-Inhalt ein neues Playback und aktiviert dieses für 2 Sekunden.
+    - Mit **Existing Playback** kann man ein bereits existierendes Playback wählen, das für 2 Sekunden gestartet wird.
+    - Mit **Set Level** lässt sich ein bereits existierendes playback auf einen bestimmten Level setzen.
+    - Siehe  [Triggers](../timelines.md#triggers) für weitere Details.
+4. Existierende Playbacks werden mit ihrer jeweiligen **Auswahltaste** angewählt. Wenn man vorher Schritt 3 überspringt, 
+so wird automatisch **Existing Playback** angenommen und das Playback für 2 Sekunden auf 100% aktiviert.
+5. Geben Sie nun die Timecode-Zeit für den Trigger ein. Dafür gibt es mehrere Möglichkeiten:
+    - Geben Sie die Zeit mit <Keys.SoftKey>Reference at hh:mm:ss.fff </Keys.SoftKey> ein und drücken Sie <Keys.HardKey>Enter</Keys.HardKey>. Verwenden Sie dabei den Punkt <Keys.HardKey>.</Keys.HardKey> als Trenner. Tippt man z.B. "1 . 05", so ergibt dies 00:01:05:000, und "2 . 2 . 20" ergibt 02:02:20.00. Mit den Pfeiltasten kann man zwischen den einzelnen Feldern (Stunden/Minuten/Sekunden) navigieren.
+    - Mit <Keys.SoftKey>Reference at Live Time</Keys.SoftKey> kann die aktuelle (blau angezeigte) Timecode-Zeit eingegeben werden.
+    - Klicken Sie nun in der Timeline-Ansicht dorthin, wo Sie den Trigger haben möchten. Die genaue Zeit lässt sich auch später noch korrigieren.
+6. Wiederholen Sie den Vorgang ab Schritt 2 zum Hinzufügen weiterer Trigger.
+
+- Um direkt ein einzelnes Playback als Trigger hinzuzufügen, drücken Sie auf <Keys.HardKey>Copy</Keys.HardKey>, dann auf die **Auswahltaste** des Playbacks, und klicken in den gewünschten Timeline-Track.
+
+- Bestehende Playbacks werden dabei als Verknüpfung (Link) eingefügt. Will man dagegen ein playback getrennt editieren können, so klickt man nach dem Wählen des Playbacks auf <Keys.SoftKey>Create New Playbacks</Keys.SoftKey>.
+
+- Die [Tabellen-Ansicht](../timelines/running-and-editing-timelines.md#tabellen-ansicht) bietet eine alternative Möglichkeit zum Editieren und ist ggf. für das Eingeben einzelner Timecode-Marken besser geeignet.
+
+### Importieren von Markern
+
+Mit der Kontext-Funktion <Keys.ContextKey>Tools</Keys.ContextKey> - <Keys.ContextKey>Import Markers</Keys.ContextKey> lassen sich Marker aus eine Audio-Editor importieren. Das kann dabei helfen, Trigger genau zu positionieren.
+
+- Stellen Sie beim Export von Markern sicher, dass diese im Format Hours:Minutes:Seconds:Frames und nicht etwa in Beats oder Measures gespeichert werden.
+
+Hier ein Beispiel für den Import von Markern aus der Audio-Software **Reaper**:
+
+1. Stellen Sie in Reaper das Timeline-Format auf HH:MM:SS:FF.
+2. Laden Sie in Reaper die gewünschten Audiodateien und erstellen Sie die Marker.
+3. Öffnen Sie den Region/Marker Manager.
+4. Klicken Sie im Region/Marker Manager mit der rechten Maustaste, wählen Sie "Export Project Regions/Markers", und speichern Sie das als csv-Datei.
+5. Kopieren Sie diese Datei auf einen USB-Stick, und laden Sie diese in Titan per Kontext-Menü <Keys.ContextKey>Import Markers</Keys.ContextKey>. Soll die Datei auf dem gleichen PC importiert werden, so muss sie in Documents\\Titan liegen.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/timelines/running-and-editing-timelines.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/timelines/running-and-editing-timelines.md
@@ -1,0 +1,163 @@
+---
+id: running-and-editing-timelines
+title: Wiedergeben und Editieren von Timelines
+sidebar_label: Wiedergeben und Editieren von Timelines
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Eine Timeline per Timecode steuern
+
+HTP-Werte (der Dimmer) von Geräten werden durch den Faderwert der Timeline gesteuert. Die Timeline wird dabei automatisch auf 100% gestartet, sobald der entsprechende Timecode erreicht wird.
+
+Diese automatische Wiedergabe kann deaktiviert werden, ebenso kann zwar automatisch gestartet werden, aber ohne den Faderwert 100%. Dazu dient die Einstellung [Activate in Range](../timelines/timeline-options.md#tab-timeline) in den Optionen der Timeline. Wird die automatische Aktivierung ausgeschaltet, so muss die Timeline manuell durch Betätigen des Faders aktiviert werden, damit die Trigger funktionieren.
+
+
+1.  Stellen Sie den Button **timecode link** (links unten in der Timeline-Ansicht) auf **Linked** (geschlossene Kettenglieder).
+2.  Starten Sie den Timecode (Wurde die Option **Activate in Range** wie oben beschrieben deaktiviert, so muss der Fader der Timeline manuell aktiviert werden).
+3.  Die Trigger der Timeline starten automatisch zu den jeweils programmierten Timecode-Zeiten.
+
+- Motorfader und die virtuellen Fader bewegen sich automatisch auf die programmierten Werte.
+
+- Verwendet man den internen Timecode, so kann dieser automatisch starten, wenn der Fader aktiviert wird, sowie auch wieder stoppen, wenn dieser deaktiviert wird, siehe [Timeline-Optionen Tab "Fader"](../timelines/timeline-options.md#tab-fader).
+
+- Damit die Timeline (nur mit internem Timecode) ständig wiederholt wird, aktivieren Sie die Option Loop im [Tab "Timeline"](../timelines/timeline-options.md#tab-timeline).
+
+- Wird der Timecode mitten in der Timeline gestartet, so starten alle aktiven Trigger, aber da die vorangegangenen Trigger eventuell nicht oder nicht in der richtigen Reihenfolge gestartet wurden, ist das Ergebnis möglicherweise nicht wie gewünscht. Mit den [Release-Optionen der Timeline](../timelines/timeline-options.md#release-tab) lässt sich das verbessern.
+
+### Eine Timeline testen
+
+Um eine Timeline ohne Timecode-Quelle zu testen, stellen Sie den Button **timecode link** unten links im Timeline-Fenster auf **Unlinked** und verwenden die Buttons Play/Pause/Rewind. 
+
+## Editieren einer Timeline
+ 
+### Auswählen der Trigger
+
+Um einen Trigger zu editieren, muss man ihn zunächst auswählen. Dafür gibt es verschiedene Möglichkeiten:
+-   Klicken Sie auf einen Playback-Block, um alle darin enthaltenen Trigger auszuwählen. Dazu erscheinen 
+    verschiedene Selektoren. Klicken Sie nochmals auf den Playback-Block, um schrittweise durch die enthaltenen Trigger 
+    durchzuschalten.
+
+![Timeline trigger handles](/docs/images/Timeline-Handles.png)
+
+- Klicken Sie auf einen oder mehrere Trigger, um diese mit auszuwählen.
+
+- Zeichnen Sie eine Auswahlbox um die zu wählenden Trigger. Dabei werden nur die in dieser Box enthaltenen Trigger gewählt. Will man also alle Trigger eines Block auswählen, so muss die Auswahlbox um den gesamten Block gezogen werden. Damit kann man umgekehrt auch einzelne Trigger auswählen, ohne mehrfach auf den Block klicken zu müssen.
+
+- Um die Auswahl aufzuheben, klickt man in den freien Bereich im Timeline-Fenster, oder man verwendet <Keys.ContextKey>Clear Trigger Selection</Keys.ContextKey> aus dem Kontext-Menü.
+
+### Auswahl mit den Pfeiltasten
+
+Mit den Pfeil-Buttons (links/rechts) wird der vorige (Pfeil links) bzw. nachfolgende (Pfeil rechts) Trigger ausgewählt.
+
+Ist vorher kein Trigger ausgewählt gewesen, so springt der Pfeil nach rechts auf den ersten und der Pfeil nach links auf den letzten Trigger.
+
+### Editieren mit den Wheels
+
+Wurden ein oder mehrere Trigger angewählt, so kann man mit den Encodern die Zeit, den Zielwert und die Fadezeit einstellen (nicht alle Trigger haben alle diese Parameter).
+
+- Encoder A bestimmt die Timecode-Zeit
+- Encoder B bestimmt den Level (Zielwert)
+- Encoder C bestimmt die Fadezeit
+
+Sind mehrere Trigger ausgewählt, so werden sie alle mit den Encodern beeinflusst.
+
+### Die Übersichtsleiste
+
+Die **Übersichtsleiste** unten im Timeline-Fenster bietet einen Überblick über alle Elemente eine Tracks.
+
+![Timeline overview bar](/docs/images/Timeline-Overview-Bar.png)
+
+- Die Reiter links und rechts entsprechen Start und Ende der Detailansicht darüber. Damit kann man rasch in einen bestimmten Bereich der Timeline springen.
+
+- Wurde in die Timeline hineingezoomt, so kann man den Bereich in der Übersichtsleiste einfach anklicken und verschieben (so, als ob man mit der 'Hand' im Detailbereich navigieren würde).
+
+- Der Editiercursor wird grau dargestellt.
+
+- Die Position der aktuellen Zeit erscheint blau.
+
+### Kopieren/Verschieben von Playbacks in einer Timeline
+
+Playback-Blöcke können auf eine anderen Zeit oder einen anderen Track verschoben werden:
+1. Drücken Sie <Keys.HardKey>Move</Keys.HardKey>.
+2. Wählen Sie den/die gewünschten Playback-Block(s), entweder durch Anklicken, oder durch Zeichnen einer Auswahlbox.
+3. Klicken Sie im gewünschten Track auf die Zeit, an die der Block verschoben werden soll.<br/>
+    Werden dabei mehrere Playback-Blöcke ausgewählt, so werden diese mit den dazwischenliegenden 
+    Zeiten (relativ) verschoben.
+
+- Um einzelne Trigger innerhalb eines Tracks zu verschieben, wählen Sie diese aus und verschieben sie mit Encoder A.
+
+Ebenso können Playback-Blöcke kopiert werden, wobei jeweils eine Verknüpfung erstellt wird, es sei denn, 
+im Menü wird die Option <Keys.SoftKey>Create New Playbacks</Keys.SoftKey> aktiviert.
+1. Drücken Sie <Keys.HardKey>Copy</Keys.HardKey>.
+2. Wählen Sie den/die gewünschten Playback-Block(s), entweder durch Anklicken, oder durch Zeichnen einer Auswahlbox.
+3. Wählen Sie im Menü zwischen <Keys.SoftKey>Create New Playbacks</Keys.SoftKey> (Erstellen neuer Playbacks) 
+   und <Keys.SoftKey>Use Referenced Playbacks</Keys.SoftKey> (Erstellen von Verknüpfungen).
+4. Klicken Sie im gewünschten Track auf die Zeit, an die der Block (bzw. die Blöcke) verschoben werden soll(en).
+
+### Löschen von Playbacks in einer Timeline
+
+Um ein Playback in einer Timeline zu löschen, drücken Sie <Keys.HardKey>Delete</Keys.HardKey>, wählen 
+den Block durch Anklicken oder Ziehen einer Auswahlbox, und bestätigen das durch nochmaliges Anklicken 
+oder durch <Keys.SoftKey>Confirm</Keys.SoftKey>.
+
+Ebens können Playback-Zeilen oder ganze Tracks per <Keys.HardKey>Delete</Keys.HardKey> gelöscht werden.
+
+### Vergeben von Legenden und Halos für Tracks
+
+Für eine bessere Orientierung kann man Tracks mit farbigen Halos versehen. Damit wird sowohl der Track umrandet 
+als auch die Trigger-Blöcke farbig dargestellt.
+
+Wurde ein Playback mit einem farbigen Halo versehen, so wird dies auch in der Timeline-Ansicht verwendet 
+wie bei Track 2 im nachfolgenden Bild. Um das Halo des Playbacks zu ändern, klicken Sie in Schritt 2 auf das Playback.
+
+![Timeline halo](/docs/images/Timeline-Halo.png)
+
+1. Drücken Sie auf <Keys.SoftKey>Set Legend</Keys.SoftKey> im Hauptmenü.
+2. Klicken Sie im Timeline-Fenster auf den gewünschten Track oder die gewünschte Playback-Zeile.
+3. Geben Sie mit <Keys.SoftKey>Legend</Keys.SoftKey> die Bezeichnung des Tracks ein oder drücken Sie 
+   auf <Keys.SoftKey>Halo</Keys.SoftKey>.
+4. Wählen Sie die gewünschte Halo-Farbe aus.
+
+- Um das Halo zu entfernen, drücken Sie bei Schritt 4 auf <Keys.SoftKey>Remove Halo</Keys.SoftKey>.
+- Mit <Keys.SoftKey>Set Legend</Keys.SoftKey> können auch für Marker legenden vergeben werden.
+- Für einen **Wait for Go**-Trigger kann man die Farbe einstellen, indem man diesen bei Schritt 2 anklickt.
+
+### Snap -- Fangptionen
+
+Mit der Kontext-Option <Keys.ContextKey>Snap Options</Keys.ContextKey> lässt sich einstellen, ob neu hinzugefügte 
+Objekte beim Klicken in der Timeline-Ansicht von bereits existierenden Objekten 'gefangen' werden.
+Es gibt folgende Möglichkeiten:
+- Snap To Triggers
+- Snap To Markers
+- Snap To Cursor
+
+### Kompakte Track-Ansicht
+
+Hat man gleichzeitig viele Tracks in einem Fenster, so können diese auf kleinere Höhe gebracht werden, 
+so dass man mehrere gleichzeitig dargestellt bekommt. Klicken Sie dazu auf das Dreieck links neben den einzelnen Tracks.
+
+Es gibt mehrere Möglichkeiten: 
+- mit dem ersten Klick wird das Dreieck um 45° gedreht. Trigger, die sich nicht mit anderen überschneiden, 
+  werden auf einer Zeile dargestellt. Überschneidende Trigger werden auf getrennten Zeilen angezeigt. Das ist 
+  kompakter als die große Ansicht, aber trotzdem noch gut editierbar.
+- mit dem zweiten Klick werden alle - auch sich überschneidende - Trigger in einer Zeile dargestellt. Das 
+  Dreieck ist dazu um 90° gedreht und zeigt nach rechts.
+
+### Tabellen-Ansicht
+
+Die Timeline kann auch in einer Tabellenansicht angezeigt werden, klicken Sie dazu im Kontext-Menü 
+auf <Keys.ContextKey>Open Table View</Keys.ContextKey>. Damit werden alle Trigger mit ihren Details in einer 
+Tabelle angezeigt, so wie z.B. von Cuelisten gewohnt. Mit den Buttons auf der linken Seite lässt sich die Liste filtern.
+Timeline-Fester und die Timeline-Tabelle können gleichzeitig geöffnet sein.
+
+![Timeline table view](/docs/images/Timeline-Table-View.png)
+
+- bis auf den Trigger-Typ lassen sich alle Details editieren, indem man auf die jeweilige Tabellenzelle klickt 
+und die Änderungen über das Menü vornimmt.
+- Mit dem Button <Keys.ContextKey>+</Keys.ContextKey> können neue Trigger hinzugefügt werden.
+- Um in der Tabellenansicht Trigger zu löschen, drücken Sie auf <Keys.HardKey>Delete</Keys.HardKey> 
+und die zu löschende Tabellenzeile. Klicken Sie zur Bestätigung nochmals auf die Zeile oder drücken 
+Sie auf <Keys.SoftKey>Confirm</Keys.SoftKey>.
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/timelines/timeline-options.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/timelines/timeline-options.md
@@ -1,0 +1,101 @@
+---
+id: timeline-options
+title: Timeline-Optionen
+sidebar_label: Timeline-Optionen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Timelines haben verschiedene Optionen, mit denen das Verhalten genau eingestellt werden kann.
+Drücken Sie <Keys.HardKey>Options</Keys.HardKey> (oder die Menütaste <Keys.SoftKey>Options</Keys.SoftKey> im 
+Hauptmenü), dann die **Auswahltaste** der jeweiligen Timeline.
+Die Vorgabewert sind hier **fett** dargestellt.
+
+## Tab "Handle"
+
+Die gleichen Optionen wie bei Cues, siehe [Options](../cues/playback-options.md#handle-tab).
+
+## Tab "Times"
+
+![Timeline Options: Times](/docs/images/Timeline-Options-Times.png)
+
+Hier wird die Startzeit und die Dauer der Timeline eingestellt. Daraus ergeben sich die Punkte, 
+an denen mit 'Loop' die Timeline wiederholt wird, siehe [Loop (Tab "Timeline")](../timelines/timeline-options.md#tab-timeline), oder wann die Timeline bei externem Timecode automatisch startet.
+Hiermit kann auch die Timeline begrenzt werden, so dass nichts passiert, wenn der Timecode mal völlig aus dem Ruder läuft.
+
+## Tab "Fader"
+
+![Timeline Options: Fader](/docs/images/Timeline-Options-Fader.png)
+
+Hier wird bestimmt, was mit em internen Timecode passiert, wenn der Fader der Timeline aktiviert bzw. auf 0 gebracht wird. Wird ein externer Timecode verwendet, so bleiben diese Einstellungen ohne Auswirkung.
+
+Option | Wirkung
+-------|--------
+Fader Raised Action | **No Action**: Der interne Timecode bleibt unverändert, sobald der Fader aktiviert wird.<br/>Play: Der interne Timecode wird gestartet, sobald der Fader aktiviert wird.
+Fader Zero Action   | **No Action**: Der interne Timecode bleibt unverändert, wenn der Fader auf 0 gesetzt wird.<br/>Stop: Der interne Timecode wird gestoppt, wenn der Fader auf 0 gesetzt wird. <br/>Pause: Der interne Timecode wird angehalten (Pause), wenn der Fader auf 0 gesetzt wird.
+Kill At Zero | **Off:** Die Timeline bleibt aktiv, wenn der Fader auf 0 gesetzt wird. <br/>On: Die Timeline wird deaktiviert, wenn der Fader auf 0 gesetzt wird.
+
+> Mit diesen Optionen lässt sich ein aufwendiger Effekt als Ablauf programmieren. Programmieren Sie diesen als Timeline mit den Einstellungen **Play** und **Stop**. So kann der Ablauf einfach per Fader abgerufen werden. Beachten Sie, dass dazu der Timecode entkoppelt sein muss, damit der Effekt wirklich nur 1x läuft.
+
+## Tab "Release"
+
+![Timeline Options: Release](/docs/images/Timeline-Options-Release.png)
+
+Dies bestimmt das Verhalten der LTP-Attribute, wenn die Timeline deaktiviert wird. Damit wird das Ergebnis 
+vorhersehbarer, vor allem, wenn man in der Timeline hin- und herspringt. Das könnte ansonsten zu unerwarteten 
+Ergebnissen führen, wenn LTP-Werte aus vorigen Playbacks verbleiben
+
+Option | Wirkung
+-------|--------
+Override Playback Release | **Off**: Es gelten die Release-Einstellungen der einzelnen Playbacks.<br/>On: Die Release-Einstellungen der Timeline überschreiben die Release-Einstellungen der Playbacks.
+Release Playbacks to Home | Off: LTP-Werte der Playbacks bleiben erhalten, wenn die Playbacks deaktiviert werden.<br/>**On**: LTP-Werte gehen auf ihren Home-Wert zurück, wenn nicht vorher andere Werte gesetzt wurden.
+Timeline-Global Release Mask | Globale Release-Maske für Playbacks, die durch diese Timeline getriggert werden. Voreinstellung: **keine Attribute werden released**. Damit wird die sonstige Globale Release-Maske für Playbacks, die in dieser Timeline enthalten sind, überschrieben. Im Infobereich wird eine entsprechende Warnung angezeigt.
+Timeline-Global Release Time | Globale Release-Zeit für Playbacks, die durch diese Timeline getriggert werden. Voreinstellung: **2 Sekunden**. Damit wird die sonstige Globale Release-Zeit für Playbacks, die in dieser Timeline enthalten sind, überschrieben.
+
+## Tab "Timeline"
+
+![Timeline Options: Timeline](/docs/images/Timeline-Options-Timeline.png)
+
+Option | Wirkung
+-------|--------
+Activate In Range | **Activate at 100%**: Die Timeline wird automatisch mit 100% gestartet, sobald der anliegende Timecode im Bereich der Timeline liegt (also zwischen angegebenem Start und Ende).<br/>Activate at 0%: Die Timeline wird bei passendem Timecode automatisch gestartet, aber mit 0% Faderwert.<br/>Off: Die Timeline wird nicht automatisch gestartet, sondern muss manuell aktiviert werden.
+Kill Out Of Range | Off: Die Timeline bleibt aktiviert, wenn der Timecode außerhalb des gültigen Bereichs ist (Start/Ende).<br/>**On:** Die Timeline wird deaktiviert, sobald der Timecode außerhalb des gültigen Bereichs ist.
+Loop | **Off**: Der interne Timecode wird nicht auf den Startwert zurückgesetzt, sobald das festgelegte Ende der Timeline erreicht ist.<br/>On: Der interne Timecode wird auf den Startwert zurückgesetzt, sobald das festgelegte Ende der Timeline erreicht ist.
+
+- Die Option Loop funktioniert nur mit dem internen Timecode.
+
+## Tab "Timecode"
+
+![Timeline Options: Timecode](/docs/images/Timeline-Options-Timecode.png)
+
+Option | Wirkung
+-------|--------
+Timecode Source | Bestimmt die Timecode-Quelle der Timeline (Timecode 1-4). Siehe [Steuern einer Cueliste per Timecode](../cue-lists/cue-list-timing.md#steuern-einer-cueliste-per-timecode).
+Timecode Source Unlinked | Gleiche Funktion wie der Link-Button in der Timeline-Ansicht, siehe  [Timecode verbinden und steuern](../timelines.md#timecode-verbinden-und-steuern)
+
+## Time -- Optionen für Zeiten
+
+Einige Optionen können auch im Menü **Edit Times** eingestellt werden. Drücken Sie dazu die 
+Taste <Keys.HardKey>Time</Keys.HardKey> (oder die Menütaste <Keys.SoftKey>Edit Times</Keys.SoftKey> 
+im Hauptmenü), gefolgt von der **Auswahltaste** der Timeline.
+
+### Offset einstellen
+
+Wenn der verwendete Timecode einen großen Offset hat, also von den ursprünglich programmierten Zeiten abweicht, so kann 
+man hier einen Offset eingeben, mit dem die ganze Timeline korrigiert wird, ohne dass man manuell alle Timecode-Marken
+ändern muss. Hier lassen sich auch kleine Änderungen von nur wenigen Frames vornehmen, um besser zu synchronisieren.
+
+1. Im Menü **Edit Times** drücken Sie die Taste <Keys.SoftKey>Set Offset</Keys.SoftKey>.
+2. Geben Sie bei <Keys.SoftKey>Nudge Amount</Keys.SoftKey> den gewünschten Betrag ein, um den die  Timeline versetzt werden soll.
+3. Betätigen Sie <Keys.SoftKey>Add</Keys.SoftKey> oder <Keys.SoftKey>Subtract</Keys.SoftKey> um den Offset (Zeitversatz) der Timeline wie gewünscht einzustellen.
+4. Der aktuelle Offset wird im Infobereich angezeigt.
+
+Wurde ein Offset eingegeben, so wird dies in der Timeline-Ansicht unter dem eigentlichen Timecode angezeigt. Im nachfolgenden Bild ist die Anzeige für ein Offset von 45 Sekunden zu sehen.
+
+![Timeline timecode offset](/docs/images/Timeline-Offset.png)
+
+
+### Start Time & Duration (Startzeit und Dauer)
+
+Hier kann man ebenso wie im [Tab "Times"](../timelines/timeline-options.md#tab-times) Startzeit und Dauer der Timeline eingeben.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics.md
@@ -1,0 +1,274 @@
+---
+id: titan-basics
+title: Anschließen des Pultes, erste Schritte
+sidebar_label: Anschließen des Pultes, erste Schritte
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+In diesem Abschnitt wird das Anschließen des Pultes sowie die
+grundlegende Bedienung erläutert.
+
+> Funkgeräte können die Funktion des Pultes stören. Es wird empfohlen, solche Geräte nicht unmittelbar auf, neben oder beim Pult zu verwenden oder abzulegen. Vielmehr sollten sie etwa in einer Tasche oder am Gürtel getragen werden.
+
+
+## Netzanschluss
+
+Die Pulte funktionieren mit Netzspannung im Bereich von 80 bis 260 V.
+
+Möglicherweise ist Ihr Pult mit einer internen USV (unterbrechungsfreien
+Stromversorgung) ausgestattet. Wenn nicht, empfiehlt sich die Verwendung
+einer externen USV, die im Computerfachhandel bezogen werden kann. Bei
+plötzlichem Verlust der Netzspannung kommt es normalerweise zu
+Datenverlust (bis zum letzten Speicherpunkt), und beim Wiedereinschalten
+des Pultes werden die Festplatten überprüft, was zu Verzögerungen führt.
+Eine USV hingegen bietet Schutz gegen die meisten mit dem Strom
+verbundenen Probleme, und gibt einem die Zeit, um das Pult geordnet
+herunterzufahren.
+
+Ist Ihr Pult mit einer internen USV ausgestattet (Diamond 9, Diamond 7, Sapphire 
+Touch, Arena, Tiger Touch II, sowie optional andere Modelle), so wird bei
+Unterbrechung der Stromversorgung dies im Bildschirm angezeigt sowie die
+Zeit, die zum Herunterfahren des Pultes noch verbleibt. Außerdem wird
+eine Warnung angezeigt, sowie der aktuelle Stand der Show gespeichert.
+Dazu wird die Toolbar orange und es wird angezeigt (nicht auf dem D9 und D7), 
+wie lange das Pult noch bis zum automatischen Herunterfahren läuft.
+
+![UPS Toolbar](/docs/images/UPS-Toolbar.png)
+
+-   Unmittelbar vor dem Herunterfahren des Pultes wird diese Anzeige
+    schließlich rot.
+-   Wenn ein Pult oder TNP in der Session auf USV läuft, wird das in den
+	Logs vermerkt.
+
+&nbsp;**Nur beim Diamond 9, Diamond 7 und Arena:** Der Netzwerk-Switch im Pult verfügt über eine
+eigene USV, so dass das Pult auch kurz abgeschaltet werden kann, ohne den
+Betrieb des Switches zu beeinträchtigen. Nach kompletter Trennung vom
+Netz oder Ausschalten des Pultes läuft der Switch noch für etwa 5 Minuten weiter. Dies ist wichtig,
+wenn dieser Switch auch andere Geräte mit Signal versorgt, das Pult 
+selbst jedoch abgeschaltet oder neu gestartet werden muss. 
+
+## Einschalten und Ausschalten
+
+Die Pulte arbeiten mit Windows als Betriebssystem, daher sollte man dies
+jeweils ordnungsgemäß herunterfahren, anstatt einfach nur die
+Netzspannung abzuschalten.
+
+Das **Starten** erfolgt durch kurzes Betätigen (und wieder Loslassen)
+des Hauptschalters rechts neben dem Touchscreen. Das Display sowie der
+optionale externe Bildschirm zeigen den Startprozess. Das Arena benötigt
+etwa 1:30 min für das Starten.
+
+Das **Ausschalten** des Pultes erfolgt ebenso durch kurzes Betätigen
+(und wieder Loslassen) des Hauptschalters. Daraufhin erfolgt ein
+ordnungsgemäßes Herunterfahren. Bitte mit dem Trennen vom Netz warten,
+bis die Anzeige 'Power' erloschen ist (etwa 30 sec.)
+
+> Benutzen Sie nicht den Netzschalter auf der Rückseite des Pultes. Beim Betätigen dieses Schalters würde das Pult nicht geordnet heruntergefahren werden, und sämtliche Änderungen der Show gingen verloren.
+
+## Herunterfahren erzwingen
+
+Zum **erzwungenen Ausschalten** - wenn das normale Ausschalten nicht
+funktioniert - ist der Hauptschalter für 5 Sekunden gedrückt zu halten.
+Dabei gehen sämtliche Änderungen seit dem letzten Speichern verloren.
+
+&nbsp;**Pulte mit USV:** Aufgrund der integrierten USV kann man zum harten
+Resetten nicht einfach den Netzstecker ziehen. Drücken Sie dazu bei
+abgezogenem Netzstecker den Schalter "Battery Disconnect", um auch die
+USV zu unterbrechen (beim Arena: Rückseite; beim Tiger Touch 2/Sapphire
+Touch: unter der linken Seitenwange).
+
+&nbsp;**Achtung beim Diamond 9, Diamond 7 und beim Arena**: dabei wird auch der integrierte Switch
+abgeschaltet. Das ist besonders wichtig, wenn über diesen Switch ein
+Backup-Pult angeschlossen ist! Wird das Pult normal heruntergefahren,
+so bleibt der Switch aufgrund seiner USV noch etwa 5 Minuten
+eingeschaltet.
+
+## Inbetriebnahme von T3/Titan Mobile und T1/T2
+
+Verbinden Sie das T3/Titan Mobile bzw. den T1/T2 erst mit Ihrem Computer,
+wenn Sie die **Titan PC-Suite** installiert haben. Zur Installation führen Sie
+einfach das Installationsprogramm aus; damit werden auch alle
+erforderlichen Treiber installiert.
+
+> Ab Titan v14 wird Windows 10 64 Bit vorausgesetzt. Ältere Versionen 
+sowie virtuelle Maschinen werden nicht unterstützt. Empfohlen wird 
+mindestens ein i5 der 5. Generation mit 4 GB RAM. Auf [https://avolites.com/titan-pc-system-requirements](https://avolites.com/titan-pc-system-requirements/) gibt es weitere Angaben zu den Systemvoraussetzungen.
+
+Es empfiehlt sich die Verwendung eines Touchscreens. Ist ein solcher
+nicht vorhanden, klicken Sie mit der Maus auf die entsprechenden
+Buttons.
+
+Für den Betrieb von Titan Mobile, Titan One und dem Titan Simulator gibt
+es ein einheitliches Software-Paket: die **Avolites Titan PC-Suite**.
+Diese enthält alle genannten Programme.
+
+### T3/Titan Mobile
+
+Sobald die Titan PC-Suite installiert ist, können Sie das
+T3 bzw. Titan Mobile per USB-Kabel mit Ihrem PC verbinden (sollte das Pult über
+zwei USB-Buchsen verfügen, so ist nur die obere zu verwenden). Der PC
+erkennt daraufhin neue Hardware; bei den entsprechenden Rückfragen
+wählen Sie ‚Software automatisch installieren'. Bei älteren Titan
+Mobiles, die keinen AvoKey enthalten, ist ein separater AvoKey
+erforderlich und muss parallel zum Titan Mobile an einer weiteren
+USB-Buchse angeschlossen sein.
+
+Beim T3, sowie bei neueren Titan Mobiles, ist ein AvoKey bereits eingebaut und auch bereits lizenziert. Damit können diese ohne weitere Lizenzierung an jedem Computer mit der Titan PC-Suite betrieben werden, wobei die Software unbedingt einen AvoKey - oder eben ein T3 oder Titan Mobile - benötigt, um zu starten. Siehe [Software-Lizenzierung](./system-settings/recovering-reinstalling-the-console.md#software-lizenzierung) für weitere Details.
+
+- Titan Go erkennt automatisch, ob ein T3 oder ein Titan Mobile verbunden ist, und blendet die kompakte Anzeige der Bedienelemente, wie sie für den T1 und T2 vorgesehen ist, aus. Möchte man diese trotzdem verwenden, so lässt sich das per Benutzereinstellung [Virtual Hardware](system-settings/user-settings.md#display) auf der Seite **Display** umstellen.
+
+**Stromversorgung beim Titan Mobile**: Die Stromversorgung erfolgt über den USB-Anschluss. Optional kann ein
+separates Netzteil (9 V Gleichspannung) angeschlossen werden. Für dieses
+gelten folgende Spezifikationen: 9-12V Gleichspannung, 800mA;
+Steckverbinder, außen 5,5mm, innen 2,5mm, 9,5mm lang; Pluspol auf dem
+inneren Kontakt
+
+Bei der ersten Verwendung ist das Titan Mobile und der zugehörige AvoKey
+ggf. noch bei Avolites zu [lizenzieren](./system-settings/recovering-reinstalling-the-console.md#software-lizenzierung) (kostenlos), um die Software
+verwenden zu können. Die Lizenz wird auf dem (internen oder externen)
+AvoKey fest gespeichert und bezieht sich auf das jeweilige Titan Mobile.
+Dieses kann also - mit dem entsprechenden AvoKey - ohne weitere
+Lizenzierung auch an anderen Computern betrieben werden.
+
+### T1/T2
+
+Der T1 und T2 bieten volle Titan-Funktionalität, sind aber auf ein 
+bzw. zwei Universen beschränkt (der T1 kann zudem nicht per MIDI und 
+WebAPI gesteuert werden). Zum Betrieb ist die Software Titan Go zu 
+starten. Auch der T1/T2 ist bereits ab Werk lizenziert und kann 
+mit jedem Computer betrieben werden. 
+
+- Soll der **Titan One** (ältere Version mit Kabel) mit Titan ab Version 12 verwendet werden, so muss 
+ein AvoKey parallel dazu per USB angeschlossen sein.
+
+### Windows-Einstellungen für die Titan PC-Suite
+
+Oft haben Windows-PCs ab Werk ein paar Voreinstellungen, die z.B. die USB-Hardware trennen, den Computer in den Ruhezustand versetzen, oder andere Dinge tun, die man während der Show nicht gebrauchen kann. Um unerwünschte Unterbrechungen während der Show zu vermeiden, empfehlen sich bei der Verwendung eines T1/T2/T3 oder Titan Mobile auf einem normalen PC folgende **Windows Systemeinstellungen**:
+
+1. USB Power Saving für das T1/T2/T3/Titan Mobile deaktivieren (im Gerätemanager, Eigenschaften des Geräts)
+
+2. Bildschirm/PC/Festplatte nie deaktivieren (normalerweise einen entsprechenden Energiesparplan wählen oder erstellen)
+
+3. automatische Windows-Updates deaktivieren
+
+4. Indizierung der Festplatte deaktivieren
+
+5. die Firewall deaktivieren
+
+## Titan Healthcheck -- die Eigendiagnose
+
+Bei Start der Titan-Software wird ein Selbsttest ausgeführt, der Titan
+Healthcheck. Dieser überprüft das Dateisystem, die Firmware
+verschiedener Baugruppen sowie weitere potentielle Fehlerquellen.
+Sollten irgendwelche Probleme festgestellt werden, so wird eine
+Fehlermeldung ausgegeben mit Hinweisen zur Fehlerbehebung.
+
+![Healthcheck](/docs/images/Healthcheck.png)
+
+Die Fehlerbehebung sollte nur ausgeführt werden, wenn ausreichend Zeit
+zur Verfügung steht, da manche Module bis zu einer Stunde benötigen
+können.
+
+## DMX anschließen
+
+DMX kann sowohl über die XLR-Buchsen (5-polig) als auch über verschiedene
+Netzwerkprotokolle (Art-Net, sACN) ausgegeben werden, um andere
+DMX-Ethernet-Nodes, Medienserver und anderes zu steuern,
+
+Beim Patchen eines Dimmers oder Gerätes muss dem Pult mitgeteilt werden,
+auf welchem der verfügbaren DMX-Universen sich das Gerät befindet. Jedes
+einzelne der Universen kann einem oder mehreren der DMX-Anschlüsse auf
+der Rückseite des Pultes zugeordnet, oder aber per [Ethernet (Art-Net, sACN)](networking/controlling-fixtures-over-a-network.md) gesendet werden.
+
+Das D9, D7 und das Arena enthält zusätzlich einen 
+internen [Netzwerkswitch](networking/connecting-the-arena-to-a-network.md) mit optischen
+Ausgängen (Glasfaser/OpticalCon).
+
+> Beim Starten einer neuen Show werden die DMX-Linien ab 1 aufsteigend den 5-poligen XLR-Buchsen auf der Rückseite des Pultes zugewiesen; wird dagegen eine bestehende Show von einem anderen System geladen, so wird die dort vorgenommene Zuordnung der Linien übernommen, und sollte ggf. überprüft werden.
+
+Die 5-poligen Buchsen sind wie folgt belegt:
+
+  |   Pin #   | Belegung     |
+  |     ---   | ---          |
+  |   Pin 1   |   Erde       |
+  |   Pin 2   |   Daten -    |
+  |   Pin 3   |   Daten +    |
+  |   Pin 4   |   unbelegt   |
+  |   Pin 5   |   unbelegt   |
+
+
+Jede DMX-Linie ist durch alle Geräte, die mit dieser Linie gesteuert
+werden sollen, durchzuschleifen und sollte durch einen
+Abschlusswiderstand (120 Ohm zwischen Pin 2 und 3) abgeschlossen werden.
+Die Verwendung von passiven Splittern (Y-Splittern) kann zu Datenverlust
+führen und sollte vermieden werden.
+
+## Einen Monitor anschließen
+
+Es lässt sich ein (D9, D7 und Sapphire Touch: zwei) externer Monitor anschließen (beim Tiger Touch II und
+Pearl Expert: VGA; beim Quartz, Arena, Sapphire Touch: DVI). Damit erhält
+man mehr Oberfläche zur Anzeige weiterer Fenster (etwa für den
+Visualiser oder das Channel-Grid) sowie - im Falle eines Touchscreens - 
+weiterer Steuerelemente. Bei Touchscreens empfehlen sich Modelle, die
+zu Windows Touch kompatibel sind, um Probleme durch separate Treiber zu
+vermeiden. Bei der Titan PC-Suite (Titan Go/Titan Simulator) ist ein zweiter und dritter Bildschirm
+davon abhängig, dass der verwendete Computer dies unterstützt.
+
+Der externe Bildschirm ist standardmäßig deaktiviert, und zeigt das mit
+'Disabled' an. Um ihn zu aktivieren, öffnen Sie das System-Menü
+(<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>), 
+wählen <Keys.SoftKey>Display Setup</Keys.SoftKey>, und drücken <Keys.SoftKey>External Display Disconnected</Keys.SoftKey>. Damit ändert sich die Anzeige auf <Keys.SoftKey>External Display Connected</Keys.SoftKey>, und der Bildschirm wird aktiviert.
+
+Zum Ändern der Bildschirmauflösung oder anderer Monitoreinstellungen
+bei den Pulten (nicht bei der PC-Suite) klicken Sie oben auf 'Tools', 
+dann auf 'Control Panel' (Systemsteuerung), dann auf 'External Monitor', 
+und wählen die passende Auflösung. Bei der Titan PC-Suite erfolgt dies 
+über die Windows-Systemsteuerung).
+
+Weitere Details dazu sowie eine Anleitung zur Suche möglicher Fehler
+[finden Sie hier](system-settings/external-displays.md).
+
+## Weitere Anschlussmöglichkeiten
+
+Es lassen sich eine USB-Tastatur sowie eine Maus anschließen.
+Insbesondere bei der Verwendung eines externen Displays ohne
+Touch-Funktion ist eine Maus dringend zu empfehlen, um die Fenster und
+Funktionen darauf nutzen zu können (beim Sapphire Touch lässt sich der
+Trackball als Maus verwenden).
+
+Stehen nicht genügend USB-Anschlüsse zur Verfügung, so lassen sich diese
+durch einen normalen USB-Hub erweitern.
+
+Mittels MIDI (alle Pulte außer Titan One/T1) lassen sich Playbacks triggern
+sowie per MIDI-Timecode Cuelisten steuern. Auch USB-MIDI-Geräte können
+an das Pult angeschlossen werden. Der T1 kann nicht über MIDI gesteuert werden, 
+der T2 ausschließlich über USB-MIDI.
+
+Neuere Pult-Modelle verfügen auch über einen Eingang für SMPTE-LTC-Timecode.
+
+Mittels der Netzwerkbuchse(n) (EtherCON oder RJ-45) lässt sich das Pult in ein
+Netzwerk (LAN) integrieren, womit sich viele weitere interessante
+Möglichkeiten ergeben, etwa die Ausgabe weitere Universen über
+Art-Net/sACN, das Betreiben mehrerer Pulte im Verbund (Backup,
+Multiuser) oder die Steuerung des Pultes per App.
+
+Eine oder zwei 3-polige XLR-Buchse ist als Anschluss für eine
+Pultleuchte vorgesehen. Die Belegung ist 1-Minus, 2-Plus (12V
+Gleichspannung). Ggf. muss die Belegung der verwendeten Pultleuchte
+angepasst werden, da es dafür verschiedene Systeme gibt. 
+
+- Bei neueren Pulten lässt sich die Helligkeit der Pultleuchte im 
+System-Menü (<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>) mit den Encodern einstellen.
+
+## Verwenden von Faderwings
+
+"[Wings](./about-the-consoles/fader-wings.md)" bieten zusätzliche 
+Bedienelemente wie Fader und Tasten, und sind je nach Einsatzzweck eine 
+sinnvolle Ergänzung. Verbunden werden sie mit dem Pult bzw. Computer über USB.
+
+Das Pearl Expert Touch Wing funktioniert ausschließlich mit dem [Pearl Expert](about-the-consoles/pearl-expert-and-touch-wing.md). 
+Es ist mit dem Pult zu verbinden, bevor dieses gestartet wird.
+
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics.md
@@ -63,7 +63,7 @@ etwa 1:30 min für das Starten.
 Das **Ausschalten** des Pultes erfolgt ebenso durch kurzes Betätigen
 (und wieder Loslassen) des Hauptschalters. Daraufhin erfolgt ein
 ordnungsgemäßes Herunterfahren. Bitte mit dem Trennen vom Netz warten,
-bis die Anzeige 'Power' erloschen ist (etwa 30 sec.)
+bis die Anzeige 'Power' erloschen ist (etwa 30 sec.). Das Herunterfahren lässt sich auch mit dem Befehl **Turn Off Console** aus dem Tools-Menü erreichen.
 
 > Benutzen Sie nicht den Netzschalter auf der Rückseite des Pultes. Beim Betätigen dieses Schalters würde das Pult nicht geordnet heruntergefahren werden, und sämtliche Änderungen der Show gingen verloren.
 
@@ -178,9 +178,14 @@ Netzwerkprotokolle (Art-Net, sACN) ausgegeben werden, um andere
 DMX-Ethernet-Nodes, Medienserver und anderes zu steuern,
 
 Beim Patchen eines Dimmers oder Gerätes muss dem Pult mitgeteilt werden,
-auf welchem der verfügbaren DMX-Universen sich das Gerät befindet. Jedes
-einzelne der Universen kann einem oder mehreren der DMX-Anschlüsse auf
-der Rückseite des Pultes zugeordnet, oder aber per [Ethernet (Art-Net, sACN)](networking/controlling-fixtures-over-a-network.md) gesendet werden.
+auf welchem der verfügbaren DMX-Universen sich das Gerät befindet. 
+Als Vorgabe werden normalerweise alle vorhandenen DMX-Buchsen jeweils einer Linie zugewiesen,
+und die Linien werden auch per sACN ausgegeben.
+
+Die Ausgabe kann auch per Art-Net erfolgen, und die Zuordnung zu den DMX-Buchsen und zu sACN kann 
+verändert werden, siehe [DMX-Einstellungen](system-settings/dmx-output-mapping.md).
+
+Je nach Pult gibt es ein Limit bei der Anzahl möglicher Linien, siehe [DMX-Einstellungen](system-settings/dmx-output-mapping.md).
 
 Das D9, D7 und das Arena enthält zusätzlich einen 
 internen [Netzwerkswitch](networking/connecting-the-arena-to-a-network.md) mit optischen
@@ -248,6 +253,8 @@ der T2 ausschließlich über USB-MIDI.
 
 Neuere Pult-Modelle verfügen auch über einen Eingang für SMPTE-LTC-Timecode.
 
+- Weitere Informationen zum Einrichten externer Trigger siehe [Externe Trigger](/running-the-show.md/midi-dmx-or-audio-triggering).
+
 Mittels der Netzwerkbuchse(n) (EtherCON oder RJ-45) lässt sich das Pult in ein
 Netzwerk (LAN) integrieren, womit sich viele weitere interessante
 Möglichkeiten ergeben, etwa die Ausgabe weitere Universen über
@@ -261,14 +268,4 @@ angepasst werden, da es dafür verschiedene Systeme gibt.
 
 - Bei neueren Pulten lässt sich die Helligkeit der Pultleuchte im 
 System-Menü (<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey>) mit den Encodern einstellen.
-
-## Verwenden von Faderwings
-
-"[Wings](./about-the-consoles/fader-wings.md)" bieten zusätzliche 
-Bedienelemente wie Fader und Tasten, und sind je nach Einsatzzweck eine 
-sinnvolle Ergänzung. Verbunden werden sie mit dem Pult bzw. Computer über USB.
-
-Das Pearl Expert Touch Wing funktioniert ausschließlich mit dem [Pearl Expert](about-the-consoles/pearl-expert-and-touch-wing.md). 
-Es ist mit dem Pult zu verbinden, bevor dieses gestartet wird.
-
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/clearing-the-console.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/clearing-the-console.md
@@ -1,0 +1,27 @@
+---
+id: clearing-the-console
+title: Inhalt des Pultes löschen
+sidebar_label: Inhalt des Pultes löschen
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Bevor man beginnt, eine neue Show zu programmieren, empfiehlt es sich,
+den Inhalt des Pultes zu löschen. Dabei wird sowohl das Patching als
+auch die Programmierung gelöscht, und die Benutzereinstellungen werden
+zurückgesetzt.
+
+1.  Drücken Sie die Taste <Keys.HardKey>Disk</Keys.HardKey>.
+2.  Drücken Sie <Keys.SoftKey>New Show</Keys.SoftKey>.
+3.  Drücken Sie <Keys.SoftKey>OK</Keys.SoftKey> zur Bestätigung.
+4.  Drücken Sie <Keys.HardKey>Exit</Keys.HardKey>, um den Disk-Modus zu beenden.
+
+-   Beim Starten einer neuen Show lässt sich wählen, ob die bereits im
+    Pult vorhandenen DMX-Einstellungen übernommen oder die aus der Show
+    verwendet werden sollen; damit wird die Zuordnung der internen
+    Linien auf die DMX-Anschlüsse und Art-Net-Geräte bestimmt.
+
+-   Im System-Menü gibt es außerdem die Option <Keys.SoftKey>Wipe</Keys.SoftKey>, die die gleiche
+    Funktion hat; Avolites-Oldies werden dies von der Classic-Software
+    so gewohnt sein .

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/creating-reports.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/creating-reports.md
@@ -1,0 +1,41 @@
+---
+id: creating-reports
+title: Erstellen von Reports
+sidebar_label: Erstellen von Reports
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Beim Vorbereiten einer Show ist es oft sinnvoll, Patchlisten oder andere
+Details der Programmierung zu exportieren, etwa um der Crew eine
+Patchliste ausdrucken zu können, oder ganz einfach zur Dokumentation.
+
+![Exported Report](/docs/images/Exported-Report.png)
+
+Reports können als HTML, PDF, CSV oder XML erstellt werden und die
+folgenden Informationen enthalten.
+
+-   Geräte
+-   Speicherplätze (Cues)
+-   Chaser
+-   Cuelisten
+-   Paletten
+-   Gruppen
+
+Erstellen eines Reports:
+
+1.  Drücken Sie die Taste <Keys.HardKey>Disk</Keys.HardKey>.
+2.  Wählen Sie <Keys.SoftKey>Reports</Keys.SoftKey>.
+3.  Wählen Sie das/die zu exportierende(n) Detail(s).
+4.  Wählen Sie das Ausgabeformat.
+5.  Wählen Sie das Laufwerk, auf dem der Report gespeichert werden soll.
+
+Reports werden in folgenden Verzeichnissen gespeichert:
+
+- bei der Titan PC Suite (Titan Go, Titan
+Simulator) im Verzeichnis `Eigene Dokumente\Titan\Reports`
+- bei allen Pulten im Verzeichnis `D:\Data\Reports`
+
+Ist der Report fertig exportiert, so wird das jeweilige Verzeichnis
+automatisch geöffnet, um den Report schneller finden zu können.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/front-panel-buttons.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/front-panel-buttons.md
@@ -1,0 +1,144 @@
+---
+id: front-panel-buttons
+title: Die Tasten der Konsole
+sidebar_label: Die Tasten der Konsole
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Die den Fadern zugeordneten blauen und grauen (Auswahl und Flash) Tasten sowie die
+Macro/Executor-Tasten sind weitgehend frei zu konfigurieren.
+
+## Auswahl- und Flashtaste
+
+Zu jedem  Fader auf dem Pult gibt es verschiedene Tasten. Diese werden hier **Select/Auswahltaste** und **Flash**-Taste genant, auch wenn die jeweilige Funktion per Key Profile geändert werden kann (s.u.).
+
+
+&nbsp;<Keys.Annotation>A</Keys.Annotation> **Select/Auswahltaste**
+
+&nbsp;<Keys.Annotation>B</Keys.Annotation> **Flashtaste**
+
+
+Auf dem **Diamond 9** , dem **Diamond 7** und dem **T3** sind die Tasten für die Drehregler (nur bei D9/D7) und Fader wie folgt angeordnet::
+
+![Diamond Select and Flash](/docs/images/Diamond-Select-Flash.png)
+
+Auf dem **Sapphire Touch** sind die Tasten für die oberen sowie die unteren Fader wie auf den nachfolgenden Bildern angeordnet. Dabei hat das Sapphire Touch jeweils auch noch eine schwarze Taste, die per Key Profile belegt werden kann (s.u.).
+
+![Sapphire Select and Flash](/docs/images/Sapphire-Select-Flash.png)
+
+Bei **allen anderen Pulten** sind die Tasten folgendermaßen angeordnet:
+
+![Arena Select and Flash](/docs/images/Arena-Select-Flash.png)
+
+
+## Key Profiles -- Tastenprofile
+
+Es ist möglich, die Funktionsweise der Flash- und der
+Auswahltasten (sowie der schwarzen Tasten beim Sapphire Touch) zu
+ändern. Ebenso lässt sich die Funktion einiger Schaltflächen ändern.
+Diese Einstellungen lassen sich als [Key Profile (Tastenprofil)](../system-settings/key-profiles.md) 
+abspeichern. Einzelne Tastenprofile lassen sich einzelnen Benutzern zuordnen oder für die 
+vereinfachte Bedienung des Pultes bei bestimmten Anwendungsfällen verwenden.
+
+## Macros -- Tastenfolgen
+
+Während des Programmierens sind zuweilen bestimmte Abfolgen von
+Tastendrücken sehr oft auszuführen. Zur Vereinfachung lassen sich solche
+Tastenfolgen sehr einfach abspeichern und mit dem Betätigen einer
+einzigen Taste wieder abrufen; dies wird **Macro** genannt. Macros können
+die Tastendrücke mit den aufgezeichneten Pausen (Real Time) oder aber so
+schnell wie möglich (Full Speed) wiedergeben.
+
+Full Speed dient dabei insbesondere für wiederkehrende Aufgaben beim
+Programmieren, während mit Real Time auch ganze Effekte - mit ihrem
+Timing - wiedergegeben werden können.
+
+Macros können in den meisten Arbeitsfenstern sowie direkt auf den dafür 
+vorgesehenen Tasten auf dem Pult abgelegt werden; außerdem gibt 
+es ein Fenster "Macros". Die 10 'Macro'-Tasten (altes Tiger Touch) 
+korrespondieren mit den ersten zehn Schaltflächen im 'Macros'-Fenster, 
+während die Macro/Executor/Workspace-Tasten im Fenster 'Feste Playbacks' 
+angezeigt werden.
+
+- Auf dem Diamond 9 gibt es extra 6 Macrotasten mit einem Display zur Anzeige der 
+aktuellen Funktion zwischen den Faderbänken.
+
+- Das Arena hat noch zwei weitere Macro-Tasten vorn links auf dem Pult.
+
+Ein Macro aufzeichnen
+
+1.  Drücken Sie die blaue Taste <Keys.HardKey>Macro</Keys.HardKey> (oberhalb des Ziffernblocks)
+2.  Drücken Sie <Keys.SoftKey>Record</Keys.SoftKey>.
+3.  Wählen Sie <Keys.SoftKey>Full Speed</Keys.SoftKey> oder <Keys.SoftKey>Real Time</Keys.SoftKey>.
+4.  Betätigen Sie eine freie Taste oder Schaltfläche auf dem 
+Touchscreen, oder drücken Sie auf <Keys.SoftKey>Record</Keys.SoftKey>, um das Macro nur in die Show Library zu speichern. Damit beginnt die Aufzeichnung. Währenddessen blinkt die Taste <Keys.HardKey>Macro</Keys.HardKey>.
+5.  Führen Sie nun die aufzuzeichnende Tastenfolge aus.
+6.  Klicken Sie <Keys.HardKey>Macro</Keys.HardKey> zum Beenden der Aufzeichnung.
+
+Zum Ausführen des aufgezeichneten Macros einfach die Taste betätigen,
+auf der das Macro gespeichert wurde. Daraufhin werden sämtliche Schritte
+der Tastenfolge automatisch ausgeführt (wahlweise mit den
+aufgezeichneten Pausen oder in schneller Folge).
+
+- In Macros werden nur 'richtige' Tasten aufgezeichnet, sowie einige spezielle Klicks auf dem Touchscreen, z.B. das Auswählen von Geräten oder das Wechseln von Menüs. Änderungen anderer Eigenschaften per Klick im Display werden nicht aufgezeichnet
+
+- 
+Macros können auch als **Script** programmiert werden. Eine Einführung findet sich auf [Avolites WebAPI](https://www.avolites.com/webapi), eine Dokumentation der Funktionen gibt es auf [Avolites API documents](https://api.avolites.com/16.0/#scripts), und praktische Beispiele finden Sie im [Avolites-Wiki](https://www.avosupport.de/wiki/macros/start) (externe Website).
+
+
+## Tastenkombinationen
+
+Viele Funktionen des Pultes lassen sich durch Tastenkombinationen
+aufrufen; dies ist insbesondere mit der Titan PC-Suite (Titan Go oder Titan
+Simulator).
+
+Dabei 'fängt' Titan (das Pult-System) die Tastendrücke ab; soll ein
+anderes Programm Zugriff auf die Tastatur haben, so muss die
+‚Break'(Pause)-Taste gedrückt werden, womit weder Tastenkombinationen
+noch Texteingabe am Pult funktionieren. Umschalten des Menüs reicht die
+Tastatur wieder an Titan durch.
+
+Taste | Aktion | | Taste | Aktion
+---|---|---|----|-----
+  F1 	   |  Hilfe (englisch) anzeigen | |  Ctrl X   |  Ausschneiden (Text)
+  F2       |  Fenster wählen            | |  Ctrl C   |  Kopieren (Text)
+  F3       |  Min/Max		            | |  Ctrl V   |  Einfügen (Text)
+  Shift F3 |  Nächstes Fenster          | |  Ctrl A   |  Alles markieren (Text)
+  F4       |  Größe/Position		    | |  Ctrl Z   |  Undo
+  Shift F4 |  Bildschirm wechseln       | |  Ctrl Y   |  Redo
+  F5       |  Fenster schließen         | |  Alt C    |  Clear
+  Shift F5 |  Alle Fenster schließen    | |  Alt R    |  Record 
+  F6       |  Fenster 'Playbacks'       | |  Alt A    |  Avo (shift) 
+  F7       |  Fenster 'Fixtures'  		| |  Alt L    |  Locate
+  F8       |  Fenster 'Groups'    		| |  Alt P    |  Patch
+  F9       |  Fenster 'Colours'   		| |  Alt ⇑ D  |  Disk
+  F10      |  Fenster 'Positions' 		| |  Alt ⇑ S  |  System-Menü
+  F11      |  Fenster 'Gobos/Beams'     | |  Alt V    |  Open/View
+  F12      |  Fenster 'Channel Grid'    | |  Alt G    |  Go
+  Esc      |  EXIT 			            | |  Alt D    |  Delete
+  Enter    |  ENTER 	                | |  Alt ⇑ C  |  Copy
+  Alt 1    |  Menütaste A               | |  Alt M    |  Move
+  Alt 2    |  Menütaste B               | |  Alt U    |  Unfold
+  Alt 3    |  Menütaste C               | |  Alt I    |  Include
+  Alt 4    |  Menütaste D               | |  Alt ⇑ R  |  Release
+  Alt 5    |  Menütaste E               | |  Alt S    |  Shape
+  Alt 6    |  Menütaste F               | |  Alt ⇑ T  |  Fixture Tools/ML Menu
+  Alt 7    |  Menütaste G               | |  Alt B    |  Blind
+  Alt ⇑ F  |  <Keys.HardKey>Fixture</Keys.HardKey>               | |  Alt O    |  Off
+  Alt ⇑ P  |  <Keys.HardKey>Palette</Keys.HardKey>               | |  Alt F    |  Fan
+  Alt ⇑ M  |  <Keys.HardKey>Macro</Keys.HardKey>                 | |  Alt ⇑ O  |  Attribute options
+  Alt ⇑ G  |  <Keys.HardKey>Group</Keys.HardKey>                 | |  Alt ⇑ L  |  Latch menu
+  / (num)  |  <Keys.HardKey>Thro</Keys.HardKey>                  | |  Alt Q    |  Cue/Connect
+  \* (num) |  <Keys.HardKey>@</Keys.HardKey>                     | |  Alt W    |  Open Window
+  \- (num) |  <Keys.HardKey>Not</Keys.HardKey>                   | |  Alt T    |  Times
+  \+ (num) |  <Keys.HardKey>And</Keys.HardKey>                   | |  Alt ⇑ U  |  Update
+   Alt ←   |  Previous fixture    	    | |  Alt ⇑ I  |  Select If
+   Alt →   |  Next fixture              | |           |  |
+   Alt ↑   |  All                       | |           |  |
+   Alt ↓   |  Highlight                 | |           |  |
+
+⇑ = Shift/Umschalt
+
+(Num) = auf dem Ziffernblock

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/front-panel-buttons.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/front-panel-buttons.md
@@ -20,7 +20,7 @@ Zu jedem  Fader auf dem Pult gibt es verschiedene Tasten. Diese werden hier **Se
 &nbsp;<Keys.Annotation>B</Keys.Annotation> **Flashtaste**
 
 
-Auf dem **Diamond 9** , dem **Diamond 7** und dem **T3** sind die Tasten für die Drehregler (nur bei D9/D7) und Fader wie folgt angeordnet::
+Auf dem **D9** , dem **D7**, dem **D3** und dem **T3** sind die Tasten für die Drehregler (nur bei D9/D7) und Fader wie folgt angeordnet::
 
 ![Diamond Select and Flash](/docs/images/Diamond-Select-Flash.png)
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/loading-and-saving-shows.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/loading-and-saving-shows.md
@@ -1,0 +1,202 @@
+---
+id: loading-and-saving-shows
+title: Laden und Sichern von Shows
+sidebar_label: Laden und Sichern von Shows
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Eine beliebige Anzahl von Shows lässt sich sowohl auf einem externen
+USB-Speicher als auch auf der internen Festplatte abspeichern. Außerdem
+führt das Pult regelmäßig eine automatische Sicherung durch (Autosave).
+
+> Shows vom Tiger Touch können auf andere Avolites TITAN-Pulte übertragen werden, nicht jedoch auf ältere Avolites-Pulte, da das Format der Dateien unterschiedlich ist.<br/>
+Shows, die mit einer neueren Version der Titan-Software erstellt wurden, laufen in älteren Versionen möglicherweise überhaupt nicht oder nicht korrekt.  
+
+Obwohl die Show auf dem internen Laufwerk sicher aufgehoben ist,
+empfiehlt es sich sehr, die Daten auch auf externen USB-Speicher
+(USB-Stick o.ä.) zu speichern, etwa für den Fall, dass etwas
+Unvorhergesehenes mit dem Pult passiert, oder um die Show auf einem
+anderen Pult zu verwenden.
+
+## Die Show speichern
+
+Die aktuelle Show lässt sich jederzeit unter ihrem gegenwärtigen oder
+einem neuen Namen speichern. Wird die aktuelle Show unter ihrem
+bisherigen Namen gespeichert, so wird extra diese Version gespeichert.
+So kann man später zu einzelnen Versionen zurückkehren.
+
+Um die Show zu speichern, gehen Sie wie folgt vor:
+
+1.  Drücken Sie die Taste <Keys.HardKey>Disk</Keys.HardKey>.
+2.  Drücken Sie <Keys.SoftKey>Save</Keys.SoftKey>.
+3.  Wenn externer USB-Speicher angeschlossen ist, wählen Sie mit den
+Tasten zwischen <Keys.SoftKey>Removable Disk</Keys.SoftKey> (Wechseldatenträger, USB-Speicher)
+und <Keys.SoftKey>Internal hard drive</Keys.SoftKey>(interne Festplatte).
+4.  Handelt es sich um eine neue Show, so vergeben Sie mit der Tastatur
+einen Namen für die Show. Ist es dagegen eine neue Version einer bereits
+existierenden Show, so können Sie einen Namenszusatz eingeben, um später
+die Version schneller wiederfinden zu können.
+5.  Klicken Sie <Keys.HardKey>Enter</Keys.HardKey> oder <Keys.SoftKey>Save</Keys.SoftKey> (oder <Keys.SoftKey>Overwrite</Keys.SoftKey>, falls bereits
+eine Show gleichen Namens existiert und überschrieben werden soll). Nun
+wird die Show gesichert.
+6.  Drücken Sie <Keys.HardKey>Exit</Keys.HardKey> oder <Keys.SoftKey>OK</Keys.SoftKey>, um den Modus 'Disk' zu verlassen.
+
+-   Zum Speichern der Show unter einem neuen Namen wählen Sie die
+    Funktion <Keys.SoftKey>Save As</Keys.SoftKey>.
+
+-   Zweimaliges Drücken der Taste <Keys.HardKey>Disk</Keys.HardKey> veranlasst ein Speichern der
+    Show als Quicksave. Quicksaves werden im gleichen Verzeichnis wie
+    die normal gesicherten Shows gespeichert.
+
+-   Eine neue Version wird selbst dann gespeichert, wenn man den
+    gleichen Namenszusatz wie vorher vergibt.
+
+Beim Speichern auf der internen Festplatte werden die Daten in das
+Verzeichnis 'D:\\Shows' gespeichert. Bei der PC-Suite werden die
+Showdaten in 'Eigene Dokumente\\Titan\\Shows' gespeichert.
+
+## Laden einer Show
+
+Beim Einschalten/Starten wird automatisch die zuletzt geladene Show
+geladen.
+
+![Show Browser](/docs/images/Show-Browser.png)
+Zum Laden einer anderen Show betätigen Sie die Taste <Keys.HardKey>Disk</Keys.HardKey> und wählen
+die Option <Keys.SoftKey>Load Show</Keys.SoftKey>. Darauf wird der Show-Browser angezeigt.
+
+Links oben kann man das zu verwendende Laufwerk wählen. Links unten
+lässt sich die Anzeige filtern, etwa um nur manuelle oder nur Autosaves
+anzuzeigen. Rechts werden die verschiedenen vorhandenen Versionen der
+gefundenen Show angezeigt; damit kann man schnell und einfach zu einem
+früheren Programmierstand wechseln.
+
+Ebenso lassen sich Shows auch über die Menütasten auswählen und
+laden:
+
+1.  Drücken Sie die blaue Taste <Keys.HardKey>Disk</Keys.HardKey>.
+2.  Drücken Sie <Keys.SoftKey>Load Show</Keys.SoftKey>.
+3.  Wenn ein externer USB-Speicher angeschlossen ist, wählen Sie nun das
+Laufwerk, von dem die Show geladen werden soll.
+4.  Momentan im angewählten Speicher vorhandene Shows werden bei den
+Menütasten A bis E angezeigt (mit F und G kann man in der Liste
+weiterblättern). Um die Auswahl einzugrenzen, geben Sie die
+Anfangsbuchstaben der gewünschten Show mit der Tastatur ein.
+5.  Gibt es mehrere Versionen der Show, so wählen Sie die gewünschte
+aus.
+6.  Drücken Sie auf <Keys.SoftKey>Load Show</Keys.SoftKey>. Beim Laden der Show wird der
+Fortschritt für die einzelnen Elemente der Show angezeigt.
+7.  Nachdem die Show geladen ist, kehrt die Anzeige zum normalen
+Betriebsmodus zurück.
+
+Beim Laden einer Show lässt sich wählen, ob die bereits im Pult
+vorhandenen DMX-Einstellungen übernommen oder die aus der Show verwendet
+werden sollen; damit wird die Zuordnung der internen Linien auf die
+DMX-Anschlüsse und Netzwerkgeräte bestimmt.
+
+## Teile aus anderen Shows importieren
+
+Ist eine Show ähnlich einer früheren, so möchte man vielleicht Teile aus
+dieser in der neuen verwenden; so könnte man z.B. einige Paletten, die
+damals für Robe Robins programmiert wurden, jetzt für andere Lampen
+verwenden. Genau dazu dient die Import-Funktion.
+
+Voraussetzung für das Importieren ist das Zuordnen (Mappen) von Geräten der
+importierten zu Geräten der aktuellen Show, so dass das Pult weiß, auf
+welche Geräte die importierten Daten anzuwenden sind.
+
+![Fixture Mapping](/docs/images/Fixture-Mapping.png)
+
+Ist dies geschehen, lassen sich Teile der älteren Show auf
+Tasten/Schaltflächen der neuen Show speichern und verwenden.
+
+![Import](/docs/images/Import.png)
+
+1.  Drücken Sie die Taste <Keys.HardKey>Disk</Keys.HardKey>.
+2.  Klicken Sie <Keys.SoftKey>Import Show</Keys.SoftKey> (Das große Plus-Zeichen oben im Fenster
+Show-Verzeichnis ruft ebenfalls diese Funktion auf).
+3.  Darauf öffnet sich der Show-Browser. Wählen Sie die zu importierende
+Show aus und klicken Sie auf <Keys.SoftKey>Load Show</Keys.SoftKey>.
+4.  Nun öffnet sich das Fenster Show-Verzeichnis (Show Library). Die
+aktuelle sowie die zu importierende Show haben jeweils Schaltflächen
+oben im Fenster. Es lassen sich Teile aus mehreren Show gleichzeitig
+importieren, indem man Schritte 1 bis 3 wiederholt.
+5.  Klicken Sie auf den Reiter 'Mapper' und wählen Sie die importierte
+Show.
+6.  Wählen Sie ein Gerät der importierten Show und klicken Sie dann auf
+den Pfeil bei einem Gerät der aktuellen Show, um es zuzuordnen. Um eine
+Zuordnung wieder aufzuheben, wählen Sie aus dem 
+Kontext-Menü <Keys.SoftKey>Clear Fixture Mapping</Keys.SoftKey>.<br/>
+Um ein importiertes Gerät auf mehrere vorhandene Geräte zuzuordnen,
+ziehen Sie um diese einen Auswahlrahmen, oder Sie klicken wiederholt auf
+das zu importierende sowie ein vorhandenes Gerät.
+7.  Sind alle Gerät zugeordnet, für die etwas importiert werden soll,
+klicken Sie auf den Reiter ‚Show Library'.
+8.  Wählen Sie die zu importierenden Bestandteile (einzeln oder mehrere
+gleichzeitig). Mit den Schaltflächen links lassen sich einzelne
+Kategorien auswählen (z.B. Gruppen oder Paletten).
+9.  Wählen Sie nun Tasten oder Schaltflächen (in den jeweiligen
+Fenstern), auf die die importierten Teile gespeichert werden sollen.
+10.  Ist alles Gewünschte importiert, so beenden Sie den Vorgang 
+mit <Keys.HardKey>Exit</Keys.HardKey>.
+
+-   Rechts und links im Show-Browser lassen sich Filter für die
+    anzuzeigenden Gerätetypen setzen, um die Suche zu vereinfachen.
+
+-   Wird der Show-Browser angezeigt, so kann man die Import-Funktion
+    direkt über einen Klick auf das <Keys.SoftKey>+</Keys.SoftKey> (Pluszeichen) aufrufen.
+
+-   Weitere Informationen zum Show-Verzeichnis siehe [Show Library](./show-library.md).
+
+## Autosave -- Automatisches Speichern
+
+Die aktuelle Show wird durch das Pult beim Herunterfahren automatisch
+gespeichert. Ebenso erfolgt alle 30 Minuten eine automatische
+Speicherung etwa für den Fall eines plötzlichen Stromausfalls.
+
+Die Häufigkeit des automatischen Speicherns lässt sich ändern bzw. die
+Funktion ganz abschalten. Dazu wählt man die Option <Keys.SoftKey>Auto Save</Keys.SoftKey> aus
+dem 'Disk'-Menü (Taste <Keys.HardKey>Disk</Keys.HardKey>). Autosaves lassen sich wie
+anderweitig gespeicherte Shows im Show-Browser auswählen und aufrufen.
+
+> Früher gab es bei langsamer Hardware die Empfehlung, während der Show Autosave zu deaktivieren, damit es nicht zu Performance-Einbußen kam. Auf aktuellen Pulten und guter Hardware gilt dies nicht mehr: lassen Sie Autosave daher aus Sicherheitsgründen aktiviert.
+
+## Recover -- Show Wiederherstellen
+
+Wurde Titan nicht richtig beendet, etwa durch einen Stromausfall, und
+wird dann neu gestartet, so kann der letzte Stand meist nicht direkt
+wiederhergestellt werden. In diesem Fall gibt es die Option <Keys.SoftKey>Recover Show</Keys.SoftKey>, 
+womit versucht wird, die frühere Show aus einem temporären
+Verzeichnis zu rekonstruieren. Außerdem werden auch Funktionen zum
+Starten einer neuen Show oder dem Laden einer anderen Show angeboten.
+
+## Sichern existierender Shows auf USB-Sticks
+
+Wollen Sie einfach eine Kopie der aktuellen Show anfertigen, so machen
+Sie das am besten mit der normalen Speicherfunktion ('Save'), und wählen
+das externe USB- anstelle des internen Laufwerks.
+
+Um eine auf der internen Festplatte vorhandene Show auf einen USB-Stick
+zu kopieren, stellen Sie zunächst sicher, dass die aktuelle Show
+gesichert ist. Dann laden Sie die zu kopierende Show von der Festplatte
+und speichern sie auf USB-Stick. Alternativ lässt sich das auch per
+'Folders' aus dem Tools-Menü realisieren.
+
+## Eine Show zum automatischen Starten festlegen
+
+Normalerweise wird beim Starten der Software die zuletzt verwendete Show geladen. Mitunter 
+(z.B. beim unbeaufsichtigten Betrieb oder bei Verwendung mit dem [Venue Mode](../running-the-show.md#setting-a-venue-mode-workspace-for-basic-controls-while-locked)) ist es erwünscht, 
+beim Start immer eine bestimmte Show zu laden. dafür dient die Funktion **Start Up Show**.
+
+1. Laden Sie die Show, die Sie als Start Up Show festlegen möchten.
+2. Drücken Sie die Taste <Keys.HardKey>Disk</Keys.HardKey>.
+3. Drücken Sie <Keys.SoftKey>Next</Keys.SoftKey>, bis die Option **Start Up Show** im Menü erscheint.
+4. Drücken Sie <Keys.SoftKey>Start Up Show</Keys.SoftKey>. Ist keine Start Up Show festgelegt, so wird **Unlocked** angezeigt.
+5. Drücken Sie <Keys.SoftKey>Create and Lock Show</Keys.SoftKey>. Damit wird die aktuelle Show als Start Up Show festgelegt, und in der Anzeige steht nun **Start Up Show Locked**.
+6. Ist bereits eine Start Up Show eingerichtet, so lässt sich diese Zuordnung mit <Keys.SoftKey>Update Show</Keys.SoftKey> auf die gerade geladene Show ändern oder aber mit <Keys.SoftKey>Unlock</Keys.SoftKey> wieder löschen.
+
+Ebenso können Playbacks so eingerichtet werden, dass diese beim Programmstart aktiviert werden. Damit 
+kann die Bühne gleich in eine Einlas-Stimmung versetzt oder das Saallicht aktiviert werden. Siehe [Run On Startup](../cues/playback-options.md#run-on-startup).
+
+> Ist eine Start Up Show eingerichtet, so werden beim Herunterfahren der Software ungespeicherte Änderungen verworfen.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/loading-and-saving-shows.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/loading-and-saving-shows.md
@@ -11,8 +11,9 @@ Eine beliebige Anzahl von Shows lässt sich sowohl auf einem externen
 USB-Speicher als auch auf der internen Festplatte abspeichern. Außerdem
 führt das Pult regelmäßig eine automatische Sicherung durch (Autosave).
 
-> Shows vom Tiger Touch können auf andere Avolites TITAN-Pulte übertragen werden, nicht jedoch auf ältere Avolites-Pulte, da das Format der Dateien unterschiedlich ist.<br/>
-Shows, die mit einer neueren Version der Titan-Software erstellt wurden, laufen in älteren Versionen möglicherweise überhaupt nicht oder nicht korrekt.  
+> Shows vom Tiger Touch können auf andere Avolites TITAN-Pulte übertragen werden.<br/>
+Shows aus älteren Titan-Versionen können in neuere Versionen geladen werden (z.B. kann eine Show aus Titan v16 in ein Pult mit Titan v18 geladen werden).<br/>
+Shows aus neueren Titan-Versionen in älteren Versionen zu öffnen ist nicht möglich und wird zu Fehlern führen.
 
 Obwohl die Show auf dem internen Laufwerk sicher aufgehoben ist,
 empfiehlt es sich sehr, die Daten auch auf externen USB-Speicher

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/multi-user-operation.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/multi-user-operation.md
@@ -1,0 +1,169 @@
+---
+id: multi-user-operation
+title: Mehrbenutzer-Betrieb
+sidebar_label: Mehrbenutzer-Betrieb
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Es lassen sich mehrere Pulte zum gemeinsamen Steuern einer Show
+verbinden. Ebenso lassen sich mehrere Benutzer - auch auf ein und
+demselben Pult - anlegen, etwa mit verschiedenen Tastenanordnungen oder
+Speicherplatz-Belegungen. Das kann z.B. für Support-Bands sinnvoll sein.
+
+## Users -- Benutzer
+
+In jeder Show kann es mehrere Benutzer geben, von denen jeder seine
+eigenen Einstellungen, Tastenprofile und Handle Worlds verwalten kann.
+Damit lässt sich sehr schnell zwischen verschiedenen Einstellungen und
+Belegungen umschalten, etwa bei einem Festival mit mehreren Operatoren.
+
+Die Benutzer werden mit in der Show-Datei gespeichert; der beim
+Speichern aktive Benutzer wird beim Laden der Show wieder aktiviert. Die
+Vorgabe für den Benutzer ist "Operator"; der jeweils aktive Benutzer und
+sein Tastenprofil werden im Display angezeigt.
+
+![systemarea](/docs/images/System-Area.png)
+
+Das Ändern und Neuanlegen von Benutzern erfolgt im Menü 'Users'
+(Benutzer).
+
+1.  Drücken Sie die Taste <Keys.HardKey>Disk</Keys.HardKey>.
+2.  Klicken Sie auf <Keys.SoftKey>Users</Keys.SoftKey>.
+3.  Um zu einem anderen Benutzer zu wechseln, klicken Sie 
+auf <Keys.SoftKey>Change Current User</Keys.SoftKey> und wählen einen anderen 
+Benutzer (der momentan aktuelle Benutzer ist markiert).
+4.  Um einen neuen Benutzer anzulegen, wählen Sie <Keys.SoftKey>Add a User</Keys.SoftKey>, geben
+einen Namen ein und drücken Sie <Keys.SoftKey>OK</Keys.SoftKey>.
+5.  Ebenso kann man schnell im Hauptmenü den Benutzer wechseln: halten
+Sie die <Keys.HardKey>Avo</Keys.HardKey>-Taste gedrückt und wählen Sie aus dem Menü <Keys.SoftKey>User ... </Keys.SoftKey>
+
+-   Wird mit mehreren Konsolen gleichzeitig an der Show gearbeitet, so
+    erscheint ein neu angelegter Benutzer automatisch auch auf den
+    anderen Pulten.
+
+## Handle Worlds
+
+Jede Show kann mehrere Handle Worlds enthalten, wobei jede
+unterschiedliche Tastenbelegungen und Anordnungen von Schaltflächen
+speichert. Damit kann sich jeder Benutzer seine individuellen
+Bedienelemente zusammenstellen, zwischen denen dann schnell umgeschaltet
+werden kann.
+
+Wird der Benutzer gewechselt, so wird auch die Handle World gewechselt.
+
+Sämtliche Handle Worlds werden in der Showdatei gespeichert; die Vorgabe
+für die Handle World ist "Mapping World 1".
+
+Das Verwalten der Handle Worlds erfolgt ebenfalls im Menü "Disk":
+
+1.  Drücken Sie die Taste <Keys.HardKey>Disk</Keys.HardKey>.
+2.  Klicken Sie auf <Keys.SoftKey>Handle Worlds</Keys.SoftKey>.
+3.  Zum Wechseln der Handle World klicken Sie <Keys.SoftKey>Select Handle World</Keys.SoftKey>
+und wählen aus der Liste eine andere Handle World (die momentan aktive ist markiert).
+4.  Um eine neue Handle World anzulegen, wählen Sie <Keys.SoftKey>Add Handle World</Keys.SoftKey>, 
+geben eine Namen ein und klicken <Keys.SoftKey>OK</Keys.SoftKey>.
+5.  Mit <Keys.SoftKey>Delete Handle World</Keys.SoftKey> wird die Handle World gelöscht;
+Schaltflächen, die nur in dieser verwendet wurden, sind nur noch über
+das Show-Verzeichnis (Show Library) erreichbar und können bei Bedarf neu
+zugeordnet werden.
+
+-   Schaltflächen/Speicherplätze aus anderen Handle Worlds sind über das
+    Show-Verzeichnis (Show Library) erreichbar und können in der eigenen
+    Handle World neu zugeordnet werden.
+
+-   Die Option <Keys.SoftKey>Follow World Page Change</Keys.SoftKey> bestimmt, ob auf anderen
+    Pulten, die in der gleichen Handle World arbeiten, die Seiten der
+    Speicherplätze synchron gewechselt werden.
+
+## Verbinden mit anderen TitanNet-Sessions
+
+Sind mehrere Titan-Pulte im gleichen Netzwerk miteinander
+verbunden, so können diese als Multi-User, [Backup](../running-the-show/linking-consoles-for-multi-user-or-backup.md#pulte-für-den-backup-betrieb-einrichten) oder beides
+gleichzeitig arbeiten.
+
+> Alle Pulte in einer Titan-Session müssen auf der gleichen Software-Version laufen.
+
+Details zur Einrichtung des Netzwerkbetriebs mehrerer Pult siehe
+[Netzwerk einrichten](../networking.md).
+
+1.  Drücken Sie die Taste <Keys.HardKey>Disk</Keys.HardKey>.
+2.  Klicken Sie auf <Keys.SoftKey>TitanNet Sessions</Keys.SoftKey>.
+3.  Mit <Keys.SoftKey>Sessions View</Keys.SoftKey> erhält man ein Fenster mit einer Übersicht,
+wie das Pult gerade mit anderen Pulten verbunden ist bzw. welche
+TitanNet-Sessions verfügbar sind. Zum Verbinden klicken Sie im Display
+auf das Symbol eines anderen Pultes und wählen <Keys.SoftKey>Connect</Keys.SoftKey>.
+4.  Oder Sie wählen <Keys.SoftKey>Backup</Keys.SoftKey>, <Keys.SoftKey>Multi-User</Keys.SoftKey> 
+oder <Keys.SoftKey>Backup & Multi-User</Keys.SoftKey> -- auch hier werden momentan verfügbare Sessions angezeigt.
+Klicken Sie auf eine Session, um sich mit dieser zu verbinden.
+
+![SessionsView](/docs/images/SessionsView.png)
+
+Eine grüne Linie zeigt eine gute Verbindung an, eine gepunktete rote
+Linie dagegen Verbindungsprobleme. Nicht verfügbare Pulte erscheinen
+auf rotem Hintergrund.
+
+Zunächst fungieren alle Pulte als Master. Verbindet man sich nun von
+einem anderen Pult aus mit dieser Session im Mehrbenutzerbetrieb, so
+wird dieses Pult ein Slave und übernimmt den momentanen Stand der
+Show vom Master-Pult. Auf dem Slave-Pult kann man wählen, ob die
+Show lokal oder auf dem Master-Pult gespeichert werden soll.
+
+In der Titelleiste werden Details zum Master/Slave-Status angezeigt.
+Der Name des jeweiligen Pultes lässt sich mit der Option <Keys.SoftKey>Console Legend</Keys.SoftKey> ändern.
+
+![Shell Slave](/docs/images/Shell-Slave.png)
+
+Im Mehrbenutzerbetrieb arbeiten Pulte gemeinsam an der gleichen Show.
+Ist auf allen die gleiche Handle World gewählt, so werden Änderungen an
+sämtliche Pulte übertragen; wird z.B. ein Cue auf einem Slave-Pult
+gestartet, so wird dieser auch auf dem Master-Pult als aktiv
+gekennzeichnet. Auf Pulten mit Motorfadern fahren diese auf den
+entsprechenden Pegel; sind keine Motorfader vorhanden, so muss der Fader
+manuell auf den aktuellen Wert gebracht werden, um die Steuerung dieses
+Cues zu übernehmen. Arbeiten die Pulte dagegen in unterschiedlichen
+Handle Worlds, so ist ein weitgehend unabhängiges Arbeiten möglich.
+
+> Pulte mit dem gleichen Benutzer und der gleichen Handle World haben immer auch das gleiche Playback-Handle connected, also mit der Steuerung verbunden. Ist dies nicht erwünscht, so muss ein anderer Benutzer und Handle World gewählt werden.
+
+In jedem Falle erfolgt die DMX-Ausgabe durch das Master-Pult. Kanäle,
+die auf anderen Pulten im Programmer aktiv sind, werden mit einem blauen
+Punkt bei der Anzeige der Räder markiert. Wird auf mehreren Pulten
+gleichzeitig an einem Gerät gearbeitet, so hat das Pult Priorität über
+das Gerät, an dem die letzte Änderung vorgenommen wurde.
+
+Slave-Pulte können die Session jederzeit verlassen: entweder per
+Schaltfläche <Keys.SoftKey>Leave Session</Keys.SoftKey> in der **Sessions-Ansicht** oder im
+**TitanNet-Menü**. Nach dem Verlassen der Session wird die Show geladen, die
+vor dem Beitritt zur Session aktiv war. Auf Master-Pulten gibt es
+hingegen die Option <Keys.SoftKey>Terminate Session</Keys.SoftKey> (Session beenden).
+
+Läuft ein Pult als [Backup](../running-the-show/linking-consoles-for-multi-user-or-backup.md#pulte-für-den-backup-betrieb-einrichten), 
+so gibt es die Optionen <Keys.SoftKey>Takeover</Keys.SoftKey>, <Keys.SoftKey>Sync Now</Keys.SoftKey> 
+und <Keys.SoftKey>Leave Session</Keys.SoftKey>. Mit <Keys.SoftKey>Takeover</Keys.SoftKey> kann die Show übernommen
+werden: dieses Pult wird nun Master und gibt DMX aus, der am Masterpult
+aktive Benutzer und die Handle World werden nun an diesem neuen Master
+aktiviert. Die DMX-Ausgabe des vorherigen Masters wird deaktiviert.
+
+> Für Mehrbenutzerbetrieb und Session-Backup müssen alle beteiligten 
+  Pulte exakt den gleichen Versionsstand haben.
+
+### PC-Suite (Titan Go, Titan Simulator)
+
+Damit sich die verschiedenen Pulte gegenseitig im Netzwerk finden, muss auf Windows-Ebene die **Network Discovery** aktiviert sein (Netzwerk-Einstellungen bzw. Freigabecenter).
+
+## Programmieren mit mehreren Benutzern
+
+Jeder Benutzer (und jede Remote) verfügt über einen eigenen Programmierspeicher,
+so dass Fixtures unabhängig voneinander programmiert werden können. Werden durch einen Benutzer 
+Änderungen vorgenommen, aber danach nicht <Keys.HardKey>Clear</Keys.HardKey> gedrückt, so bleiben 
+die eingestellten Werte in dessen Programmer. Das mag für andere User irritierend sein, da diese die Werte nicht 
+einfach mit <Keys.HardKey>Clear</Keys.HardKey> löschen können. 
+
+Zur Abhilfe lassen sich alle Programmer aller User löschen: halten Sie dazu <Keys.HardKey>Clear</Keys.HardKey> gedrückt 
+und wählen <Keys.SoftKey>Clear all programmers</Keys.SoftKey> aus dem Menü..
+ 
+Attribute, deren Werte gerade durch einen anderen Programmer beeinflusst werden, werden durch einen Punkt in Cyan angezeigt.
+
+![Blue dot showing multi-user control of attribute](/docs/images/Wheel-Other-Programmer.png)

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/multi-user-operation.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/multi-user-operation.md
@@ -11,6 +11,8 @@ Es lassen sich mehrere Pulte zum gemeinsamen Steuern einer Show
 verbinden. Ebenso lassen sich mehrere Benutzer - auch auf ein und
 demselben Pult - anlegen, etwa mit verschiedenen Tastenanordnungen oder
 Speicherplatz-Belegungen. Das kann z.B. für Support-Bands sinnvoll sein.
+Ein zweites Pult kann aber auch als Backup-Konsole verbunden werden, 
+siehe [Pulte für den Backup-Betrieb einrichten](../running-the-show/linking-consoles-for-multi-user-or-backup.md#pulte-für-den-backup-betrieb-einrichten).
 
 ## Users -- Benutzer
 
@@ -84,6 +86,9 @@ verbunden, so können diese als Multi-User, [Backup](../running-the-show/linking
 gleichzeitig arbeiten.
 
 > Alle Pulte in einer Titan-Session müssen auf der gleichen Software-Version laufen.
+Als Backup verwendete Pulte müssen mindestens ebenso viele Linien ermöglichen wie die Hauptkonsole,
+siehe [DMX-Einstellungen](../system-settings/dmx-output-mapping.md) zu den Limits pro Pult.
+
 
 Details zur Einrichtung des Netzwerkbetriebs mehrerer Pult siehe
 [Netzwerk einrichten](../networking.md).
@@ -147,7 +152,8 @@ aktive Benutzer und die Handle World werden nun an diesem neuen Master
 aktiviert. Die DMX-Ausgabe des vorherigen Masters wird deaktiviert.
 
 > Für Mehrbenutzerbetrieb und Session-Backup müssen alle beteiligten 
-  Pulte exakt den gleichen Versionsstand haben.
+  Pulte exakt den gleichen Versionsstand haben. Als Backup verwendete Pulte müssen mindestens 
+  ebenso viele Linien ermöglichen wie die Hauptkonsole.
 
 ### PC-Suite (Titan Go, Titan Simulator)
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/other-parts-of-the-touch-screen.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/other-parts-of-the-touch-screen.md
@@ -1,0 +1,186 @@
+---
+id: other-parts-of-the-touch-screen
+title: Andere Bereiche der Anzeige
+sidebar_label: Andere Bereiche der Anzeige
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+## Die Menütasten
+
+Auf der rechten Seite des Touchscreens befindet sich der Menü-Bereich.
+Direkt daneben angeordnet sind die Menütasten A-G. Beim Diamond 9 gibt es 
+für das Menü extra ein Touch-Display links neben dem rechten Bildschirm. 
+(Das Pearl Expert hat dafür extra ein kleines LCD-Display im Pult).
+
+![Titan Touch Screen User Interface](/docs/images/Titan-Touch-Screen-User-Interface.png)
+
+Gibt es mehr Funktionen als in den verfügbaren Platz
+passen, so erscheinen Schaltflächen <Keys.SoftKey>Previous</Keys.SoftKey> (zurück) und <Keys.SoftKey>Next</Keys.SoftKey>
+(weiter), um durch die Funktionen zu blättern. Man kann jeweils die
+Schaltfläche oder die 'richtige' Taste (direkt daneben) benutzen.
+
+Die senkrechte Leiste links neben den Menü-Schaltflächen zeigt den Namen
+des aktuellen Menüs. Bei Bedarf lässt sich das gerade aktive Menü
+einrasten (so dass es nicht laufend wieder angewählt werden muss); dazu
+dient die Taste <Keys.HardKey>Menu Latch</Keys.HardKey> (auf dem Pearl Expert und dem alten Tiger
+Touch die Taste <Keys.HardKey>ML Menu</Keys.HardKey>). Die senkrechte Leiste neben den Buttons
+wird rot, sobald ein Menü eingerastet ist. Das ist z.B. sinnvoll, wenn 
+viele einzelne Playbacks oder Paletten kopiert oder verschoben werden 
+sollen.
+
+Der Informationsbereich links davon (mit dem Avolites-Logo) bietet
+Hinweise zum aktuellen Programmierschritt, außerdem werden hier die
+letzten Befehle für die Undo-Funktion aufgelistet. Auf dem Diamond 9 befindet sich der Infobereich 
+oberhalb der Menütasten im Menü-Touchscreen.
+
+![Prompt Area](/docs/images/System-Area.png)
+
+Am unteren Rand des Touchscreens wird die Funktion der Encoder (Räder) 
+angezeigt. Wenn Attribute der Geräte angewählt sind, werden hier die 
+geräteweise möglichen Einstellungen aufgelistet. Oberhalb der 
+dargestellten Walze befindet sich die Bezeichnung der Attribute, die 
+jeder Encoder steuert, in der Mitte der Walze steht der aktuelle Wert. 
+Durch Anklicken des oberen oder unteren Teiles der Walze lassen sich 
+Attributwerte z.B. auf 0% oder 100% setzen.
+
+Wenn gerade eine Sequenz gesteuert wird (Cueliste bzw. Chaser), so
+findet man auf der Walze Informationen darüber.
+
+![Wheels](/docs/images/Wheels-2.png)
+
+Unmittelbar darüber bzw. daneben werden in einer Leiste die
+Attributgruppen IPCGBESFX angezeigt: I = Intensity = Helligkeit; P = 
+Position; C = Colour = Farbe; G = Gobo; B = Beam = Beeinflussung des 
+Lichtstrahls; E = Effect, S = Special, FX = (generierte) Effekte. 
+Die ausgewählte Gruppe wird grau hinterlegt, die aktuell veränderte 
+dagegen blau.
+
+Die Darstellung der Menütasten variiert mit der jeweils möglichen
+Bedienungsoption:
+
+  |   Darstellung   | Bedeutung          |
+  |     ---   | ---          |
+  |  ![Softkey - Action](/docs/images/Softkey-Action.png)  |  **Aktionstaste** - beim Anklicken wird dieser Befehl ausgeführt   |
+  |  ![Softkey - Option](/docs/images/Softkey-Option.png)  |  **Optionstaste** - zum Durchschalten durch eine Anzahl von Optionen   |
+  |  ![Softkey - New Menu](/docs/images/Softkey-New-Menu.png)  |  **Neues Menü** - öffnet ein weiteres Menü   |
+  |  ![Softkey - Text Entry](/docs/images/Softkey-Text-Entry.png)  |  **Texteingabe** - Taste betätigen, um mit der Tastatur einen Text einzugeben  |
+
+## Die Werkzeugleiste
+
+Auf allen Konsolen außer dem Diamond 9, Diamond 7 und dem Sapphire Touch befindet sich am oberen
+Bildschirmrand die Werkzeugleiste.
+
+![Tools Menu](/docs/images/Tools-Menu.png)
+
+Beim Sapphire Touch befindet sich die Werkzeugleiste am Mittelsteg, also
+links im rechten sowie rechts im linken Display.
+
+![Sapphire Tools Menu](/docs/images/Sapphire-Tools-Menu.png)
+
+Auf dem Diamond 9/Diamond 7 gibt es statt der Werkzeugleiste einen Button <Keys.ContextKey>Tools</Keys.ContextKey>.
+Auf dem D9 ist dieser links oben auf dem rechten Touchscreen. Beim D7-215 (2 Displays) ist dieser oben links auf dem 
+linken Touchscreen, beim D7-330 (3 Displays) oben links auf dem mittleren Touchscreen. 
+Außerdem gibt es die Taste <Keys.HardKey>Tools</Keys.HardKey> auf der ausziehbaren Tastatur.
+
+![D9 Tools button](/docs/images/Tools-Button-D9.png)
+
+Beim Betätigen der Schaltfläche 'Tools' öffnet sich ein Menü mit Zugriff
+auf verschiedene weitere Konfigurationsmöglichkeiten (abhängig vom
+Pult):
+
+**About** zeigt Informationen über die Software-Version.
+
+**Help** öffnet das (englische) Online-Handbuch.
+
+**Control Panel** öffnet ein Untermenü mit Einstellungsmöglichkeiten
+etwa für den Bildschirm oder die USB Expert-Konsole, die die Verbindung
+zwischen der Bedienoberfläche und dem Hauptprozessor herstellt. Der
+Punkt 'More...' öffnet die Windows-Systemsteuerung, um die
+Systemkonfiguration zu bearbeiten.
+
+**Touch Screen Setup** (in Control Panel) öffnet das 
+Einrichtungsprogramm für die Touchscreens, mit dem diese z.B. auch 
+kalibriert werden können.
+
+**USB Expert Console** (in Control Panel) ist das Einrichtungsprogramm 
+für die Verbindung zwischen Bedienoberfläche und Hauptprozessor. 
+Sollten Probleme auftreten, kann man hier hilfreiche Informationen 
+für die Fehlersuche finden.
+
+**Folders** öffnet das Dateisystem zum direkten Zugriff. Dies wird u.a.
+zum Sichern der Daten sowie zum Updaten benötigt.
+
+**Switch Task** dient zum Umschalten
+zwischen mehreren Programmen, und zum Bewegen der Programmfenster auf
+den externen Bildschirm. Benutzen Sie das Symbol 'Bildschirm wechseln',
+um ein Fenster zwischen Touchscreen und externem Bildschirm hin- und
+herzuschalten; 'Zentrieren' zentriert das Fenster auf dem Bildschirm,
+'Schließen' schließt das jeweilige Programm.
+
+![Switch Task](/docs/images/Switch-Task.png)
+
+**Switch Software** erlaubt es, zwischen verschiedenen Versionen der
+Pult-Software (sofern installiert) umzuschalten. Das kann sinnvoll sein,
+um Shows aus älteren Versionen zu laden.
+
+**Additional Programs** dient zum Aufruf einiger Diagnoseprogramme, die
+dem Avolites-Support die Fehlersuche ermöglichen.
+
+**Restart** und **Shutdown Software** startet die Titan-Software neu
+bzw. schließt sie. Normalerweise benötigt man das nur beim
+Programm-Update.
+
+In der Werkzeugleiste befindet sich auch jeweils ein Button zum Aufrufen
+der Bildschirmtastatur. Auf dem Diamond 9 gibt es dafür die Taste <Keys.HardKey>Keyboard</Keys.HardKey>.
+
+> Bei der Titan PC Suite (Titan Go, Titan Simulator) gibt es keine Toolbar, da alle diese Funktionen über Windows bzw. die Systemsteuerung zur Verfügung stehen.
+
+## Visualiser
+
+![Visualiser](/docs/images/Capture-Visualiser-Workspace-Window.png)
+
+Ab Titan Version 10 ist Capture als Visualiser in die Software
+integriert. Genauere Informationen gibt es im Abschnitt [Capture Visualiser](../capture-visualiser.md).
+
+Mit dem Visualiser erhält man einen realistischen Eindruck von der
+jeweiligen Beleuchtungssituation. So lässt sich vorprogrammieren,
+Anpassungen vornehmen sowie etwa während der Show per Blind-Modus letzte
+Änderungen machen.
+
+## Undo/Redo -- Rückgängig machen/Wiederholen
+
+Im Konsolenbereich des Bildschirms (links neben der Leiste mit den
+Menütasten) wird eine Liste der zuletzt ausgeführten
+Programmieraktionen angezeigt.
+
+![System Area](/docs/images/System-Area.png)
+
+Klickt man in diesen Bereich, so öffnet sich das History-Fenster mit
+einer genaueren Liste, und man kann Aktionen daraus einfach rückgängig
+machen.
+
+Die zuletzt ausgeführte Aktion wird im Konsolenbereich fett dargestellt;
+im History-Fenster wird sie rot hinterlegt.
+
+![Undo Window](/docs/images/Undo-Window.png)
+
+Klickt man in diesem Fenster nun auf eine der vorherigen Aktionen, so
+werden alle Aktionen bis zu dieser rückgängig gemacht. Derart
+deaktivierte Aktionen werden ausgegraut dargestellt; klickt man darauf,
+so können sie wiederhergestellt werden.
+
+Ebenso kann man mittels Undo/Redo durch die Liste durchschalten (<Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>Undo</Keys.HardKey> bzw. <Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>Redo</Keys.HardKey>; Pfeil-links bzw. Pfeil-rechts
+unterhalb des Ziffernblocks auf älteren Pulten).
+
+Einige Aktionen können nicht rückgängig gemacht werden; dies wird durch
+ein rotes Verbotszeichen dargestellt.
+
+![Undo Cant Undo](/docs/images/Undo-Cant-Undo.png)
+
+Im Mehrbenutzerbetrieb kann das Fenster eine separate Spalte pro
+Benutzer zeigen, mit den jeweils letzten Aktionen des Users. Dazu dient
+die Option <Keys.ContextKey>Show All Users and Consoles</Keys.ContextKey> im Kontext-Menü dieses Fensters. 
+Als Vorgabe wird mit <Keys.ContextKey>Show Only Current User</Keys.ContextKey> nur der
+aktuelle Benutzer angezeigt.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/show-library.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/show-library.md
@@ -1,0 +1,57 @@
+---
+id: show-library
+title: Show Library - das Show-Verzeichnis
+sidebar_label: Show Library - das Show-Verzeichnis
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Im Fenster 'Show Library' (Show-Verzeichnis) werden sämtliche Details
+und Bestandteile der programmierten Show übersichtlich angezeigt. Dies
+dient insbesondere zum Transferieren solcher Details zwischen mehreren
+Shows - auch auf Pulte mit weniger Fader/Tasten - , ist aber auch eine
+gute Übersicht beim Verschieben innerhalb einer Show.
+
+Zum Öffnen drücken Sie zweimal auf 
+[<Keys.HardKey>Open/View</Keys.HardKey>](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster) 
+und wählen <Keys.SoftKey>Show Library</Keys.SoftKey> (im Hauptmenü können Sie auch <Keys.SoftKey>Open Workspace Window</Keys.SoftKey> 
+drücken und <Keys.SoftKey>Show Library</Keys.SoftKey> aus der Liste bei den Menütasten wählen).
+
+## Der Reiter Show Library
+
+Auf dem Reiter 'Show Library' werden sämtliche programmierten Elemente
+der Show, die gepatchten Geräte, Gruppen, Paletten, Playbacks, Macros
+und Workspaces angezeigt. Auf der linken Seite gibt es mehrere Buttons,
+um die Anzeige nach verschiedenen Rubriken zu filtern und die anderen
+Elemente auszublenden.
+
+![Show Library](/docs/images/Show-Library.png)
+
+Die Elemente in der Show Library können zum Auswählen einfach angeklickt
+werden.
+
+## Shows zum Importieren mappen
+
+Klicken Sie oben rechts auf das '+' (Plus), so können Sie weitere Shows
+zum Importieren einzelner Elemente auswählen (mappen).
+
+Auf dem Reiter ‚Mapper' werden dabei die Geräte der importierten auf
+Geräte der aktuellen Show zugeordnet (gemappt). Daraufhin können dann
+die programmierten Elemente - etwa Paletten, Cues, Chaser etc. - in
+die aktuelle Show [importiert werden](../titan-basics/loading-and-saving-shows.md#teile-aus-anderen-shows-importieren).
+
+## Der Reiter Users (Benutzer)
+
+Damit können Benutzer angelegt/ausgewählt werden. Identisch mit der
+Option <Keys.SoftKey>Users</Keys.SoftKey> im <Keys.HardKey>Disk</Keys.HardKey>-Menü.
+
+## Der Reiter Key Profiles (Tastenprofile)
+
+Auf dem Reiter [Key Profiles](../system-settings/key-profiles.md) werden 
+die verschiedenen vorhandenen Key Profiles (Tastenprofile) angezeigt. 
+Links werden die Profile angezeigt, rechts sind die jeweiligen 
+Funktionszuordnungen der Tasten aufgeführt. Dies ist nur eine Anzeige -
+ein Ändern der Tastenprofile ist hier nicht möglich.
+
+![Key Profiles](/docs/images/Key-Profiles.png)

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/titan-simulator.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/titan-simulator.md
@@ -1,0 +1,73 @@
+---
+id: titan-simulator
+title: Der Titan Simulator
+sidebar_label: Der Titan Simulator
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Soll vorab programmiert oder eine Show angepasst werden, ohne bereits
+ein Pult zu verwenden? Kein Problem, genau dazu dient der Titan
+Simulator. Damit lassen sich auf jedem normalen PC alle Typen von
+Titan-Pulten simulieren und Shows erstellen und verändern.
+
+> Zum Starten des Titan Simulators ist ein Editor AvoKey oder andere Avolites-Hardware erforderlich (T1, T2 oder Titan Mobile). Editor AvoKeys sind bei Ihrem lokalen Avolites-Vertrieb oder im Avolites-Webshop erhältlich.
+
+![titansimulator](/docs/images/Titan-Simulator.jpeg)
+
+## Den Titan Simulator installieren
+
+Sie müssen Administrator-Berechtigungen auf dem Computer haben, um den
+Titan Simulator zu installieren oder auszuführen. Ab Titan v12 ist für
+den Simulator ein Editor AvoKey oder ein angeschlossener T1, T2 oder Titan Mobile
+erforderlich.
+
+> Zu den Systemanforderungen siehe [Inbetriebnahme von T3/Titan Mobile und T1/T2](../titan-basics.md#inbetriebnahme-von-t3titan-mobile-und-t1t2).                 
+
+- Capture verlangt dabei eine leistungsstarke Grafikkarte. Sollten dabei 
+Probleme auftreten, stellen Sie bitte sicher, die aktuellsten Treiber
+für Ihre Grafikkarte installiert zu haben.   
+
+Laden Sie einfach die **Titan PC-Suite** herunter (verfügbar im
+Download-Bereich auf www.avolites.com) und installieren sie. Beim ersten
+Programmstart muss eventuell noch [der AvoKey lizenziert](../system-settings/recovering-reinstalling-the-console#software-lizenzierung) werden; folgen Sie dazu den
+Anweisungen des Authenticator-Hilfsprogramms, das automatisch startet.
+
+Einmal lizenziert, kann man die Software entweder als Titan Go oder als Titan Simulator starten:
+
+-   Wird die Software als Titan Go mit dem Editor AvoKey gestartet, so lässt sich nur ein
+    DMX-Universum über Artnet/sACN ausgeben. Mit einem T1/T2 werden
+    eine bzw. zwei Linien als DMX und über Netzwerk ausgegeben.
+
+-   Wird die Software als Titan Simulator gestartet (zu erkennen an der Anzeige 'Offline' rechts
+    oberhalb der Arbeitsfenster), so können sämtliche Pulte dargestellt
+    werden, auch lassen sich der Visualiser oder Art-Net-Knoten
+    verwenden. Allerdings werden in unregelmäßigen Abständen Störsignale
+    an die Ausgänge geschickt (der sog. Spoiler). Dann einfach ein paar
+    Sekunden warten, bevor mit dem Programmieren weitergemacht wird.
+
+## Verwenden des Titan Simulator
+
+Beim Start des Titan Simulators können Sie das zu emulierende Pult
+wählen. Daraufhin erscheint ein Fenster mit dem 'Virtual Panel'
+(virtuelle Pultoberfläche), sowie weitere Fenster mit den
+Monitorausgängen der gewählten Konsole.
+
+> Der Inhalt des Touchscreens wird jeweils in einem separaten Fenster gezeigt. Es empfiehlt sich daher, mit mehreren Monitoren zu arbeiten.
+
+Das 'Virtual Panel' arbeitet wie die richtige Pultoberfläche. Um eine
+Taste gedrückt zu halten (für Tastenkombinationen), klicken Sie diese
+mit der rechten Maustaste.
+
+## Verwenden des Virtuellen Panels mit dem Pult
+
+Das virtuelle Panel ist nicht nur für den Visualiser wichtig, sondern
+kann auch sonst auf dem Pult hilfreich sein. Wenn etwa aus irgendwelchen
+Gründen die Pult-Hardware defekt sein sollte (auch wenn nur z.B.
+einzelne Fader oder Knöpfe betroffen sind), kann man damit immer noch
+das Pult bedienen.
+
+Das Virtuelle Panel wird über das Tools-Menü gestartet: Tools-\>Other
+Programs-\>Virtual Panel. Die Steuerelemente wirken parallel zu den
+'echten' Bedienelementen des Pultes.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/titan-simulator.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/titan-simulator.md
@@ -12,7 +12,7 @@ ein Pult zu verwenden? Kein Problem, genau dazu dient der Titan
 Simulator. Damit lassen sich auf jedem normalen PC alle Typen von
 Titan-Pulten simulieren und Shows erstellen und verändern.
 
-> Zum Starten des Titan Simulators ist ein Editor AvoKey oder andere Avolites-Hardware erforderlich (T1, T2 oder Titan Mobile). Editor AvoKeys sind bei Ihrem lokalen Avolites-Vertrieb oder im Avolites-Webshop erhältlich.
+> Zum Starten des Titan Simulators ist ein Editor AvoKey oder andere Avolites-Hardware erforderlich (T1, T2, T3 oder Titan Mobile). Editor AvoKeys sind bei Ihrem lokalen Avolites-Vertrieb oder im Avolites-Webshop erhältlich.
 
 ![titansimulator](/docs/images/Titan-Simulator.jpeg)
 
@@ -20,7 +20,7 @@ Titan-Pulten simulieren und Shows erstellen und verändern.
 
 Sie müssen Administrator-Berechtigungen auf dem Computer haben, um den
 Titan Simulator zu installieren oder auszuführen. Ab Titan v12 ist für
-den Simulator ein Editor AvoKey oder ein angeschlossener T1, T2 oder Titan Mobile
+den Simulator ein Editor AvoKey oder ein angeschlossener T1, T2, T3 oder Titan Mobile
 erforderlich.
 
 > Zu den Systemanforderungen siehe [Inbetriebnahme von T3/Titan Mobile und T1/T2](../titan-basics.md#inbetriebnahme-von-t3titan-mobile-und-t1t2).                 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/workspace-windows.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/workspace-windows.md
@@ -1,0 +1,419 @@
+---
+id: workspace-windows
+title: Arbeitsfenster
+sidebar_label: Arbeitsfenster
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Der Hauptbereich der Programmoberfläche enthält die Arbeitsfenster.
+Diese wiederum enthalten Buttons (berührungsempfindliche Flächen) zur
+Auswahl von Geräten, Gruppen, Paletten, Playbacks usw. Auch der
+Visualiser wird hier gezeigt. Es gibt für so ziemlich jeden Aspekt
+spezielle Fenster.
+
+Die Fenster können frei angeordnet werden, und es können mehrere
+Monitore verwendet werden. Die Zusammenstellung der Fenster kann als
+Workspace (Arbeitsumgebung) gespeichert werden. Arbeitsumgebungen können
+für einzelne Fenster, einzelne Bildschirme oder alles gemeinsam gelten.
+So kann man die Oberfläche des Pultes durch einen Klick verändern.
+
+Das folgende Bild zeigt eine typische Kombination mehrerer Fenster.
+
+![Workspaces](/docs/images/Titan-Touch-Screen-User-Interface.png)
+
+## Auswahl und Positionierung der Arbeitsfenster
+
+Drücken Sie zweimal auf die Taste <Keys.HardKey>View</Keys.HardKey> (heißt auf manchen 
+Pulten <Keys.HardKey>Open</Keys.HardKey> oder <Keys.HardKey>Open Window</Keys.HardKey> - 
+in diesem Handbuch heißt die Taste daher <Keys.HardKey>Open/View</Keys.HardKey>). Daraufhin 
+wird auf allen Displays ein Overlay mit Buttons für die einzelnen Fenster angezeigt. Klicken 
+Sie auf den Button des gewünschten Fensters auf dem Display, auf dem es gezeigt werden soll.
+
+- Diamond 9/Diamond 7: <Keys.HardKey>View</Keys.HardKey>. Außerdem gibt es die Taste <Keys.HardKey>Open</Keys.HardKey>, 
+mit der gleichen Funktion wie ein Doppelklick auf <Keys.HardKey>View</Keys.HardKey>.
+
+- Quartz, Titan Mobile: <Keys.HardKey>Open</Keys.HardKey>
+
+- T3, Titan Go, Tiger Touch 1, Pearl Expert: <Keys.HardKey>View</Keys.HardKey>
+
+
+![Workspace Window Selection](/docs/images/Workspace-Windows-Icons.png)
+
+War das Fenster bereits auf einem anderen Display geöffnet, so wechselt
+es mit der gleichen Größe und Position auf den gewünschten Bildschirm.
+
+Ebenso können Fenster mit der Menütaste <Keys.SoftKey>Open Workspace Window</Keys.SoftKey>
+geöffnet werden. Drückt man ein weiteres Mal auf <Keys.HardKey>Open/View</Keys.HardKey>, so wird
+das Overlay wieder ausgeblendet. Dazu kann man auch auf das <Keys.ContextKey>X</Keys.ContextKey>
+rechts oben auf dem Bildschirm klicken.
+
+Die wichtigsten Fenster lassen sich zudem per Tastenkombination
+aufrufen.
+
+### Tastenkombinationen zur Fensterauswahl
+
+-   <Keys.HardKey>Open/View</Keys.HardKey> und eine Attributbank-Taste öffnet das jeweilige
+    Palettenfenster
+
+
+
+-   <Keys.HardKey>Open/View</Keys.HardKey> + <Keys.HardKey>Patch</Keys.HardKey> öffnet die Patch-Ansicht.
+
+-	Drücken Sie <Keys.HardKey>Open/View</Keys.HardKey>, gefolgt von der Schaltfläche eines
+	gepatchten Gerätes, so öffnet sich die Geräteanzeige mit Details zu dem
+	jeweiligen Gerät.
+
+
+-	<Keys.HardKey>Open/View</Keys.HardKey> + <Keys.HardKey>Connect / Cue</Keys.HardKey> öffnet das Fenster 'Playback View'.
+
+
+-	<Keys.HardKey>Open/View</Keys.HardKey> + <Keys.HardKey>Off</Keys.HardKey> öffnet das Fenster 'Active Playbacks'.
+
+
+-	<Keys.HardKey>Open/View</Keys.HardKey> + <Keys.HardKey>Macro</Keys.HardKey> öffnet das Fenster 'Macros'.
+
+### Schaltflächen für die Einrichtung der Fenster
+
+Oben rechts in der Titelleiste verfügt jedes Fenster über drei oder vier
+Schaltflächen, über die weitere Funktionen erreichbar sind.
+
+Mit den **Optionen für die Arbeitsfenster** (zu öffnen mit dem kleinen <Keys.ContextKey>Zahnrad</Keys.ContextKey>)
+können Größe und Position der Fenster auf verschiedene Standardwerte
+gesetzt und die Größe der Schaltflächen sowie die Schriftgröße für jedes
+Fenster getrennt eingestellt werden. Die verfügbaren und angezeigten
+Elemente hängen vom jeweiligen Fenster sowie der Einrichtung des Pultes
+ab, etwa davon, ob ein externer Bildschirm angeschlossen ist. Mit den
+Buttons für Rows (Zeilen) und Columns (Spalten) kann man einstellen, wie
+die Tasten in dem Fenster angezeigt werden, siehe [Einstellen von Anzahl 
+und Größe der Buttons](../titan-basics/workspace-windows.md#anzahl-und-grösse-der-schaltflächenraster).
+
+![Appearance Menu](/docs/images/Window-Appearance-Options.png)
+
+Die Fenster lassen sich sowohl in Standard-Größen und Positionen
+anordnen als auch sehr frei verändern. Dazu dient der Button <Keys.ContextKey>Resize Window</Keys.ContextKey>.
+
+![Resize](/docs/images/Resize.png)
+
+Steht die Option <Keys.SoftKey>Edit All Windows</Keys.SoftKey> auf Off, so wird jeweils nur ein
+Fenster verändert.
+
+Klicken und ziehen Sie die obere linke oder die untere rechte Ecke des
+Fensters, um dessen Größe zu ändern. Klickt und zieht man dagegen
+irgendwo anders auf dem Bildschirm, so wird dort das Fenster neu
+aufgezogen
+
+Klicken Sie irgendwohin, so wird das Fenster dort platziert und rot
+dargestellt, bis zur Platzierung der gegenüberliegenden Ecke nochmals
+woanders geklickt wird.
+
+Steht die Option <Keys.SoftKey>Resize Neighbours</Keys.SoftKey> (Nachbarn anpassen) auf On
+(Vorgabe), so werden beim Ziehen einer Ecke angrenzende Fenster soweit
+wie möglich mit verändert, um Überlappungen zu vermeiden. Steht diese
+Option dagegen auf ‚Off', so wird jeweils nur das bearbeitete Fenster
+verändert, und alle anderen bleiben unverändert.
+
+Schaltet man <Keys.SoftKey>Edit All Windows</Keys.SoftKey> (Alle Fenster editieren) auf On, so
+werden bei allen Fenstern Ecken angezeigt, und man kann ein beliebiges
+Fenster verändern. Zum Abschluss drücken Sie dann wieder <Keys.HardKey>EXIT</Keys.HardKey>,
+&nbsp;<Keys.HardKey>ENTER</Keys.HardKey> oder <Keys.SoftKey>OK</Keys.SoftKey>.
+
+![Resize](/docs/images/Resize-2.png)
+
+> Wurde beim freien Positionieren ein Fenster versehentlich so klein gemacht, dass der Button für die Größe nicht mehr erreichbar ist, so ist die einfachste Lösung, mit der <Keys.HardKey>Min/Max</Keys.HardKey>-Taste (bzw. Funktion) dieses Fenster wieder ganz groß zu machen und nochmals zu verändern. Bei der PC-Suite (Titan One etc.) bietet sich die Taste F4 der Computertastatur an.
+
+Zum Verschieben des aktiven Fensters zwischen externem Monitor und
+Bildschirm klicken Sie in den Fenster-Optionen auf das gewünschte
+Display, oder Sie drücken <Keys.HardKey>Open/View</Keys.HardKey>, dann <Keys.SoftKey>Window Options</Keys.SoftKey>, und
+schließlich <Keys.SoftKey>Move Screen</Keys.SoftKey>, oder Sie nutzen die 
+Tastenkombination <Keys.HardKey>AVO</Keys.HardKey>+<Keys.HardKey>Size/Position</Keys.HardKey>.
+
+Aktive Fenster lassen sich mit der Taste <Keys.HardKey>Close</Keys.HardKey> schließen. Zum
+gleichzeitigen Schließen aller Fenster drücken Sie <Keys.HardKey>AVO</Keys.HardKey>+<Keys.HardKey>Close</Keys.HardKey>,
+oder Sie nutzen die Menütaste <Keys.SoftKey>Close All</Keys.SoftKey>.
+
+### Die Kontext-Schaltflächen/Buttons
+
+Auf allen Pulten außer dem Sapphire Touch und Titan Go werden je nach aktivem
+Fenster verschiedene Funktionsbuttons im Kontext-Bereich angezeigt. 
+Auf dem Diamond 9 befindet sich der Kontext-Bereich links oben auf dem rechten Display,
+beim Quartz, Arena und Tiger Touch rechts unterhalb des Info-Bereichs.<br/>
+Die angezeigten Funktionen wechseln je nachdem welches Fenster gerade aktiv ist. 
+Im folgenden Bild wird die Anzeige bei aktivem Patch-View-Fenster dargestellt:
+
+![Context Menu](/docs/images/Context-Menu.png)
+
+Beim D7, Sapphire Touch und Titan Go gibt es extra eine Schaltfläche <Keys.ContextKey>Context Menu</Keys.ContextKey>
+in der Titelleiste jedes Fensters, mit der das **Kontext-Menü** eingeblendet werden kann.
+
+![Patch View](/docs/images/Patch-View-2.png)
+
+### Anzahl und Größe der Schaltflächen/Raster
+
+Normalerweise wird die Größe der Buttons automatisch an die
+Bildschirmgröße angepasst, was z.B. dazu führt, dass sich bei
+unterschiedlichen Bildschirmgrößen die Anzahl der Buttons pro
+Zeile/Spalte - und damit ggf. die ganze Anordnung - ändert. Um dies zu
+verhindern (z.B. wenn im Geräte-Fenster die Anordnung an den
+tatsächlichen Aufbau angepasst wurde), kann man alternativ in den
+Fenster-Optionen (dazu auf das <Keys.ContextKey>Zahnrad</Keys.ContextKey> klicken) mit <Keys.ContextKey>Button Size Set Rows & Columns</Keys.ContextKey>; die gewünschte Anzahl der angezeigten Zeilen <Keys.ContextKey>Columns</Keys.ContextKey> 
+und Spalten <Keys.ContextKey>Rows</Keys.ContextKey> fest vorgeben. Damit wird immer die gewünschte 
+Anzahl an Schaltflächen angezeigt, wobei sich deren Größe entsprechend ändert.
+
+![Rows and Columns](/docs/images/Rows-and-Columns.png)
+
+Die eingegebene Anzahl von Spalten/Zeilen wird gespeichert, so dass man
+testweise zwischen einem fixen und einem variablen Layout hin- und
+herschalten kann.
+
+## Speichern der Arbeitsumgebung
+
+Mit gespeicherten Arbeitsumgebungen lässt sich die Darstellung des
+gesamten Displays durch nur einen Klick ändern/wiederherstellen.
+
+Sie können verschiedene Arbeitsumgebungen (Workspaces) zum schnellen
+Abruf auf den 'Workspace'-Schaltflächen (links vom Hauptmenü, bzw.
+am Bildschirmrand, abhängig vom Pult) abspeichern.
+
+![Workspaces](/docs/images/Recoding-a-Workspace-Layout.png)
+
+Auf externen Bildschirmen gibt es ebenfalls jeweils einen
+Workspace-Bereich (kann per [Benutzereinstellung](../system-settings/user-settings.md#display) deaktiviert werden).
+
+Um einen Workspace zu speichern, drücken Sie die Taste <Keys.HardKey>Open/View</Keys.HardKey>,
+dann <Keys.SoftKey>Record Workspace</Keys.SoftKey>, und schließlich eine der
+'Workspace'-Schaltflächen, oder führen Sie einen Doppelklick auf einer
+solchen Schaltfläche aus. Arbeitsumgebungen/Workspaces lassen sich auch
+auf graue Tasten des Pultes sowie Macro-Tasten speichern.
+
+Dabei lässt sich sehr genau bestimmen, wie neu geöffnete mit bereits
+vorhandenen Fenstern interagieren. Außerdem können einzelne Fenster
+spezifisch für bestimmte Displays festgelegt werden.
+
+-   <Keys.SoftKey>Record Visible/All Windows</Keys.SoftKey> (sichtbare/alle Fenster speichern)
+    bestimmt, ob nur die aktiven (sichtbaren), oder aber alle (auch die
+    verborgenen) Fenster in der Arbeitsumgebung gespeichert werden
+    sollen (diese Option steht beim Schnellspeichern per Doppelklick nicht zur Verfügung).
+
+-   <Keys.SoftKey>Remove/Leave other windows on recall</Keys.SoftKey> (beim Aufruf andere Fenster
+    schließen/behalten) definiert, ob beim Aufruf der Arbeitsumgebung
+    andere Fenster geöffnet bleiben oder geschlossen werden sollen. Ist
+    dies auf ‚Remove' (Schließen) gestellt, wird das im Workspace mit
+    einem X angezeigt.
+	
+	![Workspaces](/docs/images/Workspace-Layout-Button-Letters-X.png)
+
+-   <Keys.SoftKey>Screens= </Keys.SoftKey> bestimmt, ob der Workspace alle oder nur einzelne
+    Displays beinhalten soll.
+
+-   <Keys.SoftKey>Recall as Recorded/Where Selected</Keys.SoftKey> erscheint nur, wenn nur
+    einzelne Displays gespeichert werden. ‚as Recorded' wird dann mit
+    einem S und einer Nummer angezeigt und bedeutet, dass die Fenster
+    auf diesem Screen gespeichert sind bzw. geöffnet werden. ‚where
+    selected' dagegen wird mit einem stilisierten Fadenkreuz in der rechten oberen Ecke angezeigt,
+    und die Fenster werden auf dem Display geöffnet, auf dem dieser
+    Workspace aufgerufen wurde.
+	
+![Workspaces](/docs/images/Workspace-Layout-Button-Letters.png)
+
+-   Zum Löschen einer Arbeitsumgebung drücken Sie <Keys.HardKey>Open/View</Keys.HardKey>, <Keys.HardKey>Delete</Keys.HardKey>, und dann die Schaltfläche der Arbeitsumgebung.
+
+-   Drückt man beim Aufrufen eines Workspace zuerst auf <Keys.HardKey>Open/View</Keys.HardKey>
+    und dann auf den Workspace-Button, so kann man mit den Menütasten
+    bestimmen, ob die Fenster <Keys.SoftKey>As Recorded</Keys.SoftKey> (wie gespeichert) oder
+    aber auf einem bestimmten Display aufgehen sollen. Damit kann man
+    auch Workspaces, die für einen anderen Bildschirm gespeichert
+    wurden, auf dem aktuellen Display verwenden.
+	
+Die Bildschirme werden dabei wie folgt nummeriert:
+
+>  - Bei Pulten mit einem internen Screen ist dieser Screen 1 und ein eventuell vorhandenes externes Display Screen 2.<br/>
+  - Beim Diamond 9 ist der rechte Touchscreen Screen 1, der mittlere ist Screen 2, der linke ist Screen 3 (D9-330), der Editor-Touchscreen ist Screen 4, die Video-Previews sind 7, 6, 5, und extrne Displays sind 9 (links) und 8 (rechts).<br/>
+  - Beim Diamond 7 ist der rechte Touchscreen Screen 1, der mittlere ist Screen 2, der linke ist Screen 3 (nicht beim D7-215).
+  - Beim Arena ist das große interne Display Screen 1, das kleine interne ist Screen 2, und ein eventuell vorhandenes externes ist Screen 3.<br/>
+  - Beim Sapphire Touch ist das rechte Display Screen 1, das linke Screen 2, und eventuell vorhandene externe Displays sind Screen 3 und 4.    
+
+Als Beispiel sei einmal angenommen, zum Programmieren seien die Fenster
+'Fixtures' (Geräte), 'Position Palettes' (Positionspaletten), 'Fixture
+Attributes' (Geräteattribute) und 'Shapes' benötigt:
+
+1.  Drücken Sie zweimal auf <Keys.HardKey>Open/View</Keys.HardKey>, oder drücken Sie 
+ggf. <Keys.HardKey>Exit</Keys.HardKey>, um ins Hauptmenü zu gelangen, und dann die 
+Funktionstaste <Keys.SoftKey>Open Workspace Window</Keys.SoftKey>.
+
+2.  Klicken Sie auf dem eingeblendeten Overlay den Button <Keys.ContextKey>Fixtures</Keys.ContextKey>.
+
+3.  Öffnet sich das Fenster nicht in der oberen linken Ecke des
+Touchscreens, so drücken Sie die Taste <Keys.HardKey>Size/Position</Keys.HardKey> so oft, bis es
+dort platziert ist. Oder klicken Sie in der Titelleiste des Fensters auf
+das kleine <Keys.ContextKey>Zahnrad</Keys.ContextKey> und platzieren Sie damit das Fenster entsprechend.
+
+4.  Betätigen Sie wieder zweimal <Keys.HardKey>Open/View</Keys.HardKey> und wählen den 
+Eintrag <Keys.ContextKey>Positions</Keys.ContextKey>. Bewegen Sie dieses Fenster 
+mit <Keys.HardKey>Size/Position</Keys.HardKey> an die gewünschte Stelle.
+
+5.  Aktivieren Sie auf die gleiche Weise die Fenster <Keys.ContextKey>Attribute
+Editor</Keys.ContextKey> und <Keys.ContextKey>Effects</Keys.ContextKey>.
+
+6.  Drücken Sie <Keys.HardKey>Open/View</Keys.HardKey>, dann <Keys.SoftKey>Record Workspace</Keys.SoftKey>, 
+oder <Keys.HardKey>AVO</Keys.HardKey> + <Keys.HardKey>Open/View</Keys.HardKey>. 
+Geben Sie einen Namen für diese Arbeitsumgebung
+ein, und klicken Sie auf die 'Workspace'-Schaltfläche, auf die die
+aktuelle Arbeits­umgebung gespeichert werden soll. Alternativ nutzen Sie
+die ‚Quick Record' (Schnellspeicher)-Funktion: klicken Sie einfach auf
+eine freie ‚Workspace'-Schaltfläche, woraufhin diese rot hervorgehoben
+wird und ein ‚+'-Zeichen zeigt. Geben Sie nun einen Namen ein, und
+klicken Sie erneut auf diese Schaltfläche.
+
+## Schnellspeichern
+
+![Quick Record](/docs/images/Recoding-a-Workspace-Layout.png)
+
+Einige Fenster - für Gruppen, Workspaces sowie die Paletten-Fenster - besitzen eine
+Schnellspeicher-Funktion. Nehmen Sie Ihre Einstellungen vor, und klicken
+Sie einmal auf eine freie Schaltfläche. Diese wird nun rot und mit einem
+Pluszeichen (+) markiert. Nun lässt sich eine Bezeichnung (legend)
+eingeben. Danach nochmals die Schaltfläche betätigen, um das Speichern
+abzuschließen.
+
+Die Schnellspeicher-Funktion lässt sich in den [Tastenprofilen/Key Profiles](../system-settings/key-profiles.md) deaktivieren.
+
+Bei Paletten ist zu beachten, dass die Schnellspeicherfunktion etwas
+anders arbeitet als das Speichern mit der <Keys.HardKey>Record</Keys.HardKey>-Taste, 
+siehe [Speichern von Paletten](../palettes/creating-palettes.md#speichern-einer-palette): beim Schnellspeichern 
+wird automatisch eine Speichermaske angewandt abhängig davon, in welches Palettenfenster gespeichert wird.
+
+## Legenden und Bezeichnungen
+
+Sämtliche Schaltflächen lassen sich mit frei zu definierenden Legenden
+beschriften, um die Übersicht zu behalten. Ferner lassen sich die
+Schaltflächen auch bemalen. Dazu drücken Sie zunächst <Keys.SoftKey>Set Legends</Keys.SoftKey>
+und wählen dann <Keys.SoftKey>Picture</Keys.SoftKey>; daraufhin öffnet sich ein entsprechendes
+Zeichen-Fenster. Außerdem gibt es bereits eine umfangreiche Bibliothek
+vorgefertigter Zeichnungen.
+
+Farb-Paletten erhalten automatisch eine Legende mit der entsprechenden
+Farbe. Ebenso erhalten Gobo-Paletten ein Bild des Gobos, sofern die
+Personality die entsprechenden Informationen enthält.
+
+![Gobos and Beams Workspace Window](/docs/images/Gobos-and-Beams-Workspace-Window.png)
+
+## Button-Halo
+
+Sämtlichen programmierbaren Schaltflächen, etwa den Buttons für Geräte,
+Gruppen, Paletten, Playbacks etc., lassen sich farbige Ränder, sog.
+Halos, zuweisen. Damit lassen sich diese auch optisch noch besser
+unterscheiden. Zum Einstellen dieses Halos dient die Option <Keys.SoftKey>Halo</Keys.SoftKey> im
+Legenden-Menü.
+
+![Halo](/docs/images/Fixture-Halo.png)
+
+Wird ein [Halo für Geräte-Tasten](../patching/changing-the-patch.md#halo-für-fixture-buttons) aktiviert, 
+so wird dessen Farbe auch in anderen Fenstern verwendet. Außerdem können 
+automatisch unterschiedliche Halos pro Gerätetyp vergeben werden, die
+dann auch in der Patch-Ansicht verwendet werden.
+
+Auf dem Diamond 9 und Diamond 7 wird die Halo-Farbe auch zur Anzeige des Faderwerts und für die Playback-Auswahltaste verwendet.
+
+## Bildschirmtastatur
+
+Am Ende der Werkzeugleiste (am Mittelsteg zwischen den Bildschirmen beim
+Sapphire Touch, ansonsten oben im Bildschirm) befindet sich der Button
+zum Aufrufen der Bildschirmtastatur.
+
+![Keyboard Button](/docs/images/Keyboard-Button.png)
+
+Die Bildschirmtastatur kann mit der Schaltfläche <Keys.ContextKey>Max/Min</Keys.ContextKey> zwischen großen
+und kleinen Tasten umgeschaltet werden; mit der Schaltfläche <Keys.ContextKey>X</Keys.ContextKey> wird
+sie geschlossen. Per Anklicken und Ziehen des freien Bereiches oben in
+der Bildschirmtastatur lässt sich diese frei positionieren.
+
+Soll die Tastatur automatisch erscheinen, sobald eine Texteingabe
+erforderlich ist, so kann das mittels <Keys.ContextKey>Man/Auto</Keys.ContextKey> eingestellt werden. Diese
+Einstellung bleibt auch beim Schließen der Tastatur aktiv, bis sie
+wieder geändert wird.
+
+Die kleine Darstellung der Tastatur (siehe Abbildung) verzichtet auf
+einige weniger gebräuchliche Tasten.
+
+![Keyboard](/docs/images/Keyboard.png)
+
+## Trackball (nur beim Diamond 9 und Sapphire Touch)
+
+Mit dem Trackball rechts auf dem Pult lässt sich entweder die Maus
+steuern, oder die selektierten Geräte.
+
+Zur Auswahl des Maus-Modus halten Sie die Taste <Keys.HardKey>Assign</Keys.HardKey> (unterhalb
+des Trackballs) gedrückt und betätigen dazu die Taste <Keys.HardKey>Left</Keys.HardKey> (für: linke
+Maustaste). Nun steuert der Trackball die Position des Mauszeigers auf
+den Bildschirmen; mit dem Ring um den Trackball kann in den Fenstern
+gescrollt werden.
+
+Um in den Modus zur Gerätesteuerung zu schalten, drücken Sie <Keys.HardKey>Assign</Keys.HardKey> + <Keys.HardKey>Right</Keys.HardKey>: nun steuert der Trackball Pan und Tilt, und mit
+dem Ring kann Tilt sehr fein geregelt werden. Siehe [Verwenden des Trackballs](../controlling-fixtures/changing-fixture-attributes.md#der-trackball-diamond-9-und-sapphire-touch).
+
+## Video-Vorschau (nur beim Diamond 9)
+
+In den drei kleinen Displays oben rechts auf dem Pult lassen sich sowohl NDI-Videostreams als auch weitere 
+Arbeitsfenster anzeigen.
+
+![Diamond Media Preview](/docs/images/Diamond-Media-Preview.png)
+
+Um ein Display einzurichten, doppelklicken Sie <Keys.HardKey>Open/View</Keys.HardKey>, woraufhin auf allen Displays 
+Buttons der verfügbaren Fenster eingeblendet werden. Zur Anzeige der Videovorschau wählen Sie 
+**Video Preview** (1, 2 oder 3 je nach dem gewünschten Display). Zur Auswahl des anzuzeigenden NDI-Streams 
+klicken Sie auf das Display, darauf werden Miniaturansichten der verfügbaren Streams angezeigt. Klicken Sie nun den gewünschten an. Für weitere Details dazu siehe [Media Viewer](../synergy/operating-synergy.md#media-viewer).
+
+## Mini-Display (Nur beim Arena)
+
+Das Mini-Display kann genau wie der große Touchscreen zur Anzeige verschiedener Fenster dienen. Um dies einzurichten,
+ doppelklicken Sie <Keys.HardKey>Open/View</Keys.HardKey>, woraufhin auf allen Displays 
+Buttons der verfügbaren Fenster eingeblendet werden. Klicken Sie nun auf dem Mini-Display auf den 
+Icon des gewünschten Fensters.
+
+Mit der Taste <Keys.HardKey>Display</Keys.HardKey> unterhalb der Encoder rechts oben kann man 
+zwischen vier Ansichten auf dem Mini-Display umschalten:
+
+- Arbeitsfenster mit Legenden für die Encoder
+![Arena Miniscreen](/docs/images/Arena-Miniscreen.png)
+
+- Arbeitsfenster mit Legenden für die Macro-/Executortasten
+![Mini Screen Macros](/docs/images/Mini-Screen-Macros.png)
+
+- Fenster "feste Playbacks" - Dieses Fenster kann nicht auf den anderen
+Bildschirm verschoben werden, und andere Fenster überlagern es nicht.
+Die ersten beiden Zeilen sind identisch mit den Macro-/Executortasten
+darunter.
+
+- Arbeitsfenster, ohne Legenden für Encoder oder Macrotasten.
+
+## Lock und Venue Mode -- das Pult ganz oder teilweise sperren
+
+Das Pult lässt sich ganz oder teilweise sperren, um unbeabsichtigte oder unbefugte Eingriffe
+zu verhindern. Halten Sie dazu <Keys.HardKey>AVO</Keys.HardKey> gedrückt, und
+klicken Sie auf <Keys.SoftKey>Lock</Keys.SoftKey>, siehe [Das Pult sperren](../running-the-show.md#das-pult-sperren).
+
+Man kann einen bestimmten Workspace auswählen, der im 'Venue-Mode' angezeigt wird, dies ist der Venue Mode workspace. Damit kann man z.B. bestimmte Playbacks zur Bedienung freigeben, so dass das Personal zwar das Licht einschalten oder eine einfache Show starten, aber nichts weiter verändern kann.
+
+In den [Benutzereinstellungen](../system-settings/user-settings.md#lock) lässt sich festlegen, in welchem Modus das Pult bzw. die Software startet, so dass auch nach einem Neustart der richtige Modus aktiv ist.
+
+Siehe [Venue Mode Workspace](../running-the-show.md#eingeschränkter-zugriff-mit-dem-venue-mode).
+
+## Compatibility windows -- die 'Kompatibilitätsfenster'
+
+Die Fenster "Fixtures and Playbacks" (Geräte und Speicherplätze) und
+"Groups and Palettes" (Gruppen und Paletten) ermöglichen Zugriff auf die
+Speicherplätze/Tasten, die zwar auf einem Pearl Expert, nicht aber auf
+anderen Pulten vorhanden sind. Damit lassen sich also auch auf dem
+Expert erstellte Shows laden.
+
+Ist eins dieser Fenster geöffnet, gibt es die Schaltfläche <Keys.SoftKey>Move to workspace</Keys.SoftKey> im Kontextbereich. Damit lassen sich die betreffenden
+Schaltflächen in die richtigen Arbeitsfenster der anderen Titan-Pulte
+verschieben. Diesen Vorgang muss man zweimal ausführen: einmal mit
+ausgewähltem Fenster "Fixtures and Playbacks", und einmal mit "Palettes
+and Groups".
+
+
+
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/workspace-windows.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-basics/workspace-windows.md
@@ -31,12 +31,12 @@ in diesem Handbuch heißt die Taste daher <Keys.HardKey>Open/View</Keys.HardKey>
 wird auf allen Displays ein Overlay mit Buttons für die einzelnen Fenster angezeigt. Klicken 
 Sie auf den Button des gewünschten Fensters auf dem Display, auf dem es gezeigt werden soll.
 
-- Diamond 9/Diamond 7: <Keys.HardKey>View</Keys.HardKey>. Außerdem gibt es die Taste <Keys.HardKey>Open</Keys.HardKey>, 
+- D9/D7: <Keys.HardKey>View</Keys.HardKey>. Außerdem gibt es die Taste <Keys.HardKey>Open</Keys.HardKey>, 
 mit der gleichen Funktion wie ein Doppelklick auf <Keys.HardKey>View</Keys.HardKey>.
 
-- Quartz, Titan Mobile: <Keys.HardKey>Open</Keys.HardKey>
+- Quartz, Tiger Touch 2, Titan Mobile: <Keys.HardKey>Open</Keys.HardKey>
 
-- T3, Titan Go, Tiger Touch 1, Pearl Expert: <Keys.HardKey>View</Keys.HardKey>
+- D3, T3, Titan Go, Tiger Touch 1, Pearl Expert: <Keys.HardKey>View</Keys.HardKey>
 
 
 ![Workspace Window Selection](/docs/images/Workspace-Windows-Icons.png)
@@ -137,8 +137,8 @@ oder Sie nutzen die Menütaste <Keys.SoftKey>Close All</Keys.SoftKey>.
 
 Auf allen Pulten außer dem Sapphire Touch und Titan Go werden je nach aktivem
 Fenster verschiedene Funktionsbuttons im Kontext-Bereich angezeigt. 
-Auf dem Diamond 9 befindet sich der Kontext-Bereich links oben auf dem rechten Display,
-beim Quartz, Arena und Tiger Touch rechts unterhalb des Info-Bereichs.<br/>
+Auf dem D9 befindet sich der Kontext-Bereich links oben auf dem rechten Display,
+beim D3, Quartz, Arena und Tiger Touch rechts unterhalb des Info-Bereichs.<br/>
 Die angezeigten Funktionen wechseln je nachdem welches Fenster gerade aktiv ist. 
 Im folgenden Bild wird die Anzeige bei aktivem Patch-View-Fenster dargestellt:
 
@@ -355,15 +355,12 @@ dem Ring kann Tilt sehr fein geregelt werden. Siehe [Verwenden des Trackballs](.
 
 ## Video-Vorschau (nur beim Diamond 9)
 
-In den drei kleinen Displays oben rechts auf dem Pult lassen sich sowohl NDI-Videostreams als auch weitere 
-Arbeitsfenster anzeigen.
+In den drei kleinen Displays oben rechts auf dem Pult lassen sich weitere Arbeitsfenster anzeigen.
 
 ![Diamond Media Preview](/docs/images/Diamond-Media-Preview.png)
 
 Um ein Display einzurichten, doppelklicken Sie <Keys.HardKey>Open/View</Keys.HardKey>, woraufhin auf allen Displays 
-Buttons der verfügbaren Fenster eingeblendet werden. Zur Anzeige der Videovorschau wählen Sie 
-**Video Preview** (1, 2 oder 3 je nach dem gewünschten Display). Zur Auswahl des anzuzeigenden NDI-Streams 
-klicken Sie auf das Display, darauf werden Miniaturansichten der verfügbaren Streams angezeigt. Klicken Sie nun den gewünschten an. Für weitere Details dazu siehe [Media Viewer](../synergy/operating-synergy.md#media-viewer).
+Buttons der verfügbaren Fenster eingeblendet werden.
 
 ## Mini-Display (Nur beim Arena)
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-net.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-net.md
@@ -1,0 +1,27 @@
+---
+id: titan-net
+title: Der Titan Net Processor
+sidebar_label: Der Titan Net Processor
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Ein TNP (Titan Net Processor) kann entweder als Slave weitere DMX-Linien
+für ein Titan-Pult bereitstellen, oder im Stand-Alone-Modus als kompakte
+Pult-Lösung dienen, etwa zum Steuern einer auf einem anderen Pult
+programmierten Show, z.B. mit Hilfe von [beim Show-Start aktiven
+Autoload-Playbacks](cues/playback-options.md#run-on-startup).
+Ebenso kann der TNP als eigenständiges Pult (mit der Bedienoberfläche von Titan Go)
+verwendet werden, wobei sich der Anschluss eines externen Touchscreens
+empfiehlt.
+
+![Titan Net Processor](/docs/images/Titan-Net-Processor.jpeg)
+
+Zum Umschalten der Betriebsart dient die Toolbar am oberen Rand des
+Bildschirms mit der Option <Keys.SoftKey>Switch Software</Keys.SoftKey>.
+
+Modus | Bedeutung
+--- | ---
+TNP | Betrieb als Slave
+Console | Stand-Alone-Pultmodus

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-net/tnp-console-mode.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-net/tnp-console-mode.md
@@ -1,0 +1,65 @@
+---
+id: tnp-console-mode
+title: TNP im Stand-Alone-Pultbetrieb
+sidebar_label: TNP im Stand-Alone-Pultbetrieb
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Im Stand-Alone-Betrieb (Console Mode) kann ein TNP z.B. unbeaufsichtigt
+eine vorprogrammierte Show wiedergeben oder als Notfall-Backup dienen.
+Es lässt sich z.B. eine Show auf einem anderen Pult programmieren und
+dann in den TNP laden, oder man verbindet ein Pult oder Simulator mittels
+Multiuser-Session mit dem TNP.
+
+## Playbacks steuern
+
+Mittels des <Keys.SoftKey>View</Keys.SoftKey>-Buttons (nächster Absatz) kann die Anzeige der
+Playbacks aktiviert werden (Playbacks Grid).
+
+![Playback View on TNP](/docs/images/Playback-View-on-TNP.png)
+
+Dieses ist identisch mit dem Playbacks-Fenster in Titan-Pulten, und
+Playbacks können zum Aktivieren ganz einfach angeklickt werden.
+
+## Die Anzeige wählen
+
+Im Stand-Alone-Modus lässt sich die Anzeige auf dem Homescreen wählen:
+<Keys.SoftKey>Network Adapters</Keys.SoftKey> ist die normale Anzeige im 
+Slave-Modus, <Keys.SoftKey>Playbacks Grid</Keys.SoftKey> zeigt die Playbacks (s.o.), 
+und <Keys.SoftKey>Session View</Keys.SoftKey> blendet die derzeitige TitanNet-Session ein.
+
+![TNP View Screen](/docs/images/TNP-View-Screen.png)
+
+In der <Keys.SoftKey>Session View</Keys.SoftKey>-Anzeige wird gezeigt, wie der TNP gerade mit
+anderen Titan-Pulten in einer Session verbunden ist.
+
+![TNP Sessions View Screen](/docs/images/TNP-Sessions-View-Screem.png)
+
+## Die Anzeige sperren
+
+Die gewählte Anzeige wird auch gezeigt, wenn der TNP mittels <Keys.SoftKey>Lock</Keys.SoftKey>
+gesperrt ist. Werden gerade die Playbacks angezeigt, so lassen sich
+diese auch bei gesperrtem Bildschirm aktivieren. Der Button <Keys.SoftKey>Show Keypad</Keys.SoftKey> 
+blendet die Zifferntasten ein, mit denen der TNP wieder entsperrt werden kann.
+
+![TNP Locked Playback View Screen](/docs/images/TNP-Locked-Playback-View-Screen.png)
+
+## Shows laden und speichern, weitere Einstellungen
+
+Über den Button <Keys.SoftKey>Setup</Keys.SoftKey> kann man die Show speichern sowie eine andere
+laden. Ebenso lassen sich Netzwerkeinstellungen, Einstellungen für den
+Node sowie die Wahl der Anzeige vornehmen (s.o.).
+
+![TNP Setup Screen](/docs/images/TNP-Setup-Screen.png)
+
+Mit <Keys.SoftKey>Load Show</Keys.SoftKey> kann wie sonst auf den Pulten die zu ladende Show
+ausgewählt werden, siehe [Laden der Show](../titan-basics/loading-and-saving-shows.md).
+
+![TNP Setup/Load Show Screen](/docs/images/TNP-Setup-Load-Show-Screen.png)
+
+Mit <Keys.SoftKey>Save Show</Keys.SoftKey> kann die Show gespeichert werden, falls man Änderungen
+vorgenommen hat.
+
+![TNP Setup/Save Show Screen](/docs/images/TNP-Setup-Save-Show-Screen.png)

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-net/tnp-slave-mode.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-net/tnp-slave-mode.md
@@ -1,0 +1,60 @@
+---
+id: tnp-slave-mode
+title: TNP im Slave-Betrieb
+sidebar_label: TNP im Slave-Betrieb
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Normalerweise zeigt der TNP den 'Homescreen' mit Status und IP-Adressen
+der beiden Netzwerkports. Am oberen Rand sind verschiedene Buttons
+eingeblendet, über die Funktionen zum Konfigurieren des TNP erreichbar
+sind. Dabei geht es mit <Keys.SoftKey>Exit</Keys.SoftKey> stets zurück in das vorige Menü.
+
+![TNP Home Screen](/docs/images/TNP-Home-Screen.png)
+
+## Setup
+
+Im Setup-Menü lassen sich die IP-Adressen sowie generelle Eigenschaften
+des Nodes einstellen (<Keys.SoftKey>Network Settings</Keys.SoftKey> bzw. <Keys.SoftKey>Node Settings</Keys.SoftKey> anklicken).
+
+### Netzwerkeinstellungen
+
+Die Netzwerkeinstellungen können wie folgt geändert werden:
+
+1. Wählen Sie den gewünschten Netzwerkanschluss aus.<br/>
+  ![TNP - Setup - Network Settings Screen](/docs/images/TNP-Setup-Network-Settings-Screen.png)
+
+2. Als nächstes lässt sich DHCP aktivieren oder deaktivieren, die
+   IP-Adresse und Subnetz-Maske einstellen oder aber eine zufällige, aber
+   Artnet-kompatible Adresse wählen (2.\*.\*.\* oder 10.\*.\*.\*).<br/>
+   ![TNP - Setup - Network Settings - IP Settings Screen](/docs/images/TNP-Setup-Network-Settings-IP-Settings-Screen.png)
+
+3. Mit <Keys.SoftKey>Save Settings</Keys.SoftKey> werden die Einstellungen gespeichert.
+
+### Node-Einstellungen
+
+Als **Node Settings** (Node-Einstellungen) lässt sich derzeit die auf anderen Pulten
+angezeigte Farbe des Geräts sowie der Verbindungslinien einstellen, was
+die Identifizierung deutlich vereinfacht.
+
+![TNP - Setup - Node Settings - Node Line Colour Screen](/docs/images/TNP-Setup-Node-Settings-Node-Line-Colour-Screen.png)
+
+## Lock -- den TNP sperren
+
+Klickt man auf <Keys.SoftKey>Lock</Keys.SoftKey>, so kann auf einem Ziffernblock ein Code
+eingegeben werden, mit dem das Gerät gesperrt wird. Zum Entsperren muss
+der gleiche Code wieder eingegeben werden.
+
+![TNP Lock Screen](/docs/images/TNP-Lock-Screen.png)
+
+## Tools
+
+Derzeit gibt es nur einen Eintrag im Tools-Menü: den **Monitor**. Dieser
+erlaubt eine Übersicht über die aktuelle Auslastung des TNPs. Dabei kann
+entweder <Keys.SoftKey>Cycle Time</Keys.SoftKey> oder <Keys.SoftKey>Render Time</Keys.SoftKey> dargestellt werden.
+
+![TNP - Tools - Monitor - Cycle Time Screen](/docs/images/TNP-Tools-Monitor-Cycle-Time-Screen.png)
+
+

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-reference.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-reference.md
@@ -1,0 +1,188 @@
+---
+id: titan-reference
+title: Titan Befehlsreferenz
+sidebar_label: Titan Befehlsreferenz
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+Einige der hier aufgeführten Befehle müssen mit <Keys.HardKey>Enter</Keys.HardKey> abgeschlossen
+werden. Der besseren Lesbarkeit halber wurde das <Keys.HardKey>Enter</Keys.HardKey> hier jedoch
+weggelassen.
+
+<Keys.HardKey>Taste</Keys.HardKey> bedeutet eine wirkliche Taste.
+<Keys.SoftKey>Button</Keys.SoftKey> bedeutet eine Schaltfläche oder Menütaste.
+
+
+&#123; &#125; ist die Auswahl eines Speicherplatzes, z.B. &#123;Cue&#125; ist die blaue Auswahltaste
+eines Playbacks.
+
+Nummern/Zahlen werden mit den Zifferntasten eingegeben.
+
+Die verfügbaren Tasten sind teilweise je nach Pult unterschiedlich. Ist
+eine bestimmte Taste nicht vorhanden, so steht die Funktion meist als
+Makro zur Verfügung.
+
+Einige der Tasten haben auf älteren Pulten abweichende Bezeichnungen;
+diese sind hier aufgeführt:
+
+
+  Alter Name |  Neuer Name
+  -----------|------------
+  Connect    |  Cue
+  SET        |  TIME
+
+## Fixtures - Geräte
+
+Tastenfolge 										| Resultat
+---													| --- 
+<Keys.HardKey>Fixture</Keys.HardKey> 1 <Keys.HardKey>Through</Keys.HardKey> 10						| Auswahl der Geräte 1 bis 10.
+<Keys.HardKey>Fixture</Keys.HardKey> 1 <Keys.HardKey>Through</Keys.HardKey> 10 <Keys.HardKey>And</Keys.HardKey> 20 <Keys.HardKey>And</Keys.HardKey> 25	| Auswahl der Geräte 1 bis 10 sowie 20 und 25.
+<Keys.HardKey>Fixture</Keys.HardKey> 5 <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey>							| Dimmer von Gerät 5 auf 100%.	
+<Keys.HardKey>Fixture</Keys.HardKey> 1 <Keys.HardKey>Through</Keys.HardKey> 60 <Keys.HardKey>@</Keys.HardKey> 75				| Dimmer von Gerät 1 bis 60 auf 75%.
+<Keys.HardKey>Group</Keys.HardKey> 2 <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey>								| Dimmer von Gruppe 2 auf 100%.
+<Keys.HardKey>Group</Keys.HardKey> 2 <Keys.HardKey>@</Keys.HardKey> 75								| Dimmer von Gruppe 2 auf 75%.
+
+### Geräte mit Zellen (Sub Fixtures)
+
+Tastenfolge 										| Resultat
+---													| --- 
+<Keys.HardKey>.</Keys.HardKey> m												| Zelle m der gewählten Geräte wählen.
+<Keys.HardKey>.</Keys.HardKey>												| Alle Zellen der gewählten Geräte wählen.
+n <Keys.HardKey>.</Keys.HardKey>												| Alle Zellen des Geräts n.
+1 <Keys.HardKey>Through</Keys.HardKey> 5 <Keys.HardKey>.</Keys.HardKey> 2								| Zweite Zelle der Geräte 1 bis 5.
+<Keys.HardKey>.</Keys.HardKey> <Keys.HardKey>Through</Keys.HardKey> <Keys.HardKey>.</Keys.HardKey> j| Zellen 1 bis j der gewählten Geräte.									
+<Keys.HardKey>.</Keys.HardKey> m <Keys.HardKey>Through</Keys.HardKey>									| Zellen ab Zelle m der gewählten Geräte.
+<Keys.HardKey>.</Keys.HardKey> m <Keys.HardKey>Through</Keys.HardKey> <Keys.HardKey>.</Keys.HardKey>j | Zellen m bis j aller angewählten Geräte.
+n <Keys.HardKey>Through</Keys.HardKey> i<Keys.HardKey>.</Keys.HardKey> 								| Alle Zellen der Geräte n bis i
+n <Keys.HardKey>Through</Keys.HardKey> i<Keys.HardKey>.</Keys.HardKey>j								| Zelle j der Geräte n bis i
+n <Keys.HardKey>Through</Keys.HardKey> <Keys.HardKey>.</Keys.HardKey>j								| Zellen 1 bis j der Geräts n
+n <Keys.HardKey>.</Keys.HardKey> <Keys.HardKey>Through</Keys.HardKey>									| Alle Zellen der Geräte gleichen Typs ab Gerät n
+n <Keys.HardKey>.</Keys.HardKey> <Keys.HardKey>Through</Keys.HardKey> i								| Zellen 1 bis i des Geräts n
+n <Keys.HardKey>.</Keys.HardKey> <Keys.HardKey>Through</Keys.HardKey> i<Keys.HardKey>.</Keys.HardKey>j							| Zellen 1 bis j der Geräte n bis i
+
+## Select If -- Bedingte Auswahl
+
+Tastenfolge 										| Resultat
+---													| --- 
+<Keys.HardKey>Select If</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey><Keys.HardKey>@</Keys.HardKey>							| Alle Geräte mit Dimmer >0%.
+<Keys.HardKey>Select If</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>Through</Keys.HardKey> 50					| Alle Geräte mit Dimmer >50%.
+<Keys.HardKey>Select If</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> 50 <Keys.HardKey>Through</Keys.HardKey>					| Alle Geräte mit Dimmer <50%.
+
+## Record -- Speichern
+
+**<Keys.HardKey>Record</Keys.HardKey> &#123;Cueliste&#125; &#123;Cueliste&#125;**
+Anhängen an das Ende der Cueliste
+
+**<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey>**
+
+Mergen des Programmers in den gerade aktiven Cue der verbundenen Cueliste.
+
+**<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> 90.1**
+
+Mergen des Programmers in Cue 90.1 der verbundenen Cueliste (dieser Cue wird neu erstellt falls nicht vorhanden)
+
+**<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> 1 <Keys.HardKey>Through</Keys.HardKey> 10 <Keys.HardKey>And</Keys.HardKey> 20**
+
+Mergen des Programmers in Cues 1 bis 10 und 20 (nach dem <Keys.HardKey>Enter</Keys.HardKey> wählt man Kopieren/Mergen/Ersetzen oder drückt nochmals <Keys.HardKey>Enter</Keys.HardKey> zum Mergen)
+
+**<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Position</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey>**
+
+Mergen des Programmers (nur Position) in den gerade aktiven Cue.
+
+**<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Options</Keys.HardKey> <Keys.HardKey>Position</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey>**
+
+Mergen des Programmers (nur Position) in den gerade aktiven Cue.
+
+- Siehe [Updaten von Cues](./cue-lists/theatre-programming#updaten-von-cues) im Abschnitt Tipps für Theater-Programmierer für mehr Informationen zum Editieren von Cuelisten und zum Speichern von Cues.
+
+## Copy, Move -- Kopieren, Verschieben in Cuelisten
+
+**<Keys.HardKey>Copy</Keys.HardKey> &#123;Cueliste&#125; n <Keys.HardKey>Enter</Keys.HardKey>**
+
+Cue n an das Ende der Cueliste kopieren.
+
+**<Keys.HardKey>Copy</Keys.HardKey>/<Keys.HardKey>Move</Keys.HardKey> &#123;Cueliste&#125; 1 <Keys.HardKey>Through</Keys.HardKey> 10 <Keys.SoftKey>NOT</Keys.SoftKey> 5 <Keys.HardKey>And</Keys.HardKey> 20 <Keys.HardKey>@</Keys.HardKey> n**
+
+Kopieren/Verschieben der Cues 1,2,3,4,6,7,8,9,10,20 der Liste auf
+&#123;Cueliste&#125; und Einfügen hinter Cue n.
+
+**<Keys.HardKey>Copy</Keys.HardKey>/<Keys.HardKey>Move</Keys.HardKey> &#123;Cueliste&#125; 1 <Keys.HardKey>Through</Keys.HardKey> 10 <Keys.SoftKey>NOT</Keys.SoftKey> 5 <Keys.HardKey>And</Keys.HardKey> 20 <Keys.HardKey>Enter</Keys.HardKey> &#123;target playback&#125; n <Keys.HardKey>Enter</Keys.HardKey>**
+
+Kopieren/Verschieben der Cues 1,2,3,4,6,7,8,9,10,20 der Liste auf
+&#123;Cueliste&#125; und Einfügen am Ende der Cueliste.
+
+**<Keys.HardKey>Copy</Keys.HardKey>/<Keys.HardKey>Move</Keys.HardKey> &#123;Cueliste&#125; 1 <Keys.HardKey>Through</Keys.HardKey> 10 <Keys.SoftKey>NOT</Keys.SoftKey> 5 <Keys.HardKey>And</Keys.HardKey> 20 <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey>**
+
+**<Keys.HardKey>Copy</Keys.HardKey>/<Keys.HardKey>Move</Keys.HardKey> &#123;Cueliste&#125; 1 <Keys.HardKey>Through</Keys.HardKey> 10 <Keys.SoftKey>NOT</Keys.SoftKey> 5 <Keys.HardKey>And</Keys.HardKey> 20 <Keys.HardKey>Enter</Keys.HardKey> <Keys.HardKey>Enter</Keys.HardKey>**
+
+Kopieren/Verschieben der Cues 1,2,3,4,6,7,8,9,10,20 der Liste auf
+&#123;Cueliste&#125; und Einfügen am Ende der Cueliste.
+
+**<Keys.HardKey>Copy</Keys.HardKey>/<Keys.HardKey>Move</Keys.HardKey> &#123;Cueliste&#125; 1 <Keys.HardKey>Through</Keys.HardKey> 10 <Keys.SoftKey>NOT</Keys.SoftKey> 5 <Keys.HardKey>And</Keys.HardKey> 20 <Keys.HardKey>@</Keys.HardKey> &#123;target playback&#125; n**
+
+**<Keys.HardKey>Copy</Keys.HardKey>/<Keys.HardKey>Move</Keys.HardKey> &#123;Cueliste&#125; 1 <Keys.HardKey>Through</Keys.HardKey> 10 <Keys.SoftKey>NOT</Keys.SoftKey> 5 <Keys.HardKey>And</Keys.HardKey> 20 <Keys.HardKey>Enter</Keys.HardKey> &#123;target playback&#125; n <Keys.HardKey>Enter</Keys.HardKey>**
+
+Kopieren/Verschieben der Cues 1,2,3,4,6,7,8,9,10,20 der Liste auf
+&#123;Cueliste&#125; und Einfügen nach Cue n der Cueliste auf &#123;target
+playback&#125;.
+
+## Delete -- Löschen
+
+**<Keys.HardKey>Delete</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> n**
+
+Cue n der gerade verbundenen Cueliste löschen.
+
+## Include --  in den Speicher laden
+
+**<Keys.HardKey>Include</Keys.HardKey> <Keys.HardKey>Cue</Keys.HardKey> n**
+
+Cue n der gerade verbundenen Cueliste in den Programmierspeicher laden.
+
+## Times -- Zeiten
+
+**<Keys.HardKey>Time</Keys.HardKey> 5**
+
+5 Sekunden Einfadezeit.
+
+**<Keys.HardKey>Cue</Keys.HardKey> 3 <Keys.HardKey>Time</Keys.HardKey> 5**
+
+5 Sekunden Einfadezeit für Cue 3 der gerade verbundenen Liste.
+
+**<Keys.HardKey>Time</Keys.HardKey> <Keys.HardKey>Fixture</Keys.HardKey> 5**
+
+5 Sekunden Einfadezeit für alle Attribute der ausgewählten Geräte.
+
+**<Keys.HardKey>Time</Keys.HardKey> <Keys.HardKey>Fixture</Keys.HardKey> <Keys.HardKey>Gobo</Keys.HardKey> 5**
+
+5 Sekunden Einfadezeit für die Gobo-Attribute der ausgewählten Geräte.
+
+**<Keys.HardKey>Time</Keys.HardKey> <Keys.HardKey>Fixture</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>B@</Keys.HardKey> 5**
+
+5 Sekunden Einfadezeit für das gerade mit Encoder B gesteuerte Attribut der ausgewählten Geräte.
+
+**<Keys.HardKey>Time</Keys.HardKey> 5 <Keys.HardKey>@</Keys.HardKey> 3**
+
+5 Sekunden Einfadezeit, 3 Sekunden Delay.
+
+**<Keys.HardKey>Time</Keys.HardKey> 5 <Keys.HardKey>And</Keys.HardKey> 2**
+
+5 Sekunden Einfadezeit, 2 Sekunden Ausfadezeit.
+
+**<Keys.HardKey>Time</Keys.HardKey> 1 <Keys.HardKey>Through</Keys.HardKey> 10**
+
+Fadezeit nach Geräteauswahl aufgeteilt.
+
+## Cue Lists -- Cuelisten
+
+**<Keys.HardKey>Cue</Keys.HardKey> n <Keys.HardKey>Go</Keys.HardKey>**
+
+Direktes Starten von Cue n (in der aktuell verbundenen Cueliste).
+
+**5 <Keys.HardKey>Go</Keys.HardKey>**
+
+Den nächsten Cue mit 5 Sek. Fadezeit -- statt der programmierten Fadezeit -- starten.
+
+**<Keys.HardKey>Cue</Keys.HardKey> 3 <Keys.HardKey>Enter</Keys.HardKey> 5 <Keys.HardKey>Go</Keys.HardKey>**
+Cue 3 mit 5 Sek. Fadezeit -- statt der programmierten Fadezeit -- starten.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-reference/button-reference.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-reference/button-reference.md
@@ -1,0 +1,712 @@
+---
+id: button-reference
+title: Tasten-Referenz
+sidebar_label: Tasten-Referenz
+---
+
+import Keys from '@site/src/components/key.ts';
+import Video from '@site/src/components/video.tsx';
+
+In diesem Abschnitt sind alle HHardware-Tasten mit ihrer Funktion aufgeführt. **Links** führen jeweils zum Abschnitt 
+des Manuals mit weiterführenden Informationen. Manche Tasten stehen nicht auf allen Pulten zur Verfügung.
+
+&nbsp;``<n>`` -- geben Sie einen Wert mit den Zifferntasten ein.
+
+&nbsp;<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Colour</Keys.HardKey> -- drücken Sie die genannten Tasten nacheinander.
+
+&nbsp;<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Clear</Keys.HardKey> -- (Pluszeichen): halten Sie die erste Taste gedrückt und betätigen Sie dazu die zweite Taste.
+
+&nbsp;{Select} -- drücken Sie die Auswahltaste, z.B. eines Playbacks.
+
+
+
+## <Keys.HardKey>@</Keys.HardKey> 
+(beim Ziffernblock): Eingabe von numerischen Werten. kann auch mit den Tasten <Keys.HardKey>Fixture</Keys.HardKey> oder <Keys.HardKey>Group</Keys.HardKey> verwendet werden, um eine Auswahl vorzunehmen. Zu <Keys.HardKey>@</Keys.HardKey> Tasten bei den Encodern dagegen siehe [Wheel @](#wheel-).
+
+Beispiele: 
+
+&nbsp;<Keys.HardKey>Fixture</Keys.HardKey> 1 <Keys.HardKey>And</Keys.HardKey> 5 <Keys.HardKey>And</Keys.HardKey> 7 <Keys.HardKey>@</Keys.HardKey> 75 <Keys.HardKey>Enter</Keys.HardKey> = Fixtures 1,5,7 auf 75%)<br/>
+
+
+&nbsp;<Keys.HardKey>Group</Keys.HardKey> 5 <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> = alle Fixtures in Gruppe 5 auf 100%<br/>
+
+
+Tasten | Ergebnis
+--------|--------
+<Keys.HardKey>@</Keys.HardKey> ``<n>`` <Keys.HardKey>Enter</Keys.HardKey> | Stellt den Pegel der ausgewählten Geräte im Programmer auf ``<n>`` (``<n>`` normalerweise 0-99, optional einstellig 0-9, siehe [Formatting (Formate)](../system-settings/user-settings.md#formatting-formate))
+ <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> | Stellt den Pegel der ausgewählten Geräte im Programmer auf 100%.
+
+
+
+## <Keys.HardKey>@A</Keys.HardKey> <Keys.HardKey>@B</Keys.HardKey> <Keys.HardKey>@C</Keys.HardKey>
+Für die <Keys.HardKey>@</Keys.HardKey> Tasten bei den Encodern dagegen siehe [Wheel @](#wheel-).
+
+
+
+## <Keys.HardKey>Align</Keys.HardKey> 
+(Nur beim D9/D7) Kopieren von Attributwerten von einem auf andere Geräte. Auf anderen Pulten ist diese Funktion über die Taste <Keys.HardKey>ML Menu</Keys.HardKey> zu erreichen, siehe [Geräte miteinander abgleichen](../controlling-fixtures/changing-fixture-attributes.md#geräte-miteinander-abgleichen).
+
+
+
+## <Keys.HardKey>All</Keys.HardKey> 
+Auswahl nach Schema (z.B. gerade/ungerade) innerhalb der bereits angewählten Geräte beginnen oder beenden. Siehe [Geräteauswahl nach Muster](../controlling-fixtures.md#geräteauswahl-nach-muster). (Auf dem D9/D7/T3 heißt die Taste <Keys.HardKey>Pattern/All</Keys.HardKey>)
+
+
+
+## <Keys.HardKey>And</Keys.HardKey> 
+Verwendet bei der Auswahl mehrerer Elemente mit dem Ziffernblock, kann mit den Tasten <Keys.HardKey>Through</Keys.HardKey> und <Keys.HardKey>Not</Keys.HardKey> kombiniert werden. Siehe [Anwählen von Dimmern/Geräten nach (Kanal-)Nummer](../controlling-fixtures.md#anwählen-von-dimmerngeräten-nach-kanal-nummer). Diese Taste ist nicht auf allen Pulten vorhanden, es gibt aber bei numerischer Eingabe die Menütaste <Keys.SoftKey>And</Keys.SoftKey>.
+
+Beispiel:  <Keys.HardKey>Fixture</Keys.HardKey> 1 <Keys.HardKey>And</Keys.HardKey> 5 <Keys.HardKey>And</Keys.HardKey> 7
+
+Wird eine Zeit oder ein Timecode eingegeben, so kann man mit den Tasten <Keys.HardKey>And</Keys.HardKey> und <Keys.HardKey>Through</Keys.HardKey> zwischen den Werten für Stunden/Minuten/Sekunden/Frames wechseln.
+
+
+
+## <Keys.HardKey>Assign</Keys.HardKey> 
+(Nur beim D9 und ST) Zuordnung der Steuerung von Attributen mit dem Trackball, sowie dem Dimmer-Handrad (nur beim D9). Siehe [Trackball](../controlling-fixtures/changing-fixture-attributes.md#der-trackball-diamond-9-und-sapphire-touch).
+
+
+
+## <Keys.HardKey>Avo</Keys.HardKey> 
+"Shift" bzw. "Umschalt"-Taste wenn gedrückt gehalten, ermöglicht erweiterte Funktionen der normalen Befehle. Einzeln für sich ruft diese Taste ein eigenes Menü auf (Lock, Benutzereinstellungen etc.).
+
+Tasten | Aktion
+--------|--------
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>All</Keys.HardKey> | Setzt im Programmer 0% für die nicht angewählten Geräte, gleiche Funktion wie <Keys.HardKey>Rem Dim</Keys.HardKey>, siehe [Nicht ausgewählte Geräte ausblenden (Remainder Dim)](../controlling-fixtures.md#nicht-ausgewählte-geräte-ausblenden-remainder-dim). Beim Einstellen von Attributzeiten werden damit alle Geräte deselektiert, siehe [Individuelle Einblendzeiten für Attribute](../cue-lists/cue-list-timing.md#individuelle-einblendzeiten-für-attribute).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Back</Keys.HardKey> | Undo/Rückgängig, siehe [Undo/Redo -- Rückgängig machen/Wiederholen](../titan-basics/other-parts-of-the-touch-screen.md#undoredo----rückgängig-machenwiederholen).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Close</Keys.HardKey> | Alle Fenster schließen, siehe [Auswahl und Positionierung der Arbeitsfenster](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Copy</Keys.HardKey> | Wie <Keys.HardKey>Move</Keys.HardKey> (wenn keine Move-Taste vorhanden ist; funktioniert auf allen Pulten)
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey> | Aufruf des **System-Menüs**, siehe [System-Menü](../system-settings/the-system-menu.md).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Exit</Keys.HardKey> | Verlassen des Menüs direkt zum Hauptmenü.
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Fix +</Keys.HardKey> | Springt um eine Länge des Musters nach vorn (oder mit <Keys.HardKey>Fix -</Keys.HardKey> zurück) bei der Auswahl nach Muster/Schema.
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Flash On</Keys.HardKey> | Blendet die ausgewählten Geräte vorübergehend aus.
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Group</Keys.HardKey> {Select} | Speichern einer Gruppe auf einen Button/Fader, siehe [Eine Gruppe speichern](../controlling-fixtures/fixture-groups.md#eine-gruppe-speichern).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Highlight</Keys.HardKey> | Speichern des Highlight-Status, siehe [Das ausgewählte Gerät bei Fix+1/Fix-1 hervorheben](../controlling-fixtures.md#das-ausgewählte-gerät-bei-fix1fix-1-hervorheben)
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Macro</Keys.HardKey> {Select} | Ein Macro auf eine Taste speichern, siehe [Macros -- Tastenfolgen](../titan-basics/front-panel-buttons.md/#macros----tastenfolgen).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Min/Max</Keys.HardKey> | Aktivieren eines anderen bereits geöffneten Fensters, siehe [Arbeitsfenster](../titan-basics/workspace-windows.md).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Open/View</Keys.HardKey> {Workspace-Button} | Speichern der aktuellen Arbeitsumgebung (Workspace), siehe [Speichern der Arbeitsumgebung](../titan-basics/workspace-windows.md#speichern-der-arbeitsumgebung).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Release</Keys.HardKey> | Releasen aller Playbacks nach Priorität (genau wie 2 x <Keys.HardKey>Release</Keys.HardKey>). Siehe [Release](../cues/cue-playback.md#release).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Shape</Keys.HardKey> | 
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Size/Position</Keys.HardKey> | Verschiebt das aktive Fenster auf den nächsten/anderen Bildschirm, siehe [Arbeitsfenster](../titan-basics/workspace-windows.md).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Time</Keys.HardKey> | Vorschau der Attribut-Fadezeiten, siehe [Attribute Times](../controlling-fixtures/changing-fixture-attributes.md#speichern-von-zeiten-für-attribute-und-geräte).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Undo</Keys.HardKey> oder <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>@</Keys.HardKey> | Wiederholen, siehe [Undo/Redo -- Rückgängig machen/Wiederholen](../titan-basics/other-parts-of-the-touch-screen.md#undoredo----rückgängig-machenwiederholen).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.SoftKey>Blind</Keys.SoftKey> | Blind-Modus aktivieren/deaktivieren, wie <Keys.HardKey>Blind</Keys.HardKey>.
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.SoftKey>Edit current key profile</Keys.SoftKey> | einstellen der Funktion der Flash- und Auswahltasten, siehe [Tastenprofile/Key Profiles](../system-settings/key-profiles.md).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.SoftKey>Lock</Keys.SoftKey> | Vorübergehendes Sperren des Pultes, siehe [Das Pult sperren](../titan-basics/front-panel-buttons.md#das-pult-sperren).
+ <Keys.HardKey>Avo</Keys.HardKey> + <Keys.SoftKey>User Settings</Keys.SoftKey> | User Settings/Benutzereinstellungen, siehe [User Settings - Benutzereinstellungen](../system-settings/user-settings.md).
+ <Keys.HardKey>Avo</Keys.HardKey> + {Scene Master} | Aktivieren/Beenden des Preset-Modus, wenn der Scene Master auf einer Taste oder Schaltfläche liegt, siehe [Scene Master](../running-the-show/playback-controls.md#scene-master).
+ <Keys.HardKey>Avo</Keys.HardKey> + {Master} | Release eines Masters auf seinen Default-Wert (100%), siehe [Einen Master releasen](../cues/cue-playback.md#einen-master-releasen).
+ <Keys.HardKey>Avo</Keys.HardKey> + {Playback} | Playback deaktivieren (killen), siehe [Release](../cues/cue-playback.md#release).
+ <Keys.HardKey>Avo</Keys.HardKey> + Encoder drehen | Beschleunigung. Eine Umdrehung deckt den ganzen Bereich von 0 bis 100% ab.
+ <Keys.HardKey>Avo</Keys.HardKey> + 2/4/6/8 | Cursor/Pfeiltasten nach oben/links/rechts/unten
+
+
+
+
+## <Keys.HardKey>Back</Keys.HardKey> 
+Backspace (Rücktaste) bei numerischer Eingabe und Syntax.
+
+
+
+## <Keys.HardKey>Beam</Keys.HardKey> 
+Auswahl der Attributgruppe Beam zum Steuern von Zoom, Focus etc. mit den Encodern. Auch verwendet zum Einstellen von Masken. Siehe [Einstellen von Attributen mit den Encodern](../controlling-fixtures/changing-fixture-attributes.md#einstellen-von-attributen-mit-den-encodern). 
+
+
+
+## <Keys.HardKey>Blind</Keys.HardKey> 
+Aktivieren des Blind-Modus: es können Änderungen programmiert werden, ohne dass das im Output sichtbar wird. Siehe [Blind-Modus](../running-the-show/playback-controls.md#blind-modus).
+
+
+
+## <Keys.HardKey>Block</Keys.HardKey> 
+(Nur beim D9/D7 und T3) Z.Zt. nicht verwendet.
+
+
+
+## <Keys.HardKey>Chan Grid</Keys.HardKey> 
+(Nur auf dem Arena) Öffnet das Channel Grid (Kanalübersicht), siehe [Übersicht über die Kanäle: Das 'Channel Grid'-Fenster](../controlling-fixtures/viewing-and-editing-fixture-values.md#übersicht-über-die-kanäle-das-channel-grid-fenster).
+
+
+
+## <Keys.HardKey>Clear</Keys.HardKey> 
+Löschen des Inhalts des Programmierspeichers und der Geräteauswahl, siehe [Clear -- Löschen der Auswahl](../controlling-fixtures.md#clear----löschen-der-auswahl).
+
+Tasten | Ergebnis
+--------|--------
+<Keys.HardKey>Clear</Keys.HardKey> | Löscht Programmer und Geräteauswahl in einem Zug. (Optional auf zwei Tastendrücke einstellbar, siehe [Clear Action Precedence](../system-settings/user-settings.md#clear)).
+``<n>`` <Keys.HardKey>Clear</Keys.HardKey> | Löschen des Programmers und Ausfaden in ``<n>`` Sekunden.
+<Keys.HardKey>Clear</Keys.HardKey> + <Keys.HardKey>All</Keys.HardKey> | Löscht die Geräteauswahl, behält den Programmierspeicher bei.
+<Keys.HardKey>Clear</Keys.HardKey> + <Keys.SoftKey>Set Mask</Keys.SoftKey> | Löscht nur die Attribute der Clear-Maske aus dem Programmierspeicher.
+<Keys.HardKey>Clear</Keys.HardKey> + <Keys.SoftKey>Clear Selected Fixtures</Keys.SoftKey> | Löscht nur die gerade ausgewählten Geräte aus dem Programmierspeicher.
+<Keys.HardKey>Clear</Keys.HardKey> + <Keys.SoftKey>Individual Attributes</Keys.SoftKey> | Löschen einzelner Attributgruppen aus dem Programmierspeicher (zum Auswählen die Attributgruppen-Buttons verwenden).
+<Keys.HardKey>Clear</Keys.HardKey> + <Keys.SoftKey>Clear All Programmers</Keys.SoftKey> | Löscht auch die Programmer anderer User sowie der Titan Remote.
+&nbsp;<Keys.HardKey>Clear</Keys.HardKey> + <Keys.SoftKey>Clear Options</Keys.SoftKey> | Benutzereinstellungen für Clear, siehe [User settings - Clear](../system-settings/user-settings.md#clear)
+
+
+
+## <Keys.HardKey>Close</Keys.HardKey> 
+Schließt das aktuell aktive Fenster.
+
+Beispiel: (Ein Fenster durch Anklicken der Titelleiste aktivieren) <Keys.HardKey>Close</Keys.HardKey>
+
+
+
+## <Keys.HardKey>Colour</Keys.HardKey> 
+Auswahl der Attributgruppe Colour zum Steuern von RGB, CMY etc. mit den Encodern. Auch verwendet zum Einstellen von Masken. Siehe [Einstellen von Attributen mit den Encodern](../controlling-fixtures/changing-fixture-attributes.md#einstellen-von-attributen-mit-den-encodern). 
+
+
+
+## <Keys.HardKey>Commit</Keys.HardKey> 
+(Nur beim D9) Committen des Scene Masters, gleiches Ergebnis wie Stellen des Reglers auf 100%, siehe [Scene Master](../running-the-show/playback-controls.md#scene-master).
+
+
+
+## <Keys.HardKey>Connect</Keys.HardKey> 
+(Auf manchen Pulten Connect/Cue.) Verbindet die Ablaufsteuerung (Go-Taste etc.) mit einem Playback. Dient auch zur Auswahl einzelner Cues beim Programmieren und Abrufen von Cuelisten.
+
+Siehe [Verbinden eines Playbacks mit der Steuerung](../chases/chase-playback.md#verbinden-eines-playbacks-mit-der-steuerung), [Abrufen einer Cueliste](../cue-lists/cue-list-playback.md#abrufen-einer-cueliste), [Tipps für Theater-Programmierer](../cue-lists/theatre-programming.md)
+
+
+
+## <Keys.HardKey>Copy</Keys.HardKey> 
+Kopieren verschiedener Elemente (Geräte/Fixtures, Playbacks etc.). Mit <Keys.HardKey>Latch</Keys.HardKey> kann das Menü eingerastet werden, um mehrere Elemente nacheinander zu kopieren. 2x drücken, um eine Verknüpfung zu erstellen.
+
+Beispiel: <Keys.HardKey>Copy</Keys.HardKey> {zu kopierendes Playback} {Button, auf dem die Kopie gespeichert wird}
+
+Tasten | Ergebnis
+--------|--------
+<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Copy</Keys.HardKey> | Gleiches Ergebnis wie <Keys.HardKey>Move</Keys.HardKey> (für Pulte ohne Move-Taste; funktioniert auf allen Pulten)
+<Keys.HardKey>Copy</Keys.HardKey> <Keys.HardKey>Copy</Keys.HardKey> | Erstellen einer Verknüpfung; gleiches Ergebnis wie <Keys.HardKey>Copy</Keys.HardKey> <Keys.SoftKey>Link</Keys.SoftKey>
+ 
+
+
+## <Keys.HardKey>Cue</Keys.HardKey> 
+Zur Auswahl von Cues in Cuelisten. Auf manchen Pulten auch "Connect", siehe [Connect](#Connect).
+
+
+
+## <Keys.HardKey>Cue +</Keys.HardKey> 
+(Nur beim D9/D7 und T3) Wählt in der aktuell gesteuerten Cueliste den nächsten Schritt; gleiche Funktion wie <Keys.HardKey>Next Step</Keys.HardKey>.
+
+
+
+## <Keys.HardKey>Cue -</Keys.HardKey> 
+(D9/D7 only) Wählt in der aktuell gesteuerten Cueliste den vorigen Schritt; gleiche Funktion wie <Keys.HardKey>Prev Step</Keys.HardKey>.
+
+
+
+## <Keys.HardKey>Custom (wheels)</Keys.HardKey> 
+(Nur beim D9 - rechts neben den Encodern) Z.Zt. unbenutzt.
+
+
+
+## <Keys.HardKey>Delete</Keys.HardKey> 
+Löschen von Elementen. Zum Bestätigen muss das jeweilige Element ein zweites Mal angeklickt oder <Keys.HardKey>Enter</Keys.HardKey> gedrückt werden. Mit <Keys.HardKey>Latch</Keys.HardKey> kann das Menü eingerastet werden, um mehrere Elemente nacheinander zu löschen.
+
+Beispiel: <Keys.HardKey>Delete</Keys.HardKey> {Playback} {Playback}
+
+
+
+## <Keys.HardKey>Direction</Keys.HardKey> 
+(Nur beim D9/D7 und T3) Einstellen der Richtung von Shapes, siehe [Shape-Richtung](../effects/shape-generator.md#shape-richtung)
+
+
+
+## <Keys.HardKey>Disk</Keys.HardKey> 
+Aufruf von Funktionen wie Sichern oder Laden der Show. Hält man dabei <Keys.HardKey>Avo</Keys.HardKey> gedrückt, so wird das System-Menü aufgerufen. Siehe [Die Show speichern](../titan-basics/loading-and-saving-shows.md#die-show-speichern) und [Das System-Menü](../system-settings/the-system-menu.md).
+
+Tasten | Ergebnis
+--------|--------
+<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Disk</Keys.HardKey> | Aufruf System-Menü
+<Keys.HardKey>Disk</Keys.HardKey> <Keys.HardKey>Disk</Keys.HardKey> | Schnellspeichern der Show ohne Rückfrage
+
+
+
+
+## <Keys.HardKey>Edit</Keys.HardKey> 
+Editieren von Paletten, siehe [Ändern des Inhalts einer Palette](../palettes/editing-palettes.md#ändern-des-inhalts-einer-palette).
+
+
+
+## <Keys.HardKey>Effect</Keys.HardKey> 
+Auswahl der Attributgruppe Effect zum Steuern von Prism etc. mit den Encodern. Auch verwendet zum Einstellen von Masken. Siehe [Einstellen von Attributen mit den Encodern](../controlling-fixtures/changing-fixture-attributes.md#einstellen-von-attributen-mit-den-encodern). 
+
+
+
+## <Keys.HardKey>Enter</Keys.HardKey> 
+Abschließen einer Eingabe, Bestätigen eines Befehls.
+
+
+
+## <Keys.HardKey>Enter/B</Keys.HardKey> 
+(Nur beim D9) Aktivieren des Preset-Modus des Scene Masters. Siehe [Scene Master](../running-the-show/playback-controls.md#scene-master).
+
+
+
+## <Keys.HardKey>Exit</Keys.HardKey> 
+Verlässt/schließt das aktuelle Menü, geht eine Menüebene nach oben.
+
+Tasten | Ergebnis
+--------|--------
+<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Exit</Keys.HardKey> | springt direkt ins Hauptmenü
+
+
+
+## <Keys.HardKey>Exit/A</Keys.HardKey> 
+(Nur beim D9) Verlassen des Preset-Modus des Scene Masters. Siehe [Scene Master](../running-the-show/playback-controls.md#scene-master).
+
+
+
+## <Keys.HardKey>FX</Keys.HardKey> 
+(Nur beim D9/D7 und T3) Aufruf des Shape/FX-Menüs, um Shapes, Keyframe-Shapes und Pixelmapper-Effekte zu erstellen. Ebenso verwendet zur An-/Abwahl der FX Attributgruppe beim Erstellen von Masken. Siehe [Shape menu](#Shape).
+
+Mehrfaches Drücken gefolgt von <Keys.HardKey>Enter</Keys.HardKey> ruft die Optionen des Shape/FX-Menüs auf: 2 x <Keys.HardKey>FX</Keys.HardKey> dann <Keys.HardKey>Enter</Keys.HardKey> für Keyframe-Shapes, 3 x <Keys.HardKey>FX</Keys.HardKey> dann <Keys.HardKey>Enter</Keys.HardKey> für den Pixelmapper.
+
+
+
+## <Keys.HardKey>FX (wheels)</Keys.HardKey> 
+(Nur beim D9 - rechts neben den Encodern) Steuern von Shape-Größe, Geschwindigkeit und Spread mit den Encodern.
+
+
+
+## <Keys.HardKey>Fade/Delay (wheels)</Keys.HardKey> 
+(Nur beim D9 - rechts neben den Encodern) Steuern von Fade und Delayzeiten mit den Encodern.
+
+
+
+## <Keys.HardKey>Fan</Keys.HardKey> 
+Startet den Fan-Modus zum Auffächern der Attribute. Siehe [Fan-Modus](../controlling-fixtures/changing-fixture-attributes.md#fan-modus).
+
+
+
+## <Keys.HardKey>Fix +1</Keys.HardKey> 
+Wählt auf das nächste Fixture innerhalb einer angewählten Anzahl von Geräten. Verwendet, um bei mehreren ausgewählten Geräten auf das folgende zu wechseln. Siehe [Einzeln durch die Geräte einer Auswahl durchschalten](../controlling-fixtures.md#einzeln-durch-die-geräte-einer-auswahl-durchschalten).
+
+
+
+## <Keys.HardKey>Fix -1</Keys.HardKey> 
+Wählt auf das vorige Fixture innerhalb einer angewählten Anzahl von Geräten. Verwendet, um bei mehreren ausgewählten Geräten auf das vorige zu wechseln. Siehe [Einzeln durch die Geräte einer Auswahl durchschalten](../controlling-fixtures.md#einzeln-durch-die-geräte-einer-auswahl-durchschalten).
+
+
+
+## <Keys.HardKey>Fixture</Keys.HardKey> 
+Öffnet das Fixture/Channel-Menü, um Geräte numerisch - mit dem Ziffernblock - anzuwählen. Siehe [Anwählen von Dimmern/Geräten nach (Kanal-)Nummer](../controlling-fixtures.md#anwählen-von-dimmerngeräten-nach-kanal-nummer)
+
+
+
+## <Keys.HardKey>Flash On</Keys.HardKey> 
+Flasht die momentan gewählten Fixtures auf 100%.
+
+
+
+## <Keys.HardKey>Go</Keys.HardKey> 
+Startet den nächsten Cue des gerade ausgewählten Playbacks, normalerweise verwendet mit Cuelisten. Siehe [Abrufen einer Cueliste](../cue-lists/cue-list-playback.md#abrufen-einer-cueliste).
+
+
+
+## <Keys.HardKey>Go page</Keys.HardKey> 
+Geben Sie die Seitennummer ``<n>`` der betreffenden Faderbank ein, um auf diese zu wechseln. Pulte mit mehreren Faderbänken haben mehrere solche Tasten. Ebenso gibt es die Tasten <Keys.HardKey>Page +</Keys.HardKey> und <Keys.HardKey>Page -</Keys.HardKey> zum Wechseln auf die nächste/vorige Seite. Siehe [Wechsel der Playback-Seiten](../cues/cue-playback.md#wechsel-der-playback-seiten).
+  
+Tasten | Ergebnis
+--------|--------
+<Keys.HardKey>Go page</Keys.HardKey> ``<n>`` | Schaltet die Fader auf Seite n um.
+<Keys.HardKey>Release</Keys.HardKey> <Keys.HardKey>Go page</Keys.HardKey> | Release aller Playbacks der aktuellen Seite. Siehe [Playbacks seitenweise releasen](../cues/cue-playback.md#playbacks-seitenweise-releasen).
+
+
+
+## <Keys.HardKey>Gobo</Keys.HardKey> 
+Auswahl der Attributgruppe Gobo zum Steuern von Goboauswahl, Rotation etc. mit den Encodern. Auch verwendet zum Einstellen von Masken. Siehe [Einstellen von Attributen mit den Encodern](../controlling-fixtures/changing-fixture-attributes.md#einstellen-von-attributen-mit-den-encodern). 
+
+
+
+## <Keys.HardKey>Group</Keys.HardKey> 
+Öffnet das Groups-Menü zum Speichern und Editieren von Gruppen von Geräten. Siehe [Verwenden von Geräte-Gruppen](../controlling-fixtures/fixture-groups.md#verwenden-von-geräte-gruppen). Kann auch verwendet werden, um z.B. alle Geräte einer Gruppe auf einen bestimmten Dimmerwert zu setzen, Beispiel: <Keys.HardKey>Group</Keys.HardKey> 5 <Keys.HardKey>@</Keys.HardKey> <Keys.HardKey>@</Keys.HardKey> setzt alle Geräte der Gruppe 5 auf 100%.
+
+
+
+## <Keys.HardKey>Hi light</Keys.HardKey> 
+Aktiviert oder beendet den Highlight-Modus, bei dem das gerade ausgewählte Gerät durch eine andere Farbe oder Helligkeit extra hervorgehoben wird. Oft verwendet im Zusammenhang mit den Tasten <Keys.HardKey>Fix +1</Keys.HardKey> und <Keys.HardKey>Fix -1</Keys.HardKey>. Siehe [Einzeln durch die Geräte einer Auswahl durchschalten](../controlling-fixtures.md#einzeln-durch-die-geräte-einer-auswahl-durchschalten).
+
+
+
+## <Keys.HardKey>Include</Keys.HardKey> 
+(gefolgt von der Auswahltaste eines Playbacks) lädt den Inhalt eines Playbacks in den Programmierspeicher zur weiteren Bearbeitung/zum Speichern. Siehe [Cues wiederverwenden - die 'Include'-Funktion](../cues/editing-cues.md#cues-wiederverwenden---die-include-funktion).
+
+
+
+## <Keys.HardKey>Intensity</Keys.HardKey> 
+Auswahl der Attributgruppe Intensity zum Steuern von Dimmer, Shutter etc. mit den Encodern. Auch verwendet zum Einstellen von Masken. Siehe [Einstellen von Attributen mit den Encodern](../controlling-fixtures/changing-fixture-attributes.md#einstellen-von-attributen-mit-den-encodern). 
+
+
+
+## <Keys.HardKey>Keyboard</Keys.HardKey> 
+(Nur beim D9) Blendet die Bildschirm-Tastatur ein. Auf anderen Pulten geht das über einen Button in der Titelleiste der Pultsoftware. Siehe [Bildschirmtastatur](../titan-basics/workspace-windows.md#bildschirmtastatur).
+
+
+
+## <Keys.HardKey>Latch</Keys.HardKey> 
+(Nur beim D9 und T3) Rastet das aktuelle Menü ein, so dass es auch nach dem ausgeführten Befehl aktiv bleibt. Auf anderen Pulten <Keys.HardKey>Latch Menu</Keys.HardKey>, siehe unten.
+
+
+
+## <Keys.HardKey>Latch Menu</Keys.HardKey> 
+Rastet das aktuelle Menü ein, so dass es auch nach dem ausgeführten Befehl aktiv bleibt. Hilfreich z.B. beim Kopieren, Verschieben, Löschen etc. Siehe [Die Menütasten](../titan-basics/other-parts-of-the-touch-screen.md#die-menütasten).
+
+
+
+## <Keys.HardKey>Left</Keys.HardKey> 
+(Nur beim D9 und ST) Linke Maustaste bei Verwendung des Trackballs als Maus.
+
+
+
+## <Keys.HardKey>Legend</Keys.HardKey> 
+(Nur beim D9/D7 und T3) (gefolgt von der Auswahl eines Elementes) Eingabe der Legende eines Elements (Playback, Gruppe, Palette etc.). Auf anderen Pulten ist diese Funktion über den Punkt <Keys.SoftKey>Set Legend</Keys.SoftKey> im Hauptmenü erreichbar. Siehe [Legenden und Bezeichnungen](../titan-basics/workspace-windows.md#legenden-und-bezeichnungen).
+
+
+
+## <Keys.HardKey>Levels (wheels)</Keys.HardKey> 
+(Nur beim D9 - rechts neben den Encodern) Zur Eingabe von Pegeln/Attributwerten mit den Encodern.
+
+
+
+## <Keys.HardKey>Level @</Keys.HardKey> 
+(Nur beim D9/D7) Öffnet das @-Menü für das Dimmer-Handrad.
+
+
+
+## <Keys.HardKey>Library</Keys.HardKey> 
+(Nur beim Arena) Öffnet das Fenster Show Library. Siehe [Show Library - das Show-Verzeichnis](../titan-basics/show-library.md).
+
+
+
+## <Keys.HardKey>Live Time</Keys.HardKey> 
+Zur Eingabe von Zeiten für den gerade aktuellen Cue einer Cueliste. Siehe [Ändern der Zeiten einer laufenden Cueliste](../cue-lists/editing-cue-lists.md#ändern-der-zeiten-einer-laufenden-cueliste).
+
+
+
+## <Keys.HardKey>Locate</Keys.HardKey> 
+Versetzt die angewählten Geräte in eine definierte Ausgangsposition mit 'Licht an', um den Start des Programmierens zu vereinfachen. Siehe [Geräte auf Startposition setzen (Locate)](../controlling-fixtures.md#geräte-auf-startposition-setzen-locate).
+
+
+
+## <Keys.HardKey>Lock Axis</Keys.HardKey> 
+(nur beim D9 und ST) Z.Zt. nicht verwendet.
+
+
+
+## <Keys.HardKey>Macro</Keys.HardKey> 
+Öffnet das Macro-Menü zur Aufzeichnung und zum Abrufen von Folgen von Tastendrücken. Siehe [Macros -- Tastenfolgen](../titan-basics/front-panel-buttons.md#macros----tastenfolgen). 
+ 
+Macros können auch numerisch aufgerufen werden, Beispiel: <Keys.HardKey>Macro</Keys.HardKey> 5 <Keys.HardKey>Enter</Keys.HardKey>
+
+
+
+## <Keys.HardKey>Mask FX</Keys.HardKey> 
+(Nur beim D9/D7 und T3) Öffnet das Mask FX-Menü zum Erstellen von Masken zum Blocken von Shapes. Auch als Funktion im Menü Shapes&Effekte verfügbar. Siehe [Shapes stoppen mit Mask FX](../effects/shape-generator.md#shapes-stoppen-mit-mask-fx).
+
+Tasten | Ergebnis
+--------|--------
+<Keys.HardKey>Mask FX</Keys.HardKey> <Keys.HardKey>Intensity</Keys.HardKey> | Erzeugt Mask FX für Intensity (funktioniert analog für die anderen Attributgruppen)
+<Keys.HardKey>Mask FX</Keys.HardKey> <Keys.HardKey>Mask FX</Keys.HardKey> | Erzeugt Mask FX für alle Attributgruppen
+
+
+
+## <Keys.HardKey>Menu Latch</Keys.HardKey> 
+Rastet das aktuelle Menü ein, so dass es auch nach dem ausgeführten Befehl aktiv bleibt. Hilfreich z.B. beim Kopieren, Verschieben, Löschen etc. Siehe [Die Menütasten](../titan-basics/other-parts-of-the-touch-screen.md#die-menütasten).
+
+
+
+## <Keys.HardKey>Min/Max</Keys.HardKey> 
+Wechselt die Größe des aktuellen Fensters zwischen klein (ein Viertel des Bildschirms) und Vollbild. Siehe [Auswahl und Positionierung der Arbeitsfenster](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster).
+
+
+
+## <Keys.HardKey>ML Menu</Keys.HardKey> 
+
+Im Hauptmenü öffnet diese Taste das Moving Light-Menü, mit dem man Geräte-Macros abrufen sowie die Align-Funktion nutzen kann. In einem Untermenü rastet diese Taste das aktuelle Menü ein, so dass es auch nach dem ausgeführten Befehl aktiv bleibt. Hilfreich z.B. beim Kopieren, Verschieben, Löschen etc. Siehe [Die ML-Menü-Taste](../titan-basics/other-parts-of-the-touch-screen.md#die-ml-menü-taste). Auf dem D9/D7 gibt es diese Taste nicht. Geräte-Macros können mit der Taste <Keys.HardKey>Macro</Keys.HardKey> aufgerufen werden, für die Align-Funktion gibt es die Taste <Keys.HardKey>Align</Keys.HardKey>.
+
+
+
+## <Keys.HardKey>Move</Keys.HardKey> 
+zum Verschieben von Elementen auf andere Buttons. Mit der Taste <Keys.HardKey>Latch</Keys.HardKey> kann das Menü eingerastet werden, um mehrere Elemente nacheinander zu verschieben. 
+
+Beispiel: <Keys.HardKey>Move</Keys.HardKey> {zu verschiebendes Playback} {Ziel zum Verschieben des Playbacks}
+
+
+
+## <Keys.HardKey>Next Step</Keys.HardKey> 
+Auswahl des nächsten Cues in der aktuell gesteuerten Cueliste. Auf manchen Pulten <Keys.HardKey>Next Cue</Keys.HardKey> oder <Keys.HardKey>Cue +</Keys.HardKey>. Siehe [Abrufen einer Cueliste](../cue-lists/cue-list-playback.md#abrufen-einer-cueliste).
+
+
+
+## <Keys.HardKey>Next Time</Keys.HardKey> 
+Editieren von Zeiten für nächsten Cue in der aktuell gesteuerten Cueliste. Siehe [Ändern der Zeiten einer laufenden Cueliste](../cue-lists/editing-cue-lists.md#ändern-der-zeiten-einer-laufenden-cueliste).
+
+
+
+## <Keys.HardKey>Not</Keys.HardKey> 
+Auslassen einzelner Geräte bei der Auswahl einer Serie von Geräten, siehe [Anwählen von Dimmern/Geräten nach (Kanal-)Nummer](../controlling-fixtures.md#anwählen-von-dimmerngeräten-nach-kanal-nummer).
+
+Beispiel: <Keys.HardKey>Fixture</Keys.HardKey> 1 <Keys.HardKey>Through</Keys.HardKey> 5 <Keys.HardKey>not</Keys.HardKey> 3 selektiert die Geräte  1, 2, 4, 5
+
+
+
+## <Keys.HardKey>Odd/Even</Keys.HardKey> 
+Ersetzt durch <Keys.HardKey>All</Keys.HardKey>. Auswahl nach Schema (z.B. gerade/ungerade) innerhalb der bereits angewählten Geräte. Siehe [Geräteauswahl nach Muster](../controlling-fixtures.md#geräteauswahl-nach-muster).
+
+
+
+## <Keys.HardKey>Off</Keys.HardKey> 
+Zum Deaktivieren einzelner Attribute von Fixtures bzw. in Playbacks. Auf Off gesetzte Werte können später wieder aktiviert werden. Siehe [Deaktivieren von Attributen in Cues mit "Off"](../cues/editing-cues.md#deaktivieren-von-attributen-in-cues-mit-off).
+
+
+
+## <Keys.HardKey>Open</Keys.HardKey> 
+(Nur beim D9/D7) Fenster öffnen. Gleiche Funktion wie 2 x View. 
+
+(Quartz, Titan Mobile) Anzeige von Details eines Elementes, oder Öffnen eines Fenster per Doppelklick, siehe [View](#view).
+
+
+
+## <Keys.HardKey>Open/View</Keys.HardKey> 
+(Sapphire Touch, Arena, Tiger Touch) 
+
+Anzeige von Details eines Elementes, oder Öffnen eines Fenster per Doppelklick, siehe [View](#view).
+
+
+
+## <Keys.HardKey>Options</Keys.HardKey> 
+Gefolgt von der **Auswahltaste** eines Elementes, zeigt dessen Optionen. Meist bei Playbacks genutzt, aber auch bei anderen Elementen anwendbar. Siehe [Playback-Optionen](../cues/playback-options.md)
+
+
+
+## <Keys.HardKey>Page +</Keys.HardKey> 
+Wechselt auf die nächste Seite der betreffenden Faderbank. Pulte mit mehreren Faderbänken haben mehrere solche Tasten. Ebenso gibt es die Taste <Keys.HardKey>Go Page</Keys.HardKey> zum Wechseln auf eine andere, nicht unmittelbar folgende Seite. Siehe [Wechsel der Playback-Seiten](../cues/cue-playback.md#wechsel-der-playback-seiten).
+
+
+
+## <Keys.HardKey>Page -</Keys.HardKey> 
+Wechselt auf die vorige Seite der betreffenden Faderbank. Pulte mit mehreren Faderbänken haben mehrere solche Tasten. Ebenso gibt es die Taste <Keys.HardKey>Go Page</Keys.HardKey> zum Wechseln auf eine andere, nicht unmittelbar vorausgehende Seite. Siehe [Wechsel der Playback-Seiten](../cues/cue-playback.md#wechsel-der-playback-seiten).
+
+
+
+## <Keys.HardKey>Palette</Keys.HardKey> 
+Aufruf des Paletten-Menüs zum numerischen Aufrufen von Paletten. Siehe [Recalling palettes](../palettes/using-palettes.md#abrufen-per-nummersyntax).
+
+
+
+## <Keys.HardKey>Patch</Keys.HardKey> 
+Öffnet das Patch-Menü, siehe [Geräte und Dimmer patchen](../patching/patching-new-fixtures-or-dimmers.md).
+
+ 
+
+## <Keys.HardKey>Pattern/All</Keys.HardKey> 
+(Nur beim D9/D7 und T3) Auswahl nach Schema (z.B. gerade/ungerade) innerhalb der bereits angewählten Geräte beginnen oder beenden. Siehe [Geräteauswahl nach Muster](../controlling-fixtures.md#geräteauswahl-nach-muster). Auf anderen Pulten ist das die Taste <Keys.HardKey>All</Keys.HardKey>, siehe [All](#All).
+
+
+
+## <Keys.HardKey>Playback</Keys.HardKey> 
+(Arena) Öffnet das Playbacks-Fenster auf dem kleinen Display.
+
+(D9/D7 und T3) Die Tastenfolge <Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Playback</Keys.HardKey> öffnet das Playbacks-Fenster.
+
+
+
+## <Keys.HardKey>Playback (wheels)</Keys.HardKey> 
+(Nur beim D9 - rechts neben den Encodern) Aktiviert die Playback-Steuerung mit den Encodern.
+
+
+
+## <Keys.HardKey>Position</Keys.HardKey> 
+Auswahl der Attributgruppe Position zum Steuern von Pan, Tilt etc. mit den Encodern. Auch verwendet zum Einstellen von Masken. Siehe [Einstellen von Attributen mit den Encodern](../controlling-fixtures/changing-fixture-attributes.md#einstellen-von-attributen-mit-den-encodern). 
+
+
+
+## <Keys.HardKey>Preload/Auto</Keys.HardKey> 
+(Nur beim D9) Vorladen der im Scene Master vorbereiteten Szene (LTP-Werte von aktuell nicht aktiven Fixtures werden bereits geladen, so dass beim Aktivieren der Szene keine 'Fahrten im On' sichtbar sind). Siehe [Scene Master](../running-the-show/playback-controls.md#scene-master).
+
+
+
+## <Keys.HardKey>Prev Step</Keys.HardKey> 
+Auswahl des vorigen Cues in der aktuell gesteuerten Cueliste. Auf manchen Pulten <Keys.HardKey>Prev Cue</Keys.HardKey> oder <Keys.HardKey>Cue -</Keys.HardKey>. Siehe [Abrufen einer Cueliste](../cue-lists/cue-list-playback.md#abrufen-einer-cueliste).
+
+
+
+## <Keys.HardKey>Record</Keys.HardKey> 
+Speichern von Playbacks, Paletten und anderen Elementen. Siehe [Anlegen eines Cues](../cues/creating-a-cue.md#anlegen-eines-cues) und [Speichern einer Palette](../palettes/creating-palettes.md#speichern-einer-palette). Mehrfaches Betätigen von <Keys.HardKey>Record</Keys.HardKey> schaltet durch die Optionen Record Cue / Record Chase / Record Cue List / Record Timeline.
+
+Tasten | Ergebnis
+--------|--------
+<Keys.HardKey>Record</Keys.HardKey> {Playback-Auswahltaste} | Speichert den Inhalt des Programmers als Cue
+<Keys.HardKey>Record</Keys.HardKey> {Palettenbutton} | Speichert den Inhalt des Programmers als Palette
+<Keys.HardKey>Record</Keys.HardKey> {Workspace-Button} | Speichert die aktuelle Arbeitsumgebung (Fensterauswahl und -anordnung)
+<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Highlight</Keys.HardKey> | Speichert den Inhalt des Programmers als Highlight-Status, siehe [Das ausgewählte Gerät bei Fix+1/Fix-1 hervorheben](../controlling-fixtures.md#das-ausgewählte-gerät-bei-fix1fix-1-hervorheben)
+<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Locate</Keys.HardKey> | Speichert den Inhalt des Programmers als Locate-Status, siehe [Ändern des Locate-Wertes](../controlling-fixtures.md#ändern-des-locate-wertes).
+
+
+
+## <Keys.HardKey>Record Step</Keys.HardKey> 
+Speichert den Inhalt des Programmers in den aktuellen Cue der aktuell gesteuerten Cueliste. Siehe [Editieren einer Cueliste während des Programmierens](../cue-lists/editing-cue-lists.md#editieren-einer-cueliste-während-des-programmierens)
+
+
+
+## <Keys.HardKey>Release</Keys.HardKey> 
+Deaktivieren von Playbacks und Releasen von LTP-Werten auf den jeweils vorigen Wert. Siehe [Release](../cues/cue-playback.md#release). 
+
+Kann auch mit anderen Elementen verwendet werden.
+
+Tasten | Ergebnis
+--------|--------
+<Keys.HardKey>Release</Keys.HardKey> {Master} | Setzt einen Master auf seinen Vorgabewert zurück (so dass die gesteuerten Playbacks unverändert sind), siehe [Einen Master releasen](../cues/cue-playback.md#einen-master-releasen).
+<Keys.HardKey>Release</Keys.HardKey> {Playback} | Ein Playback releasen. Siehe [Release](../cues/cue-playback.md#release).
+<Keys.HardKey>Release</Keys.HardKey> <Keys.HardKey>Clear</Keys.HardKey> | Die Attribute im Programmer releasen. Siehe [Den Programmer releasen](../cues/cue-playback.md#den-programmer-releasen).
+<Keys.HardKey>Release</Keys.HardKey> <Keys.HardKey>Go Page</Keys.HardKey> | Die Playbacks einer Seite nach Priorität releasen. Siehe [Playbacks seitenweise releasen](../cues/cue-playback.md#playbacks-seitenweise-releasen).
+<Keys.HardKey>Release</Keys.HardKey> <Keys.HardKey>Release</Keys.HardKey> | Alle aktiven Playbacks nach Priorität releasen. Siehe [Release](../cues/cue-playback.md#release).
+<Keys.HardKey>Record</Keys.HardKey> <Keys.HardKey>Release</Keys.HardKey> | Den Release-Status (= Power On) speichern. Siehe [Werte für Release / Power On programmieren](../cues/cue-playback#werte-für-release--power-on-programmieren).
+
+
+
+## <Keys.HardKey>Rem Dim</Keys.HardKey> 
+Stell alle nicht selektierten Fixtures auf 0% im Programmer. Nicht auf allen Pulten vorhanden. Auch erreichbar über <Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>All</Keys.HardKey>. Siehe [Nicht ausgewählte Geräte ausblenden (Remainder Dim)](../controlling-fixtures.md#nicht-ausgewählte-geräte-ausblenden-remainder-dim)
+
+
+
+## <Keys.HardKey>Reset</Keys.HardKey> 
+(Nur auf dem D9) Löscht die Preset-Szene des Scene Master. Siehe [Scene Master](../running-the-show/playback-controls.md#scene-master).
+
+
+
+## <Keys.HardKey>Review</Keys.HardKey> 
+Startet den aktuellen Cue erneut mit Fadezeiten, zur Überprüfung und Anpassung der Zeiten. Siehe [Ändern der Zeiten einer laufenden Cueliste](../cue-lists/editing-cue-lists.md#ändern-der-zeiten-einer-laufenden-cueliste)
+
+
+
+## <Keys.HardKey>Right</Keys.HardKey> 
+(Nur beim D9 und ST) Rechte Maustaste bei Verwendung des Trackballs als Maus.
+
+
+
+## <Keys.HardKey>Scroll</Keys.HardKey> 
+Aktivieren der Scroll-Funktion mit den Encodern.
+
+
+
+## <Keys.HardKey>Select If</Keys.HardKey> 
+Bedingte Auswahl. Z.B. per Doppelklick Auswahl der Geräte im zuletzt gestarteten Playback, oder Geräte mit einem bestimmten Dimmerwert. Siehe [Auswahl von Geräten in einem Cue](../controlling-fixtures.md#auswahl-von-geräten-in-einem-cue).
+
+
+
+## <Keys.HardKey>Set</Keys.HardKey> 
+Nur auf älteren Pulten. Dies ist nun die Taste <Keys.HardKey>Time</Keys.HardKey>.
+
+
+
+## <Keys.HardKey>Shape</Keys.HardKey> 
+Wählt die Attributbank Shapes und legt die Shape-Parameter auf die Wheels, siehe  [Shapes und Effekte](../effects.md).
+
+
+
+## <Keys.HardKey>Size/Position</Keys.HardKey> 
+Verschiebt das aktuelle Fenster auf verschiedene Größen und Positionen. Wird dabei <Keys.HardKey>Avo</Keys.HardKey> gedrückt gehalten, so wird das Fenster auf das andere Display verschoben.
+
+
+
+## <Keys.HardKey>Snap</Keys.HardKey> 
+Aktiviert den Snap-Modus, so dass mit den Tasten <Keys.HardKey>Prev Step</Keys.HardKey> / <Keys.HardKey>Next Step</Keys.HardKey> ohne Fadezeiten durch die Cues einer Cueliste oder eines Chasers geschaltet werden kann. Siehe [Abrufen einer Cueliste](../cue-lists/cue-list-playback.md#abrufen-einer-cueliste). Schaltet die Benutzereinstellungen Chase Snap (bei verbundenem Chaser) oder Cue List Snap (bei verbundener Cueliste) um, siehe [General (Allgemein)](../system-settings/user-settings.md#general-allgemein).
+
+
+
+## <Keys.HardKey>Special</Keys.HardKey> 
+Auswahl der Attributgruppe Special zum Steuern von Speed, Macros etc. mit den Encodern. Auch verwendet zum Einstellen von Masken. Siehe [Einstellen von Attributen mit den Encodern](../controlling-fixtures/changing-fixture-attributes.md#einstellen-von-attributen-mit-den-encodern). 
+
+
+
+## <Keys.HardKey>Stop</Keys.HardKey> 
+Stoppt aktuell laufende Fades/Überblendungen. Siehe [Abrufen einer Cueliste](../cue-lists/cue-list-playback.md#abrufen-einer-cueliste). Ist der Fade bereits gestoppt, so geht es einen Cue rückwärts.
+
+
+
+## <Keys.HardKey>Through</Keys.HardKey> 
+von... **"bis"** bei der Auswahl eines Bereiches von Fixtures, siehe [Anwählen von Dimmern/Geräten nach (Kanal-)Nummer](../controlling-fixtures.md#anwählen-von-dimmerngeräten-nach-kanal-nummer).
+
+Beispiel: <Keys.HardKey>Fixture</Keys.HardKey> 1 <Keys.HardKey>Through</Keys.HardKey> 5 <Keys.HardKey>not</Keys.HardKey> 3 selektiert die Fixtures 1, 2, 4, 5
+
+Wird eine Zeit oder ein Timecode eingegeben, so kann man mit den Tasten <Keys.HardKey>And</Keys.HardKey> und <Keys.HardKey>Through</Keys.HardKey> zwischen den Werten für Stunden/Minuten/Sekunden/Frames wechseln.
+
+
+
+## <Keys.HardKey>Time</Keys.HardKey> 
+Öffnet das Times-Menü zur Eingabe von Zeiten für Cues, siehe [Einstellen von Überblendzeiten und Geräteversatz](../cues/cue-timing.md#einstellen-von-überblendzeiten-und-geräteversatz).
+Auch zur direkten Eingabe von Zeiten beim Programmieren. Siehe [Times -- Zeiten](../titan-reference.md#times).
+
+Tasten | Ergebnis
+--------|--------
+<Keys.HardKey>Time</Keys.HardKey> ``n`` | Setzt ``n`` Sekunden Fadezeit im Programmer, die beim nächsten Speichervorgang mit in den Cue gespeichert werden
+ <Keys.HardKey>Time</Keys.HardKey> <Keys.HardKey>Fixture</Keys.HardKey> ``n`` | Setzt ``n`` Sekunden Fadezeit für alle Attribute der ausgewählten Fixtures im Programmer
+
+
+
+
+## <Keys.HardKey>Undo</Keys.HardKey> 
+Macht die letzte Änderung rückgängig. Eine Liste der letzten Vorgänge wird im Infobereich angezeigt. Siehe [Undo/Redo -- Rückgängig machen/Wiederholen](../titan-basics/other-parts-of-the-touch-screen.md#undoredo----rückgängig-machenwiederholen).
+
+Tasten | Ergebnis
+--------|--------
+<Keys.HardKey>Avo</Keys.HardKey> + <Keys.HardKey>Undo</Keys.HardKey> | letztes Rückgängigmachen widerrufen.
+
+
+
+## <Keys.HardKey>Unfold</Keys.HardKey> 
+gefolgt von der **Auswahltaste** eines Chasers oder einer Cueliste, blendet die einzelnen Cues auf Playback-Fader ein, so dass jeder Cue einzeln bearbeitet werden kann. Siehe [Ändern eines Chasers mit der Unfold-Funktion](../chases/editing-a-chase.md#ändern-eines-chasers-mit-der-unfold-funktion).
+
+
+
+## <Keys.HardKey>Update</Keys.HardKey> 
+Aktualisieren des aktuellen Cues. Dabei wird der Inhalt des Programmers für bereits vorhandene Fixtures und Attribute in den Cue verschmolzen. Siehe [Aktualisieren gespeicherter Werte und Paletten](../cues/editing-cues.md#aktualisieren-gespeicherter-werte-und-paletten).
+
+
+
+## <Keys.HardKey>View</Keys.HardKey> 
+(D9/D7, T3, Titan Go, Pearl Expert, Tiger Touch 1) 
+
+Gefolgt von der **Auswahltaste** eines Elements werden Details über dieses angezeigt. Per Doppelklick können dagegen weitere Fenster geöffnet werden. Siehe [Anzeigen und Ändern einer Palette](../palettes/editing-palettes.md#anzeigen-und-ändern-einer-palette) und [Anzeige der Cues: Playback View und Cue View](../cues/editing-cues.md#anzeige-der-cues-playback-view-und-cue-view), oder [Auswahl und Positionierung der Arbeitsfenster](../titan-basics/workspace-windows.md#auswahl-und-positionierung-der-arbeitsfenster).
+
+Mit vielen Tastenkombinationen können weitere Fenster geöffnet werden:
+
+Tasten | Ergebnis
+--------|--------
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Beam</Keys.HardKey> | Palettenfenster Gobos&Beams
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Colour</Keys.HardKey> | Palettenfenster Colours
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Connect</Keys.HardKey> | Playback-Ansicht des verbundenen Playbacks
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Copy</Keys.HardKey> | Kopieren von Workspace-Buttons
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Delete</Keys.HardKey> | Löschen von Workspace-Buttons
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Fixture</Keys.HardKey> | Das Fixtures-Fenster (Geräte)
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>FX</Keys.HardKey> | Shape-Palettenfenster
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Gobo</Keys.HardKey> | Palettenfenster Gobos&Beams
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Group</Keys.HardKey> | Das Groups-Fenster (Gruppen)
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Intensity</Keys.HardKey> | Intensitäts-Ansicht
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Macros</Keys.HardKey> | Fenster 'Macros'
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Move</Keys.HardKey> | Verschieben von Workspace-Buttons
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Off</Keys.HardKey> | Fenster 'Active Playbacks'
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Options</Keys.HardKey> | Attribut-Editor
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Patch</Keys.HardKey> | Patch-Ansicht
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Playback</Keys.HardKey> | Playbacks-Fenster
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Position</Keys.HardKey> | Palettenfenster Positions
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Release</Keys.HardKey> | Fenster 'Active Playbacks'
+<Keys.HardKey>View</Keys.HardKey> <Keys.HardKey>Shape</Keys.HardKey> | Shape-Palettenfenster
+<Keys.HardKey>View</Keys.HardKey> ``n`` <Keys.HardKey>Enter</Keys.HardKey> | Aufruf des Workspaces mit der Nummer ``n``
+
+
+
+## <Keys.HardKey>Visualiser</Keys.HardKey> 
+Öffnet den Visualiser. Siehe [Der Capture-Visualiser](../capture-visualiser.md/).
+
+
+
+## <Keys.HardKey>Wheel @</Keys.HardKey> 
+(Die @-Tasten neben den Encodern) - Öffnet das jeweilige @-Menü zur genauen Steuerung des Attributes, das gerade auf dem Encoder liegt.
+
+
+
+## <Keys.HardKey>XYZ</Keys.HardKey> 
+(Nur beim D9 - rechts neben den Encodern) Aktiviert den XYZ-Modus der Encoder zur Positionierung der Fixtures im Capture-Visualiser und im Layout-Editor.

--- a/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-reference/button-reference.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/version-19.0/titan-reference/button-reference.md
@@ -586,6 +586,11 @@ Startet den aktuellen Cue erneut mit Fadezeiten, zur Überprüfung und Anpassung
 
 
 
+## <Keys.HardKey>Screen Mode</Keys.HardKey> 
+(nur beim D7) Umschalten des kleinen Bildschirms zwischen Attribut Editor und Anzeige der Macros.
+
+
+
 ## <Keys.HardKey>Scroll</Keys.HardKey> 
 Aktivieren der Scroll-Funktion mit den Encodern.
 

--- a/website/translated_sidebars/de/version-19.0-sidebars.json
+++ b/website/translated_sidebars/de/version-19.0-sidebars.json
@@ -1,0 +1,661 @@
+{
+  "version-19.0/docs": [
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Einführung",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/introduction"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Schnellstartanleitung",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/quick-start"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/quick-start/patching-fixtures"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/quick-start/controlling-fixtures"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/quick-start/programming-cues-and-chases"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/quick-start/programming-palettes"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/quick-start/dmx-network-setup"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/quick-start/tips-and-tricks"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Die Titan-Pulte",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/about-the-consoles"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/about-the-consoles/diamond"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/about-the-consoles/d7"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/about-the-consoles/d3"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/about-the-consoles/t3"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/about-the-consoles/t1-and-t2"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/about-the-consoles/sapphire-touch"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/about-the-consoles/arena"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/about-the-consoles/tiger-touch"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/about-the-consoles/quartz"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/about-the-consoles/titan-mobile"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/about-the-consoles/tnp"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/about-the-consoles/pearl-expert-and-touch-wing"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Titan-Grundlagen",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-basics"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-basics/workspace-windows"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-basics/other-parts-of-the-touch-screen"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-basics/front-panel-buttons"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-basics/multi-user-operation"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-basics/titan-simulator"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-basics/show-library"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-basics/loading-and-saving-shows"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-basics/clearing-the-console"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-basics/creating-reports"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Patchen",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/patching"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/patching/patching-new-fixtures-or-dimmers"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/patching/changing-the-patch"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/patching/copying-moving-and-deleting-fixtures"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/patching/fixture-personality-options"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Steuern von Dimmern und Geräten",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/controlling-fixtures"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/controlling-fixtures/changing-fixture-attributes"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/controlling-fixtures/viewing-and-editing-fixture-values"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/controlling-fixtures/fixture-groups"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/controlling-fixtures/layouts"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/controlling-fixtures/advanced-options"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Paletten",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/palettes"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/palettes/creating-palettes"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/palettes/using-palettes"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/palettes/editing-palettes"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/palettes/copying-moving-and-deleting-palettes"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/palettes/timing-with-palettes"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Shapes und Effekte",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/effects"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/effects/shape-generator"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/effects/key-frame-shapes"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/effects/pixel-mapper"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/effects/editing-shapes-and-effects"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/effects/advanced-options"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/effects/pixel-mapper-examples"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Cues",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/cues"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/cues/creating-a-cue"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/cues/cue-playback"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/cues/editing-cues"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/cues/cue-timing"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/cues/playback-options"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/cues/copying-moving-linking-and-deleting"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Chaser",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/chases"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/chases/creating-a-chase"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/chases/chase-playback"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/chases/editing-a-chase"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/chases/chase-timing"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/chases/chase-options"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/chases/copying-moving-linking-and-deleting"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Cuelisten",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/cue-lists"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/cue-lists/creating-a-cue-list"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/cue-lists/cue-list-playback"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/cue-lists/editing-cue-lists"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/cue-lists/cue-list-timing"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/cue-lists/cue-list-options"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/cue-lists/copying-moving-linking-and-deleting"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/cue-lists/theatre-programming"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Timelines",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/timelines"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/timelines/creating-a-timeline"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/timelines/running-and-editing-timelines"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/timelines/timeline-options"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Der Capture Visualiser",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/capture-visualiser"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/capture-visualiser/setting-up-the-rig"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/capture-visualiser/visualising-using-capture"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/capture-visualiser/capture-show-files"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/capture-visualiser/linking-the-console-to-stand-alone-capture"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Synergy",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/synergy"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/synergy/setting-up"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/synergy/operating-synergy"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Steuern der Show",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/running-the-show"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/running-the-show/playback-controls"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/running-the-show/set-list-window"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/running-the-show/midi-dmx-or-audio-triggering"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/running-the-show/linking-pioneerdj-system-to-titan"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/running-the-show/linking-consoles-for-multi-user-or-backup"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Fernsteuerung",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/remote-control"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/remote-control/setting-up-the-remote"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/remote-control/operating-the-remote"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/remote-control/programming-touch-panels"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Titan Net",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-net"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-net/tnp-slave-mode"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-net/tnp-console-mode"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "System und Benutzereinstellungen",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/system-settings"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/system-settings/the-system-menu"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/system-settings/external-displays"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/system-settings/key-profiles"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/system-settings/user-settings"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/system-settings/dmx-output-mapping"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/system-settings/curves"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/system-settings/upgrading-the-software"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/system-settings/recovering-reinstalling-the-console"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/system-settings/cleaning-the-console"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/system-settings/release-notes"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Personalities (Gerätedateien)",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/fixture-personalities"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Netzwerkeinstellungen",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/networking"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/networking/connecting-the-arena-to-a-network"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/networking/controlling-fixtures-over-a-network"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/networking/using-active-fixtures"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/networking/ports-used-by-titan"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/networking/a-quick-guide-to-ip-addressing"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Titan Befehlsreferenz",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-reference"
+        },
+        {
+          "type": "doc",
+          "id": "version-19.0/titan-reference/button-reference"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Glossar/Stichwortverzeichnis",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/glossary"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Index",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-19.0/alpha-index"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
german translation for v19.
Already built locally and in my own repo, already online at manual.avosupport.de