### PR TITLE
Fix for building PDFs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN apk add --update \
 # get font files
 RUN fmtutil-sys --all
 
+# Fix the repository verison for the Latex packages
+RUN tlmgr option repository https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2019/tlnet-final
+
+# Install the LaTeX packages based on fixed archive above
 RUN tlmgr install \
     adjustbox \
     babel-german \

--- a/parse/pdf.js
+++ b/parse/pdf.js
@@ -272,6 +272,12 @@ function docsVersionPath(version,lang) {
       filePath = path.join(avoParse.paths.transDocsDir,lang,avoParse.paths.docusaurusFolder,`version-${version}/`);
     }
     if (!fs.existsSync(filePath)) {
+      // A translated language may not have every version. Return null so callers
+      // (e.g. resolvePageVersion) can treat it as "not found" rather than crashing.
+      // A missing folder for the main language indicates a real error, so still throw.
+      if (lang != avoParse.lang) {
+        return "";
+      }
       throw(`Could not find versioned docs: ${filePath}`)
     };
     return filePath;
@@ -322,8 +328,9 @@ function formatMdFiles(docsPath, sidebar, version, lang) {
  * @return {string} Absolute file path to the latest version (null if not found)
  */
 function resolvePageVersion(filename,version,lang) {
-  let filepath = path.resolve(docsVersionPath(version,lang), filename);
-  if (fs.existsSync(filepath)) {
+  let docsDir = docsVersionPath(version,lang);
+  let filepath = docsDir ? path.resolve(docsDir, filename) : null;
+  if (filepath && fs.existsSync(filepath)) {
     return filepath;
   }
   else {


### PR DESCRIPTION
German Translated v12 Missing - avoid throwing in this case
lock version of tlgmr for latex version in use 